### PR TITLE
Unify app display names across platforms and improve RN tab bar

### DIFF
--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/ui/components/QuickPizzaTopBar.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/ui/components/QuickPizzaTopBar.kt
@@ -67,7 +67,7 @@ fun QuickPizzaTopBar(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "QuickPizza",
+                    text = "QuickPizza Android",
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = Color(0xFFCC2200),

--- a/Mobiles/android/app/src/main/res/values/strings.xml
+++ b/Mobiles/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">QuickPizza</string>
+    <string name="app_name">QPizza Android</string>
 </resources>

--- a/Mobiles/flutter/android/app/src/main/AndroidManifest.xml
+++ b/Mobiles/flutter/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="QuickPizza"
+        android:label="QPizza Flutter"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/Mobiles/flutter/ios/Runner/Info.plist
+++ b/Mobiles/flutter/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>QuickPizza</string>
+	<string>QPizza Flutter</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>QuickPizza</string>
+	<string>QPizza Flutter</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/Mobiles/flutter/lib/bootstrap.dart
+++ b/Mobiles/flutter/lib/bootstrap.dart
@@ -120,7 +120,7 @@ class QuickPizzaApp extends ConsumerWidget {
     final router = ref.watch(appRouterProvider);
 
     return MaterialApp.router(
-      title: 'QuickPizza',
+      title: 'QuickPizza Flutter',
       debugShowCheckedModeBanner: false,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/Mobiles/flutter/lib/core/localization/app_en.arb
+++ b/Mobiles/flutter/lib/core/localization/app_en.arb
@@ -1,7 +1,7 @@
 {
   "@@locale": "en",
 
-  "appName": "QuickPizza",
+  "appName": "QuickPizza Flutter",
 
   "navHome": "Home",
   "navAbout": "About",

--- a/Mobiles/flutter/lib/core/localization/app_localizations.dart
+++ b/Mobiles/flutter/lib/core/localization/app_localizations.dart
@@ -97,7 +97,7 @@ abstract class AppLocalizations {
   /// No description provided for @appName.
   ///
   /// In en, this message translates to:
-  /// **'QuickPizza'**
+  /// **'QuickPizza Flutter'**
   String get appName;
 
   /// No description provided for @navHome.

--- a/Mobiles/flutter/lib/core/localization/app_localizations_en.dart
+++ b/Mobiles/flutter/lib/core/localization/app_localizations_en.dart
@@ -9,7 +9,7 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get appName => 'QuickPizza';
+  String get appName => 'QuickPizza Flutter';
 
   @override
   String get navHome => 'Home';

--- a/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
+++ b/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 				DEVELOPMENT_TEAM = CF67NZZ27B;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "QPizza iOS";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -370,6 +371,7 @@
 				DEVELOPMENT_TEAM = CF67NZZ27B;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "QPizza iOS";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Mobiles/ios/QuickPizzaIos/Core/UI/Components/QuickPizzaAppBar.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/UI/Components/QuickPizzaAppBar.swift
@@ -11,7 +11,7 @@ struct QuickPizzaToolbar: ToolbarContent {
             HStack(spacing: 8) {
                 Text("🍕")
                     .font(.title2)
-                Text("QuickPizza")
+                Text("QuickPizza iOS")
                     .font(.title3)
                     .fontWeight(.semibold)
                     .foregroundStyle(AppColors.primary)

--- a/Mobiles/react-native/android/app/src/main/res/values/strings.xml
+++ b/Mobiles/react-native/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">QuickPizza RN</string>
+    <string name="app_name">QPizza RN</string>
 </resources>

--- a/Mobiles/react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Mobiles/react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/Mobiles/react-native/app.json
+++ b/Mobiles/react-native/app.json
@@ -1,4 +1,4 @@
 {
   "name": "QuickPizza",
-  "displayName": "QuickPizza RN"
+  "displayName": "QPizza RN"
 }

--- a/Mobiles/react-native/ios/Podfile.lock
+++ b/Mobiles/react-native/ios/Podfile.lock
@@ -2178,7 +2178,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FaroReactNative: 889821cf519bd2242e89ff8a2a8b3977f0a80621
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: 40d9c07f06e5cfb14add9a995c44cd9260eb8403
+  hermes-engine: af26a2fc195f459f1524c41bc6da855e0eafa8ae
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
@@ -2188,7 +2188,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: af87338af8fe3fdf3058328c8001eb9a6c35f2ac
+  React-Core-prebuilt: 8d637a909b2f1ea893ccd5f60707c5db195e57e9
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2250,7 +2250,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: 378c47f88c1f15c3e7af23cf2a6ba1b142da8cef
+  ReactNativeDependencies: c380a964bdefa6cb8a75c47f1d645646b947eb74
   RNCAsyncStorage: 7a5a6094f9f6b9158e72f1855cd86e769413d851
   RNDeviceInfo: 900bd20e1fd3bfd894e7384cc4a83880c0341bd3
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707

--- a/Mobiles/react-native/ios/QuickPizza/Info.plist
+++ b/Mobiles/react-native/ios/QuickPizza/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>QuickPizza RN</string>
+	<string>QPizza RN</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Mobiles/react-native/src/core/components/QuickPizzaAppBar.tsx
+++ b/Mobiles/react-native/src/core/components/QuickPizzaAppBar.tsx
@@ -28,7 +28,7 @@ export function QuickPizzaAppBar({
     <View style={styles.container}>
       <View style={styles.titleRow}>
         <Text style={styles.icon}>🍕</Text>
-        <Text style={styles.title}>QuickPizza</Text>
+        <Text style={styles.title}>QuickPizza RN</Text>
       </View>
       <View style={styles.rightRow}>
         {onAdvancedChange != null && advancedEnabled !== undefined && (

--- a/Mobiles/react-native/src/navigation/AppNavigator.tsx
+++ b/Mobiles/react-native/src/navigation/AppNavigator.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from 'react-native';
 import {
   NavigationContainer,
   useNavigation,
@@ -69,13 +70,23 @@ function MainTabs({
     >
       <Tab.Screen
         name="Home"
-        options={{ tabBarLabel: 'Home', tabBarIcon: () => null }}
+        options={{
+          tabBarLabel: 'Home',
+          tabBarIcon: ({color, size}) => (
+            <Text style={{fontSize: size - 2, color}}>⌂</Text>
+          ),
+        }}
       >
         {() => <HomeScreen onProfilePress={handleProfilePress} />}
       </Tab.Screen>
       <Tab.Screen
         name="About"
-        options={{ tabBarLabel: 'About', tabBarIcon: () => null }}
+        options={{
+          tabBarLabel: 'About',
+          tabBarIcon: ({color, size}) => (
+            <Text style={{fontSize: size - 2, color}}>ⓘ</Text>
+          ),
+        }}
       >
         {() => (
           <AboutScreen

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1048,9 +1048,11 @@
 
 "@grafana/faro-react-native-tracing@1.0.0-alpha.1":
   version "1.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@grafana/faro-react-native-tracing/-/faro-react-native-tracing-1.0.0-alpha.1.tgz#8d8afdffed3398279f8ec6270d3ae14dc71feeda"
+  integrity sha512-Wb9O5YVhIRW5YXMg+eatCdXffsmP2OapP+Q+zEaykIYXa7/Nj4WYXiMrdA1D2CbmSis3oNsnGBbF/scMNG6vxg==
   dependencies:
     "@grafana/faro-core" "^2.2.3"
-    "@grafana/faro-react-native" "1.0.0-alpha.1"
+    "@grafana/faro-react-native" "^1.0.0-alpha.1"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/core" "^2.0.0"
     "@opentelemetry/instrumentation" "^0.208.0"
@@ -1061,8 +1063,10 @@
     "@opentelemetry/sdk-trace-base" "^2.0.0"
     "@opentelemetry/semantic-conventions" "^1.32.0"
 
-"@grafana/faro-react-native@1.0.0-alpha.1":
+"@grafana/faro-react-native@1.0.0-alpha.1", "@grafana/faro-react-native@^1.0.0-alpha.1":
   version "1.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@grafana/faro-react-native/-/faro-react-native-1.0.0-alpha.1.tgz#dcba7cd0afae5440cb1b0b2775e811dc34971a6c"
+  integrity sha512-mf/uGqF6JW8Nb886cyBJj95pYmuR5bnWOWAMIU1N0XxZe4EIa7B7yOqHaB0xPXIGzo5cfOShIV+bQXBHILXcHQ==
   dependencies:
     "@grafana/faro-core" "^2.2.3"
     "@react-native-async-storage/async-storage" "^1.21.0"


### PR DESCRIPTION
## Summary
- Update home screen icon labels to `QPizza <platform>` across all 4 apps
  (iOS native, Android native, Flutter, React Native)
- Update in-app header titles to `QuickPizza <platform>` for quick
  identification of which variant is running
- Add tab bar icons (⌂ Home, ⓘ About) to the React Native app to match
  the other apps
- Minor: RN Gradle, yarn.lock, and Podfile.lock dependency updates

## Test plan
- [x] Verified Flutter app on Android emulator
- [x] Verified React Native app on Android emulator
- [x] Verified iOS native app on iPhone simulator


## Screenshots:

### Device Homescreen
<img width="524" height="1040" alt="ios-home" src="https://github.com/user-attachments/assets/e7cf85b8-86b3-4bfb-82a3-62505c679170" />
<img width="493" height="908" alt="android-home" src="https://github.com/user-attachments/assets/b990f0be-8e05-4787-943b-cdfe88df3ee5" />

### Android app start screen
<img width="493" height="908" alt="android-rn" src="https://github.com/user-attachments/assets/89c72d99-514d-4e28-8b1e-883fbb97b27a" />
<img width="493" height="908" alt="android-android" src="https://github.com/user-attachments/assets/22ba2535-90bc-46f6-bae5-73aa15c74e99" />
<img width="493" height="908" alt="android-flutter" src="https://github.com/user-attachments/assets/43ce35b9-0ccf-433b-8541-937e32a750f3" />

### iOS app start screen
<img width="524" height="1040" alt="ios-ios" src="https://github.com/user-attachments/assets/2d5e6a68-a3c9-41b6-9363-c61e9b22786a" />
<img width="568" height="1084" alt="ios-rn" src="https://github.com/user-attachments/assets/a43cb32f-cb20-4837-9d3b-45cb00b58132" />
<img width="524" height="1040" alt="ios-flutter" src="https://github.com/user-attachments/assets/bfb10b9f-9bcb-4257-af5b-7f6ba7fd9463" />



Made with [Cursor](https://cursor.com)