### PR TITLE
Add GitHub Action to run mobile app demo telemetry

### DIFF
--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -1,5 +1,4 @@
 name: Mobile Demo Telemetry
-# Cache verification trigger
 
 on:
   # For development: trigger on PR changes to iterate easily
@@ -123,7 +122,7 @@ jobs:
           ls -la build/app/outputs/flutter-apk/
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: flutter-apk
           path: Mobiles/flutter/build/app/outputs/flutter-apk/app-debug.apk
@@ -146,6 +145,7 @@ jobs:
           repo_secrets: |
             GRAFANA_CLOUD_STACK=grafana_cloud_stack:value
             GRAFANA_CLOUD_TOKEN=grafana_cloud_token:value
+            OPENAI_API_KEY=openai_api_key:value
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -212,8 +212,13 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
 
-      - name: Run Android emulator and app
-        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+
+      - name: Run Android emulator and e2e tests
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
+        env:
+          OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
         with:
           api-level: 34
           arch: x86_64
@@ -233,32 +238,20 @@ jobs:
             echo "Installing APK..."
             adb install -r apk/app-debug.apk
             
-            # Launch the app (package name from android/app/build.gradle.kts)
-            echo "Launching app..."
-            adb shell am start -n "com.example.flutter_mobile_o11y_demo/.MainActivity"
+            # Run e2e tests (this will launch the app and interact with it)
+            echo "Running e2e tests..."
+            cd Mobiles/flutter
+            chmod +x scripts/e2e/run_e2e_tests.sh
+            ./scripts/e2e/run_e2e_tests.sh
             
-            # Wait for app to start and generate some telemetry
-            echo "Waiting for app to start and generate telemetry..."
-            sleep 30
-            
-            # Take a screenshot for debugging
-            adb exec-out screencap -p > screenshot.png || true
-            
-            # Check if app is still running
-            adb shell pidof "com.example.flutter_mobile_o11y_demo" && echo "App is running successfully!" || echo "Warning: App may have crashed"
-            
-            # Let it run a bit more
-            echo "Letting app run to generate telemetry..."
-            sleep 30
-            
-            echo "Demo run completed!"
+            echo "E2E tests completed!"
 
-      - name: Upload screenshot
+      - name: Upload e2e test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: emulator-screenshot
-          path: screenshot.png
+          name: e2e-test-results
+          path: Mobiles/flutter/arbigent-result/
           retention-days: 3
           if-no-files-found: ignore
 
@@ -274,7 +267,7 @@ jobs:
 
       - name: Upload backend logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: backend-logs
           path: backend.log

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -222,6 +222,7 @@ jobs:
         with:
           api-level: 34
           arch: x86_64
+          profile: pixel_6
           disable-animations: true
           disk-size: 6000M
           heap-size: 600M

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -9,9 +9,9 @@ on:
       - "compose.grafana-cloud.monolithic.yaml"
   # Manual trigger for testing
   workflow_dispatch:
-  # Scheduled run - enable after PR is merged and tested
-  # schedule:
-  #   - cron: "0 */6 * * *" # Every 6 hours
+  # Scheduled run every hour for continuous telemetry
+  schedule:
+    - cron: "0 * * * *"
 
 permissions:
   contents: read
@@ -39,19 +39,6 @@ jobs:
         with:
           repo_secrets: |
             FARO_COLLECTOR_URL=faro_collector_url:value
-
-      # TODO: Remove this step after verifying Vault secrets work
-      - name: Verify Vault secrets (temporary)
-        run: |
-          echo "Checking if FARO_COLLECTOR_URL secret was retrieved..."
-          if [ -n "${{ env.FARO_COLLECTOR_URL }}" ]; then
-            echo "✅ FARO_COLLECTOR_URL is set (length: ${#FARO_COLLECTOR_URL})"
-            # Print first 20 chars to verify format without exposing full secret
-            echo "First 20 chars: ${FARO_COLLECTOR_URL:0:20}..."
-          else
-            echo "❌ FARO_COLLECTOR_URL is NOT set or empty"
-            exit 1
-          fi
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -251,7 +238,7 @@ jobs:
         with:
           name: e2e-test-results
           path: Mobiles/flutter/arbigent-result/
