### PR TITLE
iOS: add MetricKit crash instrumentation, debug tab, and OTel docs

### DIFF
--- a/Mobiles/docs/IOS_APP_ARCHITECTURE.md
+++ b/Mobiles/docs/IOS_APP_ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 This document captures architectural decisions and best practices for building the QuickPizza iOS app. It serves as context for AI agents and developers working on the iOS codebase.
 
+For telemetry-specific implementation details, see `IOS_OBSERVABILITY_OTEL_GUIDE.md`.
+
 ## Table of Contents
 
 - [Project Setup](#project-setup)

--- a/Mobiles/docs/IOS_OBSERVABILITY_OTEL_GUIDE.md
+++ b/Mobiles/docs/IOS_OBSERVABILITY_OTEL_GUIDE.md
@@ -1,0 +1,215 @@
+# iOS OpenTelemetry Instrumentation Guide (QuickPizza)
+
+This guide explains how the QuickPizza iOS app is instrumented today with OpenTelemetry Swift, what data it emits, and how to apply the same approach in your own app.
+
+Audience:
+- Demo teams who need to explain the telemetry model to customers
+- iOS engineers who want to copy this setup
+
+## 1. High-level architecture
+
+Telemetry is initialized once at app startup:
+
+- `Bootstrap.initialize()` resolves and initializes `OTelService`
+- `OTelService` registers global OTel providers and instrumentations
+- Feature repositories use injected `Tracing` and `Logging` abstractions
+
+Key files:
+- `Mobiles/ios/QuickPizzaIos/Bootstrap.swift`
+- `Mobiles/ios/QuickPizzaIos/Core/O11y/OTelService.swift`
+- `Mobiles/ios/QuickPizzaIos/Core/O11y/Tracer.swift`
+- `Mobiles/ios/QuickPizzaIos/Core/O11y/Logger.swift`
+
+## 2. Which telemetry signals are emitted
+
+QuickPizza iOS emits:
+
+1. Traces
+- Manual spans around key business operations (login, recommendation, rating)
+- Auto HTTP client spans via `URLSessionInstrumentation`
+- MetricKit payload spans (pre-aggregated Apple performance data)
+
+2. Logs
+- Application logs (`debug`, `info`, `warning`, `error`)
+- Exception logs via custom `logger.exception(...)`
+- Session lifecycle logs (`session.start`, `session.end`) from Sessions instrumentation
+- MetricKit diagnostics logs (including crashes/hangs)
+
+3. Metrics
+- No custom OTel Metrics API instrumentation yet
+- MetricKit performance data is represented as spans (SDK design)
+
+## 3. What data is collected
+
+### 3.1 Resource attributes (all telemetry)
+
+Configured in `OTelService.buildResource(...)`:
+- `service.name` (default `quickpizza-ios`)
+- `service.namespace` (`quickpizza`)
+- `service.version` (app version)
+- `service.build` (bundle build number)
+- `deployment.environment` (default `production`)
+
+### 3.2 Sessions
+
+Configured in `setupSessions()`:
+- Session timeout: 15 minutes of inactivity
+- Span enrichment: `SessionSpanProcessor()`
+- Log enrichment: `SessionLogRecordProcessor(...)`
+- Session events: `SessionEventInstrumentation.install()`
+
+Attributes added by session processors include:
+- `session.id`
+- `session.previous_id` (when available)
+
+### 3.3 Manual traces
+
+Examples:
+- `auth.login` span
+- `pizza.get_recommendation` span
+- `pizza.rate` span
+
+Typical span attributes:
+- `http.status_code`
+- domain attributes like `pizza.id`, `pizza.name`, `pizza.stars`, `auth.result`
+
+### 3.4 Auto HTTP spans
+
+`URLSessionInstrumentation` is enabled globally.
+
+The OTLP host is excluded from auto-instrumentation to avoid exporter self-tracing loops.
+
+### 3.5 Application logs and exception logs
+
+App logger is a composite:
+- OSLog (Xcode/device console)
+- OpenTelemetry logger provider
+
+`logger.error(...)` emits error logs and sets OTel semantic attributes when an `Error` exists:
+- `error.type`
+- `error.message`
+
+`logger.exception(...)` emits an exception-style log with:
+- `eventName = "exception"`
+- `exception.type`
+- `exception.message`
+- `exception.stacktrace` (current thread call stack)
+- `error.type`
+
+### 3.6 Crash and hang diagnostics (MetricKit)
+
+`MetricKitInstrumentation` is registered in `setupMetricKitInstrumentation()` and retained on the service (required because `MXMetricManager` keeps weak references).
+
+It sends:
+- Metric payloads as spans (windowed/aggregated)
+- Diagnostic entries as logs:
+  - `metrickit.diagnostic.crash`
+  - `metrickit.diagnostic.hang`
+  - `metrickit.diagnostic.cpu_exception`
+  - `metrickit.diagnostic.disk_write_exception`
+  - `metrickit.diagnostic.app_launch` (platform/version dependent)
+
+Crash/hang log attributes include OTel exception semantic fields such as:
+- `exception.type`
+- `exception.message`
+- `exception.stacktrace`
+
+Important delivery model:
+- MetricKit is delayed and batched by Apple (not realtime crash streaming)
+- Diagnostics are generally delivered in later payloads, often tied to 24h reporting windows
+
+## 4. Export model (where telemetry goes)
+
+Configured via `Config.xcconfig` values that are generated into `BuildConfig` at build time.
+
+Inputs:
+- `OTLP_ENDPOINT`
+- `OTLP_AUTH_HEADER`
+
+Behavior:
+- If `OTLP_ENDPOINT` is set: traces -> `/v1/traces`, logs -> `/v1/logs` (OTLP HTTP)
+- If `OTLP_ENDPOINT` is empty: no OTLP exporters are attached
+  - traces still print in debug via `OSLogSpanExporter`
+  - logs are still available in OSLog via `ConsoleLogger`
+
+Related files:
+- `Mobiles/ios/Config.xcconfig.example`
+- `Mobiles/ios/Scripts/generate-config.sh`
+- `Mobiles/ios/QuickPizzaIos/Core/Config/ConfigService.swift`
+
+## 5. Demo workflow (customer-facing)
+
+For quick demos, use the in-app Debug tab:
+- `Send logger.exception`
+- `Trigger test crash`
+
+Files:
+- `Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugView.swift`
+- `Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugViewModel.swift`
+
+Expected outcome:
+1. `logger.exception` appears quickly as an error/exception log in backend.
+2. Crash diagnostics via MetricKit arrive later (delayed, batched).
+
+## 6. How to apply this in your own iOS app
+
+Use this checklist:
+
+1. Add OpenTelemetry Swift packages
+- Core SDK + OTLP HTTP exporters
+- `URLSessionInstrumentation`
+- `Sessions`
+- `MetricKitInstrumentation`
+
+2. Initialize once at app startup
+- Register tracer and logger providers
+- Set resource attributes (`service.*`, environment)
+
+3. Enable session processors
+- `SessionSpanProcessor`
+- `SessionLogRecordProcessor`
+- `SessionEventInstrumentation.install()`
+
+4. Enable URLSession auto tracing
+- Add exclusion for your OTLP host
+
+5. Add structured app logging facade
+- Include `error` and optional `exception` API
+- Map to OTel semantic attributes (`error.*`, `exception.*`)
+
+6. Register MetricKit instrumentation
+- Keep a strong reference to instrumentation instance
+
+7. Add test hooks
+- Non-prod debug screen/action for exception + intentional crash
+
+8. Validate end-to-end
+- Verify traces and logs in backend
+- Verify delayed MetricKit crash delivery behavior
+
+## 7. Known limitations and nuances
+
+- MetricKit crash reporting is delayed by Apple and delivered in payload windows.
+- `session.previous_id` is not a guaranteed 1:1 crash-to-session mapping in all delayed-delivery scenarios.
+- `logger.exception(...)` and MetricKit crash logs are both logs, but represent different sources:
+  - `logger.exception`: app-triggered exception event now
+  - MetricKit crash log: OS-reported diagnostic event later
+
+## 8. Current QuickPizza iOS instrumentation inventory
+
+Implemented now:
+- OTel traces (manual + URLSession auto)
+- OTel logs (app logs + exception logs)
+- Session enrichment on spans/logs
+- MetricKit crash/hang/diagnostic ingestion
+- Debug tab for exception and crash testing
+
+Not yet implemented:
+- Custom OTel Metrics API instrumentation
+- Crash dedup strategy in app code
+- Explicit crash-to-session linkage strategy beyond default session attributes
+
+---
+
+If you are presenting this to customers, the main talking point is:
+"We combine immediate in-app observability (traces/logs) with delayed OS-level diagnostics (MetricKit), all through standard OTLP signals."

--- a/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
+++ b/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		621CCCCB2F4617FF001A3F53 /* Sessions in Frameworks */ = {isa = PBXBuildFile; productRef = 621CCCCA2F4617FF001A3F53 /* Sessions */; };
+		62A1F0012F47200100ABCD01 /* MetricKitInstrumentation in Frameworks */ = {isa = PBXBuildFile; productRef = 62A1F0022F47200100ABCD01 /* MetricKitInstrumentation */; };
 		62ECE0322F43D3D300611CB0 /* SwiftiePod in Frameworks */ = {isa = PBXBuildFile; productRef = 62ECE0312F43D3D300611CB0 /* SwiftiePod */; };
 		62ECE0352F43D6AE00611CB0 /* SwiftiePod in Frameworks */ = {isa = PBXBuildFile; productRef = 62ECE0342F43D6AE00611CB0 /* SwiftiePod */; };
 		62ECE0392F4459C400611CB0 /* Config.xcconfig.example in Resources */ = {isa = PBXBuildFile; fileRef = 62ECE0382F4459C400611CB0 /* Config.xcconfig.example */; };
@@ -41,6 +42,7 @@
 			files = (
 				621CCCCB2F4617FF001A3F53 /* Sessions in Frameworks */,
 				62ECE0352F43D6AE00611CB0 /* SwiftiePod in Frameworks */,
+				62A1F0012F47200100ABCD01 /* MetricKitInstrumentation in Frameworks */,
 				62EFEF4E2F360BAE00E72D9F /* OpenTelemetryApi in Frameworks */,
 				62EFEF522F360BAE00E72D9F /* StdoutExporter in Frameworks */,
 				62EFEF462F36082D00E72D9F /* ResourceExtension in Frameworks */,
@@ -103,6 +105,7 @@
 			packageProductDependencies = (
 				62EFEF432F36082D00E72D9F /* OpenTelemetryProtocolExporterHTTP */,
 				62EFEF452F36082D00E72D9F /* ResourceExtension */,
+				62A1F0022F47200100ABCD01 /* MetricKitInstrumentation */,
 				62EFEF472F36082D00E72D9F /* URLSessionInstrumentation */,
 				62EFEF4D2F360BAE00E72D9F /* OpenTelemetryApi */,
 				62EFEF4F2F360BAE00E72D9F /* OpenTelemetrySdk */,
@@ -445,6 +448,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 62EFEF422F36082D00E72D9F /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
 			productName = Sessions;
+		};
+		62A1F0022F47200100ABCD01 /* MetricKitInstrumentation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 62EFEF422F36082D00E72D9F /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
+			productName = MetricKitInstrumentation;
 		};
 		62ECE0312F43D3D300611CB0 /* SwiftiePod */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mobiles/ios/QuickPizzaIos/Core/O11y/Logger.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/O11y/Logger.swift
@@ -19,6 +19,7 @@ protocol Logging {
     func info(_ message: String, attributes: [String: String])
     func warning(_ message: String, attributes: [String: String])
     func error(_ message: String, error: Error?, attributes: [String: String])
+    func exception(_ message: String, error: Error, attributes: [String: String])
 }
 
 extension Logging {
@@ -33,6 +34,9 @@ extension Logging {
     }
     func error(_ message: String, error: Error? = nil, attributes: [String: String] = [:]) {
         self.error(message, error: error, attributes: attributes)
+    }
+    func exception(_ message: String, error: Error, attributes: [String: String] = [:]) {
+        self.exception(message, error: error, attributes: attributes)
     }
 }
 
@@ -60,6 +64,10 @@ final class CompositeLogger: Logging {
 
     func error(_ message: String, error: Error?, attributes: [String: String]) {
         loggers.forEach { $0.error(message, error: error, attributes: attributes) }
+    }
+
+    func exception(_ message: String, error: Error, attributes: [String: String]) {
+        loggers.forEach { $0.exception(message, error: error, attributes: attributes) }
     }
 }
 
@@ -89,6 +97,10 @@ final class ConsoleLogger: Logging {
         let fullMessage = error != nil ? "\(message): \(error!.localizedDescription)" : message
         osLogger.error("\(fullMessage)")
     }
+
+    func exception(_ message: String, error: Error, attributes: [String: String]) {
+        osLogger.error("\(message): \(error.localizedDescription)")
+    }
 }
 
 // MARK: - OtelLogger
@@ -116,14 +128,34 @@ final class OtelLogger: Logging {
     func error(_ message: String, error: Error?, attributes: [String: String]) {
         var attrs = attributes
         if let error {
-            attrs["error.type"] = String(describing: type(of: error))
-            attrs["error.message"] = error.localizedDescription
+            attrs[SemanticConventions.Error.type.rawValue] = String(describing: type(of: error))
+            attrs[SemanticConventions.Error.message.rawValue] = error.localizedDescription
         }
         let fullMessage = error != nil ? "\(message): \(error!.localizedDescription)" : message
         emitLog(fullMessage, severity: .error, attributes: attrs)
     }
 
-    private func emitLog(_ message: String, severity: Severity, attributes: [String: String]) {
+    func exception(_ message: String, error: Error, attributes: [String: String]) {
+        var attrs = attributes
+        attrs[SemanticConventions.Exception.type.rawValue] = String(describing: type(of: error))
+        attrs[SemanticConventions.Exception.message.rawValue] = error.localizedDescription
+        attrs[SemanticConventions.Exception.stacktrace.rawValue] = Thread.callStackSymbols.joined(separator: "\n")
+        attrs[SemanticConventions.Error.type.rawValue] = String(describing: type(of: error))
+
+        emitLog(
+            message,
+            severity: .error,
+            attributes: attrs,
+            eventName: SemanticConventions.Exception.exception.rawValue
+        )
+    }
+
+    private func emitLog(
+        _ message: String,
+        severity: Severity,
+        attributes: [String: String],
+        eventName: String? = nil
+    ) {
         var otelAttributes = attributes.reduce(
             into: [String: OpenTelemetryApi.AttributeValue]()
         ) { result, pair in
@@ -131,12 +163,15 @@ final class OtelLogger: Logging {
         }
         otelAttributes["level"] = .string("\(severity)")
 
-        otelLogger
+        let builder = otelLogger
             .logRecordBuilder()
             .setBody(.string(message))
             .setTimestamp(Date())
             .setAttributes(otelAttributes)
             .setSeverity(severity)
-            .emit()
+        if let eventName {
+            _ = builder.setEventName(eventName)
+        }
+        builder.emit()
     }
 }

--- a/Mobiles/ios/QuickPizzaIos/Core/O11y/OTelService.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/O11y/OTelService.swift
@@ -7,6 +7,8 @@ import URLSessionInstrumentation
 import ResourceExtension
 import Sessions
 import SwiftiePod
+import MetricKit
+import MetricKitInstrumentation
 
 let otelServiceProvider = Provider { pod in
     let config = pod.resolve(otelConfigProvider)
@@ -22,6 +24,8 @@ final class OTelService {
 
     private var isInitialized = false
     private var otelConfig: OTelConfig?
+    /// MXMetricManager keeps a weak reference to subscribers, so we retain it here.
+    private var metricKitInstrumentation: MetricKitInstrumentation?
 
     private init() {}
 
@@ -33,6 +37,7 @@ final class OTelService {
         setupSessions()
         setupTraces(config: config)
         setupLogs(config: config)
+        setupMetricKitInstrumentation()
         setupURLSessionInstrumentation(config: config)
     }
 
@@ -106,6 +111,14 @@ final class OTelService {
     }
 
     // MARK: - URLSession Instrumentation
+
+    private func setupMetricKitInstrumentation() {
+        guard metricKitInstrumentation == nil else { return }
+
+        let instrumentation = MetricKitInstrumentation()
+        MXMetricManager.shared.add(instrumentation)
+        metricKitInstrumentation = instrumentation
+    }
 
     private func setupURLSessionInstrumentation(config: OTelConfig) {
         let excludedHosts: Set<String> = {

--- a/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugView.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import SwiftiePod
+
+struct DebugView: View {
+    @State private var viewModel = pod.resolve(debugViewModelProvider)
+    @State private var showCrashConfirmation = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                VStack(spacing: 8) {
+                    Text("Debug Tools")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundStyle(AppColors.textPrimary)
+
+                    Text("Use these actions to validate OpenTelemetry exception and crash behavior.")
+                        .font(.subheadline)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(AppColors.textSecondary)
+                }
+                .padding(.top, 16)
+
+                VStack(spacing: 12) {
+                    Button {
+                        viewModel.sendExceptionEvent()
+                    } label: {
+                        Label("Send logger.exception", systemImage: "exclamationmark.bubble.fill")
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+
+                    Button {
+                        showCrashConfirmation = true
+                    } label: {
+                        Label("Trigger test crash", systemImage: "bolt.horizontal.circle.fill")
+                    }
+                    .buttonStyle(SecondaryButtonStyle())
+                }
+
+                if let lastActionMessage = viewModel.lastActionMessage {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(AppColors.success)
+                        Text(lastActionMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(AppColors.textPrimary)
+                        Spacer()
+                    }
+                    .padding(12)
+                    .background(AppColors.cardBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+
+                Text("Crash button intentionally terminates the app via fatalError.")
+                    .font(.caption)
+                    .foregroundStyle(AppColors.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Spacer(minLength: 40)
+            }
+            .padding(.horizontal, 16)
+        }
+        .background(AppColors.background)
+        .alert("Trigger test crash?", isPresented: $showCrashConfirmation) {
+            Button("Crash now", role: .destructive) {
+                viewModel.triggerCrash()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will immediately terminate the app.")
+        }
+    }
+}
+
+#Preview {
+    DebugView()
+}

--- a/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugViewModel.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugViewModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftUI
+import SwiftiePod
+
+let debugViewModelProvider = Provider(scope: AlwaysCreateNewScope()) { pod in
+    DebugViewModel(logger: pod.resolve(loggerProvider))
+}
+
+@Observable
+class DebugViewModel {
+    private let logger: Logging
+
+    var lastActionMessage: String?
+
+    init(logger: Logging) {
+        self.logger = logger
+    }
+
+    func sendExceptionEvent() {
+        let error = DebugTestError.simulatedException
+        logger.exception(
+            "Debug tab sent custom logger.exception event",
+            error: error,
+            attributes: [
+                "debug.action": "logger.exception",
+                "debug.source": "debug_tab",
+            ]
+        )
+        lastActionMessage = "Sent custom exception log"
+    }
+
+    func triggerCrash() -> Never {
+        logger.error(
+            "Debug tab is about to trigger a fatalError crash",
+            error: nil,
+            attributes: [
+                "debug.action": "crash",
+                "debug.source": "debug_tab",
+            ]
+        )
+        fatalError("Debug crash triggered from Debug tab")
+    }
+}
+
+enum DebugTestError: LocalizedError {
+    case simulatedException
+
+    var errorDescription: String? {
+        "Simulated exception from Debug tab"
+    }
+}

--- a/Mobiles/ios/QuickPizzaIos/Navigation/MainShell.swift
+++ b/Mobiles/ios/QuickPizzaIos/Navigation/MainShell.swift
@@ -21,6 +21,13 @@ struct MainShell: View {
                         Label("About", systemImage: "info.circle")
                     }
                     .tag(1)
+
+                // Debug tab
+                DebugView()
+                    .tabItem {
+                        Label("Debug", systemImage: "ladybug.fill")
+                    }
+                    .tag(2)
             }
             .tint(AppColors.primary)
             .toolbar {


### PR DESCRIPTION
## Summary
- add MetricKit instrumentation wiring to the iOS OTel service
- add custom exception logging attributes using OTel semantic conventions
- add a new Debug tab with actions to emit `logger.exception` and trigger a test crash
- add iOS observability guide documentation and link it from iOS architecture docs

## Validation
- xcodebuild project listing resolves packages and succeeds
- Debug tab actions verified locally (`logger.exception` visible in Grafana Cloud)

## Notes
- uses `MetricKitInstrumentation()` initializer for compatibility with current resolved `opentelemetry-swift` package revision
- related issue: #16
