### PR TITLE
Improve mobile demo CI telemetry realism and e2e flow stability

### DIFF
--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -93,7 +93,8 @@ jobs:
           {
             "FARO_COLLECTOR_URL": "${FARO_COLLECTOR_URL}",
             "BASE_URL": "",
-            "PORT": "3333"
+            "PORT": "3333",
+            "CI_DEMO_VERSIONING": "true"
           }
           EOF
           echo "Created config.json:"

--- a/Mobiles/flutter/config.json.example
+++ b/Mobiles/flutter/config.json.example
@@ -4,6 +4,9 @@
   "_BASE_URL_comment": "Leave empty for emulators (uses 10.0.2.2 for Android, localhost for iOS). For physical devices, set to your machine's IP like http://192.168.1.100:3333",
   "BASE_URL": "",
   
-  "PORT": "3333"
+  "PORT": "3333",
+
+  "_CI_DEMO_VERSIONING_comment": "Set to true only for CI demo builds to vary telemetry app version hourly",
+  "CI_DEMO_VERSIONING": "false"
 }
 

--- a/Mobiles/flutter/e2e-tests/arbigent-e2e_basic_pizza_flow.yaml
+++ b/Mobiles/flutter/e2e-tests/arbigent-e2e_basic_pizza_flow.yaml
@@ -19,33 +19,40 @@ scenarios:
   - id: "request_pizza"
     goal: |
       You should see a pizza recommendation on the screen.
+      As soon as you see the pizza recommendation, the goal is achieved.
 
       INSTRUCTIONS:
-      1. Tap the "Pizza, Please!" button.
+      1. Tap the "Pizza, Please!" button once.
+      2. After tapping, wait and observe before taking another action.
 
       A Pizza Recommendation has the following elements:
       - a pizza name
       - some ingredients
-      - "No thanks" and "Love it!" buttons
+      - "Pass" and "Love it!" buttons
 
       HINTS:
-      - The rating buttons might not be visible, you need to scroll down to see them.
+      - The rating buttons might not be visible; scroll all the way down to see them.
       - If you need to login, consider using the "default" / "12345678" credentials.
-    maxRetry: 0
+    maxRetry: 1
     maxStep: 15 # Allow many steps here, since we might need to go though login flow first.
 
   - id: "rate_pizza"
     dependency: "request_pizza"
     goal: |
-      You should rate the pizza by tapping "Love it!" and see confirmation.
+      You should rate the pizza and see "Rated!" text.
+      As soon as you see the "Rated!" text, the goal is achieved.
+
+      A Pizza Recommendation is rated when you see:
+      - "Rated!" text below the ratings buttons.
 
       INSTRUCTIONS:
-      1. Tap the "Love it!" button to rate the pizza.
+      1. Tap one of the rating buttons to rate the pizza. You choose which one to tap. Both are equally good. We want to test both good and bad ratings.
 
-      SUCCESS CRITERIA:
-      - You see "Rated!" text appear.
-    maxRetry: 0
-    maxStep: 5
+      HINTS:
+      - If you cannot see the Rated text, scroll all the way down to see it.
+      - A rating button is either "Love it!" or "Pass".
+    maxRetry: 1
+    maxStep: 7
 
   - id: "put_app_to_background"
     goal: |

--- a/Mobiles/flutter/lib/bootstrap.dart
+++ b/Mobiles/flutter/lib/bootstrap.dart
@@ -4,6 +4,7 @@ import 'package:faro/faro.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'core/config/app_version_resolver.dart';
 import 'core/config/app_version_provider.dart';
 import 'core/config/config_service.dart';
 import 'core/localization/app_localizations.dart';
