### PR TITLE
Bump Faro Flutter SDK to 0.12.0

### DIFF
--- a/Mobiles/flutter/lib/bootstrap.dart
+++ b/Mobiles/flutter/lib/bootstrap.dart
@@ -102,8 +102,7 @@ Future<void> bootstrap(BootstrapConfig config) async {
         // Used by Riverpod to provide providers to the app
         UncontrolledProviderScope(
           container: container,
-          child: DefaultAssetBundle(
-            bundle: FaroAssetBundle(),
+          child: FaroAssetTracking(
             child: const FaroUserInteractionWidget(child: QuickPizzaApp()),
           ),
         ),

--- a/Mobiles/flutter/pubspec.lock
+++ b/Mobiles/flutter/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: "direct main"
     description:
       name: faro
-      sha256: "94c7acfa73f6fd458bd36d1d66a616be00f01dccdff947fda7282b45e9765143"
+      sha256: af184b088debab5e8fb57bcd9e6dcd7174d8c05961dc0c0e3df92c9fbf80e9da
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0"
+    version: "0.12.0"
   ffi:
     dependency: transitive
     description:

--- a/Mobiles/flutter/pubspec.yaml
+++ b/Mobiles/flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  faro: ^0.11.0
+  faro: ^0.12.0
   flutter_riverpod: ^3.1.0
   http: ^1.1.0
   shared_preferences: ^2.2.2


### PR DESCRIPTION
## Summary
- Bump Faro Flutter SDK dependency from 0.11.0 to 0.12.0
- Migrate from deprecated `DefaultAssetBundle`/`FaroAssetBundle` to new `FaroAssetTracking` widget

## Test plan
- [ ] Verify the Flutter demo app builds and runs
- [ ] Confirm Faro telemetry is still being sent correctly