-          retention-days: 3
+          retention-days: 1
           if-no-files-found: ignore
 
       - name: Collect backend logs

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -213,13 +213,9 @@ jobs:
             echo "Installing APK..."
             adb install -r apk/app-debug.apk
             
-            # Package name from android/app/build.gradle.kts
-            PACKAGE_NAME="com.example.flutter_mobile_o11y_demo"
-            echo "Package name: $PACKAGE_NAME"
-            
-            # Launch the app using am start
+            # Launch the app (package name from android/app/build.gradle.kts)
             echo "Launching app..."
-            adb shell am start -n "$PACKAGE_NAME/.MainActivity"
+            adb shell am start -n "com.example.flutter_mobile_o11y_demo/.MainActivity"
             
             # Wait for app to start and generate some telemetry
             echo "Waiting for app to start and generate telemetry..."
@@ -229,11 +225,7 @@ jobs:
             adb exec-out screencap -p > screenshot.png || true
             
             # Check if app is still running
-            if adb shell pidof "$PACKAGE_NAME" > /dev/null 2>&1; then
-              echo "App is running successfully!"
-            else
-              echo "Warning: App may have crashed"
-            fi
+            adb shell pidof "com.example.flutter_mobile_o11y_demo" && echo "App is running successfully!" || echo "Warning: App may have crashed"
             
             # Let it run a bit more
             echo "Letting app run to generate telemetry..."

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -217,9 +217,9 @@ jobs:
             PACKAGE_NAME="com.example.flutter_mobile_o11y_demo"
             echo "Package name: $PACKAGE_NAME"
             
-            # Launch the app
+            # Launch the app using am start
             echo "Launching app..."
-            adb shell monkey -p "$PACKAGE_NAME" -c android.intent.category.LAUNCHER 1
+            adb shell am start -n "$PACKAGE_NAME/.MainActivity"
             
             # Wait for app to start and generate some telemetry
             echo "Waiting for app to start and generate telemetry..."

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -75,6 +75,11 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
+      # TODO: Add APK caching to skip rebuild when version unchanged
+      # Use actions/cache with key: apk-cache-v${{ steps.app-version.outputs.version }}
+      # GitHub cache retention: 7 days (or LRU eviction at 10GB limit)
+      # Skip build steps if cache hit
+
       - name: Install Flutter dependencies
         working-directory: Mobiles/flutter
         run: flutter pub get

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -75,16 +75,29 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
-      # TODO: Add APK caching to skip rebuild when version unchanged
-      # Use actions/cache with key: apk-cache-v${{ steps.app-version.outputs.version }}
-      # GitHub cache retention: 7 days (or LRU eviction at 10GB limit)
-      # Skip build steps if cache hit
+      - name: Cache APK
+        id: cache-apk
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: Mobiles/flutter/build/app/outputs/flutter-apk/app-debug.apk
+          key: apk-cache-v${{ steps.app-version.outputs.version }}
+
+      - name: Log cache status
+        run: |
+          if [ "${{ steps.cache-apk.outputs.cache-hit }}" = "true" ]; then
+            echo "✅ APK found in cache, skipping build"
+            ls -la Mobiles/flutter/build/app/outputs/flutter-apk/app-debug.apk
+          else
+            echo "❌ APK not in cache, will build"
+          fi
 
       - name: Install Flutter dependencies
+        if: steps.cache-apk.outputs.cache-hit != 'true'
         working-directory: Mobiles/flutter
         run: flutter pub get
 
       - name: Create config.json for CI
+        if: steps.cache-apk.outputs.cache-hit != 'true'
         working-directory: Mobiles/flutter
         env:
           FARO_COLLECTOR_URL: ${{ env.FARO_COLLECTOR_URL }}
@@ -100,6 +113,7 @@ jobs:
           cat config.json
 
       - name: Build APK (debug)
+        if: steps.cache-apk.outputs.cache-hit != 'true'
         working-directory: Mobiles/flutter
         run: |
           echo "Building APK..."

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -1,4 +1,5 @@
 name: Mobile Demo Telemetry