@@ -56,9 +57,20 @@ Future<void> bootstrap(BootstrapConfig config) async {
 
   // Get app version from package info provider (warms up the provider for later use)
   final packageInfo = await container.read(packageInfoProvider.future);
-  final appVersion = packageInfo.version;
-
-  logger.debug('App version: $appVersion');
+  final baseAppVersion = packageInfo.version;
+  final versionResolver = container.read(appVersionResolverProvider);
+  final appVersion = versionResolver.resolveTelemetryAppVersion(
+    baseVersion: baseAppVersion,
+    enableCiDemoVersioning: ConfigService.ciDemoVersioning,
+  );
+  logger.debug(
+    'App version resolved',
+    context: {
+      'baseVersion': baseAppVersion,
+      'telemetryVersion': appVersion,
+      'ciDemoVersioning': ConfigService.ciDemoVersioning.toString(),
+    },
+  );
 
   // Get collector URL from build-time config
   final collectorUrl = ConfigService.faroCollectorUrl;

--- a/Mobiles/flutter/lib/core/config/app_version_resolver.dart
+++ b/Mobiles/flutter/lib/core/config/app_version_resolver.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final appVersionResolverProvider = Provider<AppVersionResolver>((ref) {
+  return const AppVersionResolver();
+});
+
+class AppVersionResolver {
+  const AppVersionResolver();
+
+  String resolveTelemetryAppVersion({
+    required String baseVersion,
+    required bool enableCiDemoVersioning,
+    DateTime? nowUtc,
+  }) {
+    if (!enableCiDemoVersioning) {
+      return baseVersion;
+    }
+
+    final match = RegExp(r'^(\d+)\.(\d+)\.(\d+)$').firstMatch(baseVersion);
+    if (match == null) {
+      return baseVersion;
+    }
+
+    final major = int.parse(match.group(1)!);
+    final minor = int.parse(match.group(2)!);
+    final patch = int.parse(match.group(3)!);
+
+    // Keep the same variant for all launches in the same UTC hour.
+    final now = (nowUtc ?? DateTime.now()).toUtc();
+    final hourBucket =
+        '${now.year.toString().padLeft(4, '0')}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}${now.hour.toString().padLeft(2, '0')}';
+
+    final variant = _stableHash('$baseVersion|$hourBucket') % 3;
+    if (variant == 0) {
+      return '$major.$minor.$patch';
+    }
+    if (variant == 1) {
+      return '$major.$minor.${patch + 1}';
+    }
+    return '$major.$minor.${patch + 2}';
+  }
+
+  int _stableHash(String input) {
+    var hash = 5381;
+    for (final codeUnit in input.codeUnits) {
+      hash = ((hash << 5) + hash) ^ codeUnit;
+      hash &= 0x7fffffff;
+    }
+    return hash;
+  }
+}

--- a/Mobiles/flutter/lib/core/config/config_service.dart
+++ b/Mobiles/flutter/lib/core/config/config_service.dart
@@ -7,6 +7,22 @@ final configServiceProvider = Provider((ref) {
 });
 
 class ConfigService {
+  static bool get ciDemoVersioning {
+    const raw = String.fromEnvironment(
+      'CI_DEMO_VERSIONING',
+      defaultValue: 'false',
+    );
+    switch (raw.toLowerCase()) {
+      case '1':
+      case 'true':
+      case 'yes':
+      case 'on':
+        return true;
+      default:
+        return false;
+    }
+  }
+
   String get baseUrl {
     // Check if BASE_URL is set via build-time config
     const baseUrl = String.fromEnvironment('BASE_URL');

--- a/Mobiles/flutter/pubspec.yaml
+++ b/Mobiles/flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_mobile_o11y_demo
 description: "QuickPizza Flutter Mobile App"
 publish_to: "none"
 
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ^3.10.1

--- a/Mobiles/flutter/test/core/config/app_version_resolver_test.dart
+++ b/Mobiles/flutter/test/core/config/app_version_resolver_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_mobile_o11y_demo/core/config/app_version_resolver.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppVersionResolver', () {
+    const resolver = AppVersionResolver();
+
+    test('returns base version when CI demo versioning is disabled', () {
+      final result = resolver.resolveTelemetryAppVersion(
+        baseVersion: '1.1.1',
+        enableCiDemoVersioning: false,
+      );
+
+      expect(result, '1.1.1');
+    });
+
+    test('returns base version when base version is not semver', () {
+      final result = resolver.resolveTelemetryAppVersion(
+        baseVersion: 'dev-build',
+        enableCiDemoVersioning: true,
+      );
+
+      expect(result, 'dev-build');
+    });
+
+    test('returns a stable result within the same UTC hour', () {
+      final first = resolver.resolveTelemetryAppVersion(
+        baseVersion: '1.1.1',
+        enableCiDemoVersioning: true,
+        nowUtc: DateTime.utc(2026, 2, 19, 13, 1, 0),
+      );
+      final second = resolver.resolveTelemetryAppVersion(
+        baseVersion: '1.1.1',
+        enableCiDemoVersioning: true,
+        nowUtc: DateTime.utc(2026, 2, 19, 13, 59, 59),
+      );
+
+      expect(second, first);
+    });
+
+    test('returns only allowed base/patch variants', () {
+      const allowed = {'1.1.1', '1.1.2', '1.1.3'};
+
+      for (var hour = 0; hour < 24; hour++) {
+        final result = resolver.resolveTelemetryAppVersion(
+          baseVersion: '1.1.1',
+          enableCiDemoVersioning: true,
+          nowUtc: DateTime.utc(2026, 2, 19, hour, 0, 0),
+        );
+
+        expect(allowed.contains(result), isTrue, reason: 'hour=$hour');
+      }
+    });
+
+    test('uses patch-only bumps from a .0 base', () {
+      const allowed = {'1.1.0', '1.1.1', '1.1.2'};
+
+      for (var hour = 0; hour < 24; hour++) {
+        final result = resolver.resolveTelemetryAppVersion(
+          baseVersion: '1.1.0',
+          enableCiDemoVersioning: true,
+          nowUtc: DateTime.utc(2026, 2, 19, hour, 0, 0),
+        );
+
+        expect(allowed.contains(result), isTrue, reason: 'hour=$hour');
+      }
+    });
+  });
+
+  group('appVersionResolverProvider', () {
+    test('exposes AppVersionResolver via ProviderContainer', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final resolver = container.read(appVersionResolverProvider);
+
+      expect(resolver, isA<AppVersionResolver>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Improve Arbigent e2e scenario prompts/retries to make pizza request/rating steps more robust in CI.
- Add CI-only app version variation (`CI_DEMO_VERSIONING`) so scheduled runs emit realistic Faro app versions.
- Introduce a Riverpod `AppVersionResolver` with deterministic hourly patch-only variants, wire it into bootstrap, add unit tests, and bump Flutter app version to `1.1.1`.

## Test plan
- [x] `flutter test test/core/config/app_version_resolver_test.dart`
- [x] `dart analyze` on touched Dart files
- [x] Confirmed no lints on touched files

Made with [Cursor](https://cursor.com)