### PR TITLE
Bump Faro Flutter SDK to 0.11.0 and add user action instrumentation

### DIFF
--- a/Mobiles/flutter/lib/core/o11y/actions/o11y_actions.dart
+++ b/Mobiles/flutter/lib/core/o11y/actions/o11y_actions.dart
@@ -1,0 +1,52 @@
+import 'package:faro/faro.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../faro/faro.dart';
+
+final o11yActionsProvider = Provider<O11yActions>((ref) {
+  return FaroO11yActions(faro: ref.watch(faroProvider));
+});
+
+/// Abstraction for tracking user actions — high-level user interactions
+/// that group related telemetry (HTTP requests, events, logs, errors)
+/// under a single correlated context.
+///
+/// Only one action can be active at a time. Starting a new action while
+/// one is already active is a no-op. Actions end automatically when the
+/// related activity (HTTP responses, navigation) settles.
+abstract class O11yActions {
+  /// Starts a user action that groups all subsequent telemetry under
+  /// the given [name] until the action's lifecycle completes.
+  ///
+  /// [attributes] are optional key-value pairs attached to the action.
+  /// [isCritical] marks the action as high-importance for prioritized
+  /// monitoring.
+  void startUserAction(
+    String name, {
+    Map<String, String>? attributes,
+    bool isCritical = false,
+  });
+}
+
+class FaroO11yActions implements O11yActions {
+  FaroO11yActions({required Faro faro}) : _faro = faro;
+
+  final Faro _faro;
+
+  @override
+  void startUserAction(
+    String name, {
+    Map<String, String>? attributes,
+    bool isCritical = false,
+  }) {
+    _faro.startUserAction(
+      name,
+      attributes: attributes,
+      options: isCritical
+          ? const StartUserActionOptions(
+              importance: UserActionConstants.importanceCritical,
+            )
+          : null,
+    );
+  }
+}

--- a/Mobiles/flutter/lib/features/auth/domain/auth_provider.dart
+++ b/Mobiles/flutter/lib/features/auth/domain/auth_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/o11y/actions/o11y_actions.dart';
 import '../../../core/o11y/events/o11y_events.dart';
 import '../../../core/o11y/loggers/o11y_logger.dart';
 import 'auth_repository.dart';
