### PR TITLE
Fix mobile-to-backend trace context propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ build
 # secrets
 .env
 
+# local dev scripts
+run-backend.sh
+
 bin
 fly.toml
 
@@ -52,3 +55,7 @@ logs.txt
 .DS_Store
 /.claude/CLAUDE.md
 /tmp_dev/
+/Mobiles/android/.gradle
+/Mobiles/android/.idea
+/Mobiles/android/app/src/main/res/raw/config.json
+/Mobiles/android/local.properties

--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.extension.kotlin)
     implementation(libs.opentelemetry.android.okhttp3.library)
+    implementation(libs.opentelemetry.okhttp3)
     byteBuddy(libs.opentelemetry.android.okhttp3.agent)
 
     // Testing

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/di/AppModule.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/di/AppModule.kt
@@ -15,6 +15,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTelemetry
 import okhttp3.Call
 import javax.inject.Singleton
 
@@ -24,7 +25,8 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpCallFactory(): Call.Factory = buildBaseOkHttpClient()
+    fun provideOkHttpCallFactory(otelService: OTelService): Call.Factory =
+        OkHttpTelemetry.create(otelService.openTelemetry).createCallFactory(buildBaseOkHttpClient())
 
     @Provides
     @Singleton

--- a/Mobiles/android/gradle/libs.versions.toml
+++ b/Mobiles/android/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ opentelemetry-android-bom = { module = "io.opentelemetry.android:opentelemetry-a
 opentelemetry-android-agent = { module = "io.opentelemetry.android:android-agent" }
 opentelemetry-android-okhttp3-library = { module = "io.opentelemetry.android.instrumentation:okhttp3-library", version.ref = "opentelemetryAndroidInstrumentation" }
 opentelemetry-android-okhttp3-agent = { module = "io.opentelemetry.android.instrumentation:okhttp3-agent", version.ref = "opentelemetryAndroidInstrumentation" }
+opentelemetry-okhttp3 = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0" }
 opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk" }
 opentelemetry-extension-kotlin = { module = "io.opentelemetry:opentelemetry-extension-kotlin" }
 

--- a/pkg/http/otel.go
+++ b/pkg/http/otel.go
@@ -76,11 +76,13 @@ func createTraceProvider(ctx context.Context, endpoint *url.URL, otlpProtocol st
 		if insecure {
 			trace_client = otlptracehttp.NewClient(
 				otlptracehttp.WithEndpoint(endpoint.Host),
+				otlptracehttp.WithURLPath(endpoint.Path+"/v1/traces"),
 				otlptracehttp.WithInsecure(),
 			)
 		} else {
 			trace_client = otlptracehttp.NewClient(
 				otlptracehttp.WithEndpoint(endpoint.Host),
+				otlptracehttp.WithURLPath(endpoint.Path+"/v1/traces"),
 			)
 		}
 	default:
@@ -125,9 +127,9 @@ func createMetricProvider(ctx context.Context, endpoint *url.URL, otlpProtocol s
 		}
 	case "http/protobuf":
 		if insecure {
-			exporter, err = otlpmetrichttp.New(ctx, otlpmetrichttp.WithEndpoint(endpoint.Host), otlpmetrichttp.WithInsecure())
+			exporter, err = otlpmetrichttp.New(ctx, otlpmetrichttp.WithEndpoint(endpoint.Host), otlpmetrichttp.WithURLPath(endpoint.Path+"/v1/metrics"), otlpmetrichttp.WithInsecure())
 		} else {
-			exporter, err = otlpmetrichttp.New(ctx, otlpmetrichttp.WithEndpoint(endpoint.Host))
+			exporter, err = otlpmetrichttp.New(ctx, otlpmetrichttp.WithEndpoint(endpoint.Host), otlpmetrichttp.WithURLPath(endpoint.Path+"/v1/metrics"))
 		}
 	default:
 		return nil, fmt.Errorf("unsupported protocol %q", otlpProtocol)


### PR DESCRIPTION
Fixes to support sending backend telemetry to Grafana cloud OTEL endpoint and context propagation from android native app. Look mom, e2e traces:

<img width="2583" height="1219" alt="image" src="https://github.com/user-attachments/assets/5d331aeb-3367-4b06-b23f-aca1ef308aeb" />



## Summary

- **Backend OTLP path bug**: `pkg/http/otel.go` was passing only `endpoint.Host` to the OTLP HTTP exporters, silently dropping the `/otlp` path prefix — causing 404s when exporting to Grafana Cloud. Fixed by adding `WithURLPath(endpoint.Path + "/v1/traces|metrics")`.
- **Backend trace context acceptance**: Added `QUICKPIZZA_TRUST_CLIENT_TRACEID=1` support — without this the backend was treating all incoming requests as public endpoints, creating a *link* to the mobile span instead of a parent-child relationship.
- **Android `traceparent` injection**: `AppModule` was providing a plain `OkHttpClient`, relying on the ByteBuddy `okhttp3-agent` to find `GlobalOpenTelemetry`. This was unreliable since `OpenTelemetryRumInitializer` doesn't guarantee setting the global instance. Now explicitly wraps the client with `OkHttpTelemetry.createCallFactory()` using the live `OTelService` instance.
- **Android dependency**: Added `opentelemetry-okhttp-3.0` as an explicit dependency (was only transitive) to expose `OkHttpTelemetry` on the compile classpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)