+# Cache verification trigger
 
 on:
   # For development: trigger on PR changes to iterate easily

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -149,10 +149,13 @@ jobs:
           GRAFANA_CLOUD_STACK: ${{ env.GRAFANA_CLOUD_STACK }}
           GRAFANA_CLOUD_TOKEN: ${{ env.GRAFANA_CLOUD_TOKEN }}
           DEPLOYMENT_ENVIRONMENT: ci
+          # Use dev Alloy config for grafana-dev.net stack
+          ALLOY_FILE_NAME: cloud-dev.alloy
         run: |
-          echo "Starting QuickPizza backend..."
-          docker compose -f compose.grafana-cloud.monolithic.yaml up -d
-          docker compose -f compose.grafana-cloud.monolithic.yaml ps
+          echo "Starting QuickPizza backend with dev config..."
+          # Use dev override for grafana-dev.net stack (adds required module mount)
+          docker compose -f compose.grafana-cloud.monolithic.yaml -f compose.grafana-cloud.dev-override.yaml up -d
+          docker compose -f compose.grafana-cloud.monolithic.yaml -f compose.grafana-cloud.dev-override.yaml ps
           
           echo "Waiting for backend to be ready..."
           for i in {1..60}; do
@@ -165,7 +168,7 @@ jobs:
           done
           
           echo "Backend did not become ready in time"
-          docker compose -f compose.grafana-cloud.monolithic.yaml logs --no-color
+          docker compose -f compose.grafana-cloud.monolithic.yaml -f compose.grafana-cloud.dev-override.yaml logs --no-color
           exit 1
 
       - name: Enable KVM group permissions
@@ -250,12 +253,12 @@ jobs:
       - name: Collect backend logs
         if: always()
         run: |
-          docker compose -f compose.grafana-cloud.monolithic.yaml logs --no-color > backend.log 2>&1 || true
+          docker compose -f compose.grafana-cloud.monolithic.yaml -f compose.grafana-cloud.dev-override.yaml logs --no-color > backend.log 2>&1 || true
 
       - name: Stop backend
         if: always()
         run: |