@@ -47,10 +48,13 @@ class AuthStateNotifier extends Notifier<AuthState> {
   AuthState build() => const AuthState();
 
   AuthRepository get _authRepository => ref.read(authRepositoryProvider);
+  O11yActions get _o11yActions => ref.read(o11yActionsProvider);
   O11yEvents get _o11yEvents => ref.read(o11yEventsProvider);
   O11yLogger get _o11yLogger => ref.read(o11yLoggerProvider);
 
   Future<bool> login(String username, String password) async {
+    _o11yActions.startUserAction('user-login', isCritical: true);
+
     _o11yEvents.trackStartEvent('login_attempt', 'user_login');
 
     state = state.copyWith(isLoading: true, errorMessage: null);

--- a/Mobiles/flutter/lib/features/pizza/domain/pizza_provider.dart
+++ b/Mobiles/flutter/lib/features/pizza/domain/pizza_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/o11y/actions/o11y_actions.dart';
 import '../../../core/o11y/events/o11y_events.dart';
 import '../../../core/o11y/loggers/o11y_logger.dart';
 import '../../../core/o11y/metrics/o11y_metrics.dart';
@@ -51,6 +52,7 @@ class PizzaState {
 
 class PizzaStateNotifier extends Notifier<PizzaState> {
   late PizzaRepository _pizzaRepository;
+  late O11yActions _o11yActions;
   late O11yEvents _o11yEvents;
   late O11yLogger _o11yLogger;
   late O11yMetrics _o11yMetrics;
@@ -58,6 +60,7 @@ class PizzaStateNotifier extends Notifier<PizzaState> {
   @override
   PizzaState build() {
     _pizzaRepository = ref.watch(pizzaRepositoryProvider);
+    _o11yActions = ref.watch(o11yActionsProvider);
     _o11yEvents = ref.watch(o11yEventsProvider);
     _o11yLogger = ref.watch(o11yLoggerProvider);
     _o11yMetrics = ref.watch(o11yMetricsProvider);
@@ -77,6 +80,11 @@ class PizzaStateNotifier extends Notifier<PizzaState> {
   }
 
   Future<void> getPizza(Restrictions restrictions) async {
+    _o11yActions.startUserAction(
+      'get-pizza-recommendation',
+      attributes: {'vegetarian': restrictions.mustBeVegetarian.toString()},
+    );
+
     _o11yEvents.trackEvent(
       'pizza_requested',
       context: {'vegetarian': restrictions.mustBeVegetarian.toString()},

--- a/Mobiles/flutter/lib/features/ratings/domain/ratings_provider.dart
+++ b/Mobiles/flutter/lib/features/ratings/domain/ratings_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/o11y/actions/o11y_actions.dart';
 import '../../../core/o11y/events/o11y_events.dart';
 import '../../../core/o11y/metrics/o11y_metrics.dart';
 import '../models/rating.dart';
@@ -18,6 +19,7 @@ class RatingsNotifier extends AsyncNotifier<List<Rating>> {
 
   RatingsRepository get _ratingsRepository =>
       ref.read(ratingsRepositoryProvider);
+  O11yActions get _o11yActions => ref.read(o11yActionsProvider);
   O11yEvents get _o11yEvents => ref.read(o11yEventsProvider);
   O11yMetrics get _o11yMetrics => ref.read(o11yMetricsProvider);
 
@@ -32,6 +34,11 @@ class RatingsNotifier extends AsyncNotifier<List<Rating>> {
   }
 
   Future<bool> ratePizza({required int pizzaId, required int stars}) async {
+    _o11yActions.startUserAction(
+      'rate-pizza',
+      attributes: {'pizza_id': pizzaId.toString(), 'stars': stars.toString()},
+    );
+
     _o11yEvents.trackEvent(
       'pizza_rated',
       context: {'pizza_id': pizzaId.toString(), 'stars': stars.toString()},
@@ -58,6 +65,11 @@ class RatingsNotifier extends AsyncNotifier<List<Rating>> {
 
   Future<bool> deleteRatings() async {
     final currentRatings = state.value ?? [];
+
+    _o11yActions.startUserAction(
+      'delete-ratings',
+      attributes: {'count': currentRatings.length.toString()},
+    );
 
     _o11yEvents.trackEvent(
       'ratings_deleted',

--- a/Mobiles/flutter/pubspec.lock
+++ b/Mobiles/flutter/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -161,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dartypod:
+    dependency: transitive
+    description:
+      name: dartypod
+      sha256: "0c335e98224c97ae64e23b0062e563596a400dfd44dfc2b1e9dd186ef9e243ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   dbus:
     dependency: transitive
     description:
@@ -205,10 +213,10 @@ packages:
     dependency: "direct main"
     description:
       name: faro
-      sha256: c71789251105ca044cf1a914ef34d8d155b115a3984011b97e832c26d8521dc7
+      sha256: "94c7acfa73f6fd458bd36d1d66a616be00f01dccdff947fda7282b45e9765143"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.0"
   ffi:
     dependency: transitive
     description:
@@ -375,14 +383,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -435,18 +435,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -816,26 +816,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:

--- a/Mobiles/flutter/pubspec.yaml
+++ b/Mobiles/flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  faro: ^0.8.0
+  faro: ^0.11.0
   flutter_riverpod: ^3.1.0
   http: ^1.1.0
   shared_preferences: ^2.2.2


### PR DESCRIPTION
## Summary
- Upgrade Faro Flutter SDK from 0.8.0 to 0.11.0, picking up user actions, session sampling, typed OTLP attributes, and other improvements
- Add `O11yActions` abstraction (`core/o11y/actions/`) to wrap the new user actions API, keeping Faro as an implementation detail — consistent with the existing `O11yEvents`, `O11yErrors`, `O11yTraces` pattern
- Instrument four key workflows with user actions: `get-pizza-recommendation`, `user-login` (critical), `rate-pizza`, `delete-ratings`

User actions group all related telemetry (HTTP requests, events, logs, errors, traces) under a single correlated context, enabling end-to-end visibility per interaction in Grafana Frontend Observability's Actions tab.

## Test plan
- [x] Tested on device — user actions appear in Faro telemetry
- [x] Verified no lint errors
- [x] Existing events/logs/metrics continue to work alongside the new action context