-          docker compose -f compose.grafana-cloud.monolithic.yaml down -v || true
+          docker compose -f compose.grafana-cloud.monolithic.yaml -f compose.grafana-cloud.dev-override.yaml down -v || true
 
       - name: Upload backend logs
         if: always()

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -1,0 +1,267 @@
+name: Mobile Demo Telemetry
+
+on:
+  # For development: trigger on PR changes to iterate easily
+  pull_request:
+    paths:
+      - ".github/workflows/mobile_demo_telemetry.yaml"
+      - "Mobiles/flutter/**"
+      - "compose.grafana-cloud.monolithic.yaml"
+  # Manual trigger for testing
+  workflow_dispatch:
+  # Scheduled run - enable after PR is merged and tested
+  # schedule:
+  #   - cron: "0 */6 * * *" # Every 6 hours
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_CHANNEL: "stable"
+
+jobs:
+  build-flutter-apk:
+    name: Build Flutter APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    
+    steps:
+      - name: Get Vault secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
+        with:
+          repo_secrets: |
+            FARO_COLLECTOR_URL=faro_collector_url:value
+
+      # TODO: Remove this step after verifying Vault secrets work
+      - name: Verify Vault secrets (temporary)
+        run: |
+          echo "Checking if FARO_COLLECTOR_URL secret was retrieved..."
+          if [ -n "${{ env.FARO_COLLECTOR_URL }}" ]; then
+            echo "✅ FARO_COLLECTOR_URL is set (length: ${#FARO_COLLECTOR_URL})"
+            # Print first 20 chars to verify format without exposing full secret
+            echo "First 20 chars: ${FARO_COLLECTOR_URL:0:20}..."
+          else
+            echo "❌ FARO_COLLECTOR_URL is NOT set or empty"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # v2.19.0
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+
+      - name: Get App Version
+        id: app-version
+        working-directory: Mobiles/flutter
+        run: |
+          VERSION=$(grep 'version:' pubspec.yaml | cut -d' ' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION"
+
+      - name: Install Flutter dependencies
+        working-directory: Mobiles/flutter
+        run: flutter pub get
+
+      - name: Create config.json for CI
+        working-directory: Mobiles/flutter
+        env:
+          FARO_COLLECTOR_URL: ${{ env.FARO_COLLECTOR_URL }}
+        run: |
+          cat > config.json << EOF
+          {
+            "FARO_COLLECTOR_URL": "${FARO_COLLECTOR_URL}",
+            "BASE_URL": "",
+            "PORT": "3333"
+          }
+          EOF
+          echo "Created config.json:"
+          cat config.json
+
+      - name: Build APK (debug)
+        working-directory: Mobiles/flutter
+        run: |
+          echo "Building APK..."
+          flutter build apk --debug --dart-define-from-file=config.json
+          echo "APK built successfully"
+          ls -la build/app/outputs/flutter-apk/
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: flutter-apk
+          path: Mobiles/flutter/build/app/outputs/flutter-apk/app-debug.apk
+          retention-days: 1
+
+  run-mobile-demo:
+    name: Run Mobile Demo
+    needs: build-flutter-apk
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Get Vault secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
+        with:
+          repo_secrets: |
+            GRAFANA_CLOUD_STACK=grafana_cloud_stack:value
+            GRAFANA_CLOUD_TOKEN=grafana_cloud_token:value
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download APK artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: flutter-apk
+          path: apk/
+
+      - name: Verify APK
+        run: |
+          echo "Verifying downloaded APK..."
+          ls -la apk/
+          file apk/app-debug.apk
+          echo "APK size: $(du -h apk/app-debug.apk | cut -f1)"
+          echo "APK verified"
+
+      - name: Start QuickPizza backend (Docker Compose)
+        env:
+          GRAFANA_CLOUD_STACK: ${{ env.GRAFANA_CLOUD_STACK }}
+          GRAFANA_CLOUD_TOKEN: ${{ env.GRAFANA_CLOUD_TOKEN }}
+          DEPLOYMENT_ENVIRONMENT: ci
+        run: |
+          echo "Starting QuickPizza backend..."
+          docker compose -f compose.grafana-cloud.monolithic.yaml up -d
+          docker compose -f compose.grafana-cloud.monolithic.yaml ps
+          
+          echo "Waiting for backend to be ready..."
+          for i in {1..60}; do
+            if curl -fsS "http://localhost:3333/ready" > /dev/null 2>&1; then
+              echo "Backend is ready!"
+              exit 0
+            fi
+            echo "Waiting for backend... attempt $i/60"
+            sleep 2
+          done
+          
+          echo "Backend did not become ready in time"
+          docker compose -f compose.grafana-cloud.monolithic.yaml logs --no-color
+          exit 1
+
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls /dev/kvm
+
+      - name: Free disk space for Android emulator
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          
+          echo "Removing unnecessary tools..."
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          sudo apt-get clean
+          
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Run Android emulator and app
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
+        with:
+          api-level: 34
+          arch: x86_64
+          disable-animations: true
+          disk-size: 6000M
+          heap-size: 600M
+          emulator-options: "-no-window -no-metrics"
+          script: |
+            echo "Emulator is running!"
+            adb devices -l
+            
+            # Set up port forwarding so app can reach backend via localhost
+            echo "Setting up ADB reverse port forwarding..."
+            adb reverse tcp:3333 tcp:3333
+            
+            # Install the APK
+            echo "Installing APK..."
+            adb install -r apk/app-debug.apk
+            
+            # Get package name from APK
+            PACKAGE_NAME=$(aapt dump badging apk/app-debug.apk | grep package | awk -F"'" '{print $2}')
+            echo "Package name: $PACKAGE_NAME"
+            
+            # Launch the app
+            echo "Launching app..."
+            adb shell monkey -p "$PACKAGE_NAME" -c android.intent.category.LAUNCHER 1
+            
+            # Wait for app to start and generate some telemetry
+            echo "Waiting for app to start and generate telemetry..."
+            sleep 30
+            
+            # Take a screenshot for debugging
+            adb exec-out screencap -p > screenshot.png || true
+            
+            # Check if app is still running
+            if adb shell pidof "$PACKAGE_NAME" > /dev/null 2>&1; then
+              echo "App is running successfully!"
+            else
+              echo "Warning: App may have crashed"
+            fi
+            
+            # Let it run a bit more
+            echo "Letting app run to generate telemetry..."
+            sleep 30
+            
+            echo "Demo run completed!"
+
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: emulator-screenshot
+          path: screenshot.png
+          retention-days: 3
+          if-no-files-found: ignore
+
+      - name: Collect backend logs
+        if: always()
+        run: |
+          docker compose -f compose.grafana-cloud.monolithic.yaml logs --no-color > backend.log 2>&1 || true
+
+      - name: Stop backend
+        if: always()
+        run: |
+          docker compose -f compose.grafana-cloud.monolithic.yaml down -v || true
+
+      - name: Upload backend logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: backend-logs
+          path: backend.log
+          retention-days: 3
+          if-no-files-found: ignore

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -240,9 +240,7 @@ jobs:
             
             # Run e2e tests (this will launch the app and interact with it)
             echo "Running e2e tests..."
-            cd Mobiles/flutter
-            chmod +x scripts/e2e/run_e2e_tests.sh
-            ./scripts/e2e/run_e2e_tests.sh
+            cd Mobiles/flutter && chmod +x scripts/e2e/run_e2e_tests.sh && ./scripts/e2e/run_e2e_tests.sh
             
             echo "E2E tests completed!"
 

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -213,8 +213,8 @@ jobs:
             echo "Installing APK..."
             adb install -r apk/app-debug.apk
             
-            # Get package name from APK
-            PACKAGE_NAME=$(aapt dump badging apk/app-debug.apk | grep package | awk -F"'" '{print $2}')
+            # Package name from android/app/build.gradle.kts
+            PACKAGE_NAME="com.example.flutter_mobile_o11y_demo"
             echo "Package name: $PACKAGE_NAME"
             
             # Launch the app

--- a/alloy/cloud-dev.alloy
+++ b/alloy/cloud-dev.alloy
@@ -251,7 +251,7 @@ otelcol.auth.basic "otlpEndpoint" {
 otelcol.exporter.otlphttp "otlpEndpoint" {
   client {
     // FR:  gcom API to return the Grafana Cloud OTLP endpoint 
-    endpoint = "https://otlp-gateway-"+ grafana_cloud.stack.receivers.info["clusterSlug"] + ".grafana.net/otlp"
+    endpoint = "https://otlp-gateway-"+ grafana_cloud.stack.receivers.info["clusterSlug"] + ".grafana-dev.net/otlp"
     // https://github.com/grafana/beyla/blob/069049182455db603f3bda6865e7de13e45e038f/pkg/export/otel/common.go#L22
     auth     = otelcol.auth.basic.otlpEndpoint.handler
   }


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that continuously generates demo telemetry data by running the QuickPizza Flutter app with Arbigent AI-powered e2e tests.

### What it does
- **Builds Flutter APK** with Faro collector URL from Vault
- **Runs QuickPizza backend** via docker-compose with Alloy forwarding OTel data to Grafana Cloud
- **Starts Android emulator** (Pixel 6 profile) and installs the app
- **Runs Arbigent e2e tests** that simulate real user interactions:
  - Launch app
  - Request pizza recommendation
  - Rate pizza with "Love it!"
  - Background/foreground app transitions

### Telemetry generated
- **Mobile app**: Faro RUM data (sessions, views, interactions, errors)
- **Backend**: OpenTelemetry traces, metrics, and logs via Alloy

### Schedule
- Runs **hourly** for continuous telemetry data
- Also triggers on PR changes to this workflow and manual dispatch

### Optimizations
- **APK caching**: Skips rebuild when app version unchanged
- **Artifact retention**: 1 day for e2e results, 3 days for logs

### Vault secrets required
- `faro_collector_url` - Faro collector endpoint for mobile app
- `grafana_cloud_stack` - Grafana Cloud stack name
- `grafana_cloud_token` - Grafana Cloud API token
- `openai_api_key` - OpenAI API key for Arbigent e2e tests

## Test plan
- [x] Verify Vault secrets are accessible
- [x] Verify APK builds successfully  
- [x] Verify APK caching works
- [x] Verify backend starts and health check passes
- [x] Verify Android emulator runs with Pixel 6 profile
- [x] Verify Arbigent e2e tests complete successfully
- [x] Verify mobile telemetry appears in Grafana Cloud (Faro)
- [x] Verify backend telemetry appears in Grafana Cloud (OTel)