### PR TITLE
Android: expand debug tab with config, error simulation, and telemetry diagnostics

### DIFF
--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "com.grafana.quickpizza"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"
@@ -82,6 +82,9 @@ dependencies {
     // Networking
     implementation(libs.okhttp)
     implementation(libs.gson)
+
+    // Persistence
+    implementation(libs.datastore.preferences)
 
     // OpenTelemetry Android
     implementation(platform(libs.opentelemetry.android.bom))

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/MainActivity.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/MainActivity.kt
@@ -4,18 +4,28 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.grafana.quickpizza.core.o11y.AppEvents
 import com.grafana.quickpizza.navigation.AppNavGraph
 import com.grafana.quickpizza.navigation.BottomNavBar
 import com.grafana.quickpizza.ui.theme.QuickPizzaTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var appEvents: AppEvents
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,17 +33,72 @@ class MainActivity : ComponentActivity() {
         setContent {
             QuickPizzaTheme {
                 val navController = rememberNavController()
+                TrackScreenViews(navController, appEvents)
 
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),
                     bottomBar = { BottomNavBar(navController) },
                 ) { innerPadding ->
+                    val bottomInset = innerPadding.calculateBottomPadding()
                     AppNavGraph(
                         navController = navController,
-                        modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding()),
+                        modifier = Modifier
+                            .padding(bottom = bottomInset)
+                            .consumeWindowInsets(PaddingValues(bottom = bottomInset)),
                     )
                 }
             }
         }
+    }
+}
+
+/**
+ * Emits a `screen.view` event on every [NavController] destination change.
+ *
+ * Jetpack Compose Navigation is not yet covered by opentelemetry-android's
+ * auto-instrumentation (see open-telemetry/opentelemetry-android#361), so we
+ * bridge it manually via [NavController.OnDestinationChangedListener].
+ *
+ * Attributes:
+ *  - `nav.destination`          — current destination route
+ *  - `nav.previous_destination` — route we came from (empty on first event)
+ *  - `nav.kind`                 — `initial` | `push` | `pop` | `replace`
+ *
+ * We deliberately do NOT use the `screen.name` attribute key: the SDK's screen
+ * attributes log processor unconditionally overwrites it with the visible
+ * Activity/Fragment name (`MainActivity` for this single-Activity app), which
+ * silently clobbers anything we set and bumps `dropped_attributes_count`.
+ *
+ * Consequence: auto-instrumented HTTP/ANR/crash records will still report
+ * `screen.name=MainActivity`. Correlate to navigation destinations by
+ * timestamp + `session.id`.
+ */
+@Composable
+private fun TrackScreenViews(navController: NavHostController, appEvents: AppEvents) {
+    DisposableEffect(navController) {
+        var previousRoute: String? = null
+        var previousStackSize = 0
+        val listener = NavController.OnDestinationChangedListener { controller, destination, _ ->
+            val route = destination.route ?: "unknown"
+            val currentStackSize = controller.currentBackStack.value.size
+            val kind = when {
+                previousRoute == null -> "initial"
+                currentStackSize > previousStackSize -> "push"
+                currentStackSize < previousStackSize -> "pop"
+                else -> "replace"
+            }
+            appEvents.trackEvent(
+                "screen.view",
+                mapOf(
+                    "nav.destination" to route,
+                    "nav.previous_destination" to (previousRoute ?: ""),
+                    "nav.kind" to kind,
+                ),
+            )
+            previousRoute = route
+            previousStackSize = currentStackSize
+        }
+        navController.addOnDestinationChangedListener(listener)
+        onDispose { navController.removeOnDestinationChangedListener(listener) }
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/QuickPizzaApp.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/QuickPizzaApp.kt
@@ -1,6 +1,7 @@
 package com.grafana.quickpizza
 
 import android.app.Application
+import com.grafana.quickpizza.core.config.RuntimeConfigHolder
 import com.grafana.quickpizza.core.o11y.OTelService
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -9,10 +10,16 @@ import javax.inject.Inject
 class QuickPizzaApp : Application() {
 
     @Inject
+    lateinit var runtimeConfig: RuntimeConfigHolder
+
+    @Inject
     lateinit var otelService: OTelService
 
     override fun onCreate() {
         super.onCreate()
+        // Resolve the in-use URLs before anything else so OTelService and
+        // ApiClient see the same snapshot for the rest of the session.
+        runtimeConfig.current
         otelService.initialize()
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/api/ApiClient.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/api/ApiClient.kt
@@ -19,6 +19,8 @@ class ApiClient @Inject constructor(
     private val callFactory: Call.Factory,
     private val baseUrlProvider: () -> String,
     private val tokenProvider: () -> String?,
+    // Read live so debug toggles take effect without recreating the client.
+    private val errorHeadersProvider: () -> Map<String, String> = { emptyMap() },
 ) {
     private val gson = Gson()
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
@@ -27,6 +29,7 @@ class ApiClient @Inject constructor(
         val request = Request.Builder()
             .url("${baseUrlProvider()}$endpoint")
             .applyAuthHeader()
+            .applyErrorHeaders()
             .get()
             .build()
         return callFactory.newCall(request).execute()
@@ -44,6 +47,7 @@ class ApiClient @Inject constructor(
         }
         val builder = Request.Builder()
             .url("${baseUrlProvider()}$endpoint")
+            .applyErrorHeaders()
             .post(requestBody)
         if (includeAuth) builder.applyAuthHeader()
         return callFactory.newCall(builder.build()).execute()
@@ -53,6 +57,7 @@ class ApiClient @Inject constructor(
         val request = Request.Builder()
             .url("${baseUrlProvider()}$endpoint")
             .applyAuthHeader()
+            .applyErrorHeaders()
             .delete()
             .build()
         return callFactory.newCall(request).execute()
@@ -63,6 +68,11 @@ class ApiClient @Inject constructor(
         if (!token.isNullOrEmpty()) {
             addHeader("Authorization", "Token $token")
         }
+        return this
+    }
+
+    private fun Request.Builder.applyErrorHeaders(): Request.Builder {
+        errorHeadersProvider().forEach { (name, value) -> addHeader(name, value) }
         return this
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AppConfig.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AppConfig.kt
@@ -1,12 +1,19 @@
 package com.grafana.quickpizza.core.config
 
 import android.content.Context
+import android.util.Base64
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Bootstrap configuration loaded from `app/src/main/res/raw/config.json`.
+ *
+ * Holds the build-time defaults only — runtime overrides (set by the user
+ * through Debug → Config) are applied on top by [RuntimeConfigHolder].
+ */
 @Singleton
 class AppConfig @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -14,7 +21,9 @@ class AppConfig @Inject constructor(
     private val config: ConfigFile by lazy { loadConfig() }
 
     val otlpEndpoint: String get() = config.otlpEndpoint.trim()
-    val otlpAuthHeader: String get() = config.otlpAuthHeader.trim()
+    val otlpInstanceId: String get() = config.otlpInstanceId.trim()
+    val otlpApiKey: String get() = config.otlpApiKey.trim()
+
     val appVersion: String get() = runCatching {
         context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "unknown"
     }.getOrDefault("unknown")
@@ -26,7 +35,6 @@ class AppConfig @Inject constructor(
         }
 
     // Android emulator uses 10.0.2.2 to reach the host machine's localhost.
-    // This matches the Flutter ConfigService behavior on Android.
     // For physical devices, set BASE_URL in config.json to the host machine's LAN IP.
     private val defaultBaseUrl = "http://10.0.2.2:3333"
 
@@ -48,7 +56,25 @@ class AppConfig @Inject constructor(
 
     private data class ConfigFile(
         @SerializedName("OTLP_ENDPOINT") val otlpEndpoint: String = "",
-        @SerializedName("OTLP_AUTH_HEADER") val otlpAuthHeader: String = "",
+        @SerializedName("OTLP_INSTANCE_ID") val otlpInstanceId: String = "",
+        @SerializedName("OTLP_API_KEY") val otlpApiKey: String = "",
         @SerializedName("BASE_URL") val baseUrl: String = "",
     )
+}
+
+/**
+ * Builds a Grafana Cloud OTLP Gateway `Authorization` header value:
+ * `Basic base64("<instanceId>:<apiKey>")`.
+ *
+ * Returns `null` when either credential is missing — the OTel exporter
+ * should then be configured without an Authorization header (e.g. for
+ * a self-hosted OTLP receiver that doesn't require auth).
+ */
+fun buildOtlpAuthHeader(instanceId: String, apiKey: String): String? {
+    if (instanceId.isBlank() || apiKey.isBlank()) return null
+    val token = Base64.encodeToString(
+        "$instanceId:$apiKey".toByteArray(Charsets.UTF_8),
+        Base64.NO_WRAP,
+    )
+    return "Basic $token"
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/ApplicationScope.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/ApplicationScope.kt
@@ -1,0 +1,12 @@
+package com.grafana.quickpizza.core.config
+
+import javax.inject.Qualifier
+
+/**
+ * Marker for an application-scoped [kotlinx.coroutines.CoroutineScope] —
+ * lives for the entire process lifetime, used for fire-and-forget background
+ * work (e.g. keeping a hot StateFlow in sync with DataStore).
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ApplicationScope

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/DebugSettings.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/DebugSettings.kt
@@ -1,0 +1,187 @@
+package com.grafana.quickpizza.core.config
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Snapshot of all values persisted by [DebugSettingsRepository].
+ *
+ * URL overrides are nullable — `null` means "no override, use the build-time default".
+ * Boolean toggles default to `false`.
+ */
+data class DebugSettings(
+    val backendUrlOverride: String? = null,
+    val otlpEndpointOverride: String? = null,
+    val otlpInstanceIdOverride: String? = null,
+    val otlpApiKeyOverride: String? = null,
+    val errorOnRecommendations: Boolean = false,
+    val errorOnIngredients: Boolean = false,
+    val slowRecommendations: Boolean = false,
+    val slowIngredients: Boolean = false,
+    val useV2PizzaSchema: Boolean = false,
+    val skipAuthDepInTools: Boolean = false,
+) {
+    val hasActiveOverrides: Boolean
+        get() = backendUrlOverride != null ||
+            otlpEndpointOverride != null ||
+            otlpInstanceIdOverride != null ||
+            otlpApiKeyOverride != null ||
+            errorOnRecommendations ||
+            errorOnIngredients ||
+            slowRecommendations ||
+            slowIngredients ||
+            useV2PizzaSchema ||
+            skipAuthDepInTools
+
+    /**
+     * Backend expects:
+     *  * `x-error-*` headers — value is the error message (any non-empty string)
+     *  * `x-delay-*` headers — value is a Go duration string (e.g. `3s`, `500ms`)
+     *
+     * Delay values are tuned so both toggles produce ~3s of user-visible
+     * slowness. `record-recommendation` is called once per `POST /api/pizza`,
+     * so 3s → ~3s. `get-ingredients` is called four times per request
+     * (oil, tomato, mozzarella, topping), so 750ms → ~3s total.
+     */
+    val errorInjectionHeaders: Map<String, String>
+        get() = buildMap {
+            if (errorOnRecommendations) put("x-error-record-recommendation", "simulated recommendation service failure")
+            if (errorOnIngredients) put("x-error-get-ingredients", "simulated ingredient lookup failure")
+            if (slowRecommendations) put("x-delay-record-recommendation", "3s")
+            if (slowIngredients) put("x-delay-get-ingredients", "750ms")
+        }
+}
+
+private val Context.debugSettingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "debug_settings")
+
+private object DebugSettingsKeys {
+    val backendUrl = stringPreferencesKey("debug_backend_url")
+    val otlpEndpoint = stringPreferencesKey("debug_otlp_endpoint")
+    val otlpInstanceId = stringPreferencesKey("debug_otlp_instance_id")
+    val otlpApiKey = stringPreferencesKey("debug_otlp_api_key")
+    val errorRecommendations = booleanPreferencesKey("debug_error_recommendations")
+    val errorIngredients = booleanPreferencesKey("debug_error_ingredients")
+    val slowRecommendations = booleanPreferencesKey("debug_slow_recommendations")
+    val slowIngredients = booleanPreferencesKey("debug_slow_ingredients")
+    val useV2PizzaSchema = booleanPreferencesKey("debug_use_v2_pizza_schema")
+    val skipAuthDepInTools = booleanPreferencesKey("debug_skip_auth_dep_in_tools")
+}
+
+@Singleton
+class DebugSettingsRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+) {
+    private val dataStore: DataStore<Preferences> = context.debugSettingsDataStore
+
+    val flow: Flow<DebugSettings> = dataStore.data.map { it.toSettings() }
+
+    // Hot snapshot kept in sync with DataStore. Seeded synchronously at construction
+    // so [current] is safe to read from any thread without coroutine ceremony — used
+    // by ApiClient.errorHeadersProvider on every request.
+    private val _state: MutableStateFlow<DebugSettings> = MutableStateFlow(
+        runBlocking { snapshot() },
+    )
+    val state: StateFlow<DebugSettings> = _state.asStateFlow()
+    val current: DebugSettings get() = _state.value
+
+    init {
+        applicationScope.launch {
+            flow.collect { _state.value = it }
+        }
+    }
+
+    /**
+     * Synchronous snapshot. Used at app bootstrap (before coroutines are practical)
+     * to seed [com.grafana.quickpizza.core.config.RuntimeConfig]. Blocks the calling
+     * thread until DataStore returns the first emission.
+     */
+    suspend fun snapshot(): DebugSettings = dataStore.data.first().toSettings()
+
+    suspend fun setBackendUrlOverride(value: String?) = updateString(DebugSettingsKeys.backendUrl, value)
+    suspend fun setOtlpEndpointOverride(value: String?) = updateString(DebugSettingsKeys.otlpEndpoint, value)
+    suspend fun setOtlpInstanceIdOverride(value: String?) = updateString(DebugSettingsKeys.otlpInstanceId, value)
+    suspend fun setOtlpApiKeyOverride(value: String?) = updateString(DebugSettingsKeys.otlpApiKey, value)
+    suspend fun setErrorOnRecommendations(value: Boolean) = updateBoolean(DebugSettingsKeys.errorRecommendations, value)
+    suspend fun setErrorOnIngredients(value: Boolean) = updateBoolean(DebugSettingsKeys.errorIngredients, value)
+    suspend fun setSlowRecommendations(value: Boolean) = updateBoolean(DebugSettingsKeys.slowRecommendations, value)
+    suspend fun setSlowIngredients(value: Boolean) = updateBoolean(DebugSettingsKeys.slowIngredients, value)
+    suspend fun setUseV2PizzaSchema(value: Boolean) = updateBoolean(DebugSettingsKeys.useV2PizzaSchema, value)
+    suspend fun setSkipAuthDepInTools(value: Boolean) = updateBoolean(DebugSettingsKeys.skipAuthDepInTools, value)
+
+    /**
+     * Persist all URL + OTLP credential overrides atomically. Empty / blank values
+     * clear the corresponding override.
+     */
+    suspend fun saveConfigOverrides(
+        backendUrl: String?,
+        otlpEndpoint: String?,
+        otlpInstanceId: String?,
+        otlpApiKey: String?,
+    ) {
+        val normalizedBackend = normalize(backendUrl)
+        val normalizedOtlp = normalize(otlpEndpoint)
+        val normalizedInstanceId = normalize(otlpInstanceId)
+        val normalizedApiKey = normalize(otlpApiKey)
+        dataStore.edit { prefs ->
+            if (normalizedBackend != null) prefs[DebugSettingsKeys.backendUrl] = normalizedBackend
+            else prefs.remove(DebugSettingsKeys.backendUrl)
+            if (normalizedOtlp != null) prefs[DebugSettingsKeys.otlpEndpoint] = normalizedOtlp
+            else prefs.remove(DebugSettingsKeys.otlpEndpoint)
+            if (normalizedInstanceId != null) prefs[DebugSettingsKeys.otlpInstanceId] = normalizedInstanceId
+            else prefs.remove(DebugSettingsKeys.otlpInstanceId)
+            if (normalizedApiKey != null) prefs[DebugSettingsKeys.otlpApiKey] = normalizedApiKey
+            else prefs.remove(DebugSettingsKeys.otlpApiKey)
+        }
+    }
+
+    suspend fun resetAll() {
+        dataStore.edit { it.clear() }
+    }
+
+    private suspend fun updateString(key: Preferences.Key<String>, value: String?) {
+        val normalized = normalize(value)
+        dataStore.edit { prefs ->
+            if (normalized != null) prefs[key] = normalized else prefs.remove(key)
+        }
+    }
+
+    private suspend fun updateBoolean(key: Preferences.Key<Boolean>, value: Boolean) {
+        dataStore.edit { it[key] = value }
+    }
+
+    private fun normalize(value: String?): String? {
+        val trimmed = value?.trim()?.trimEnd('/')
+        return if (trimmed.isNullOrEmpty()) null else trimmed
+    }
+
+    private fun Preferences.toSettings(): DebugSettings = DebugSettings(
+        backendUrlOverride = this[DebugSettingsKeys.backendUrl],
+        otlpEndpointOverride = this[DebugSettingsKeys.otlpEndpoint],
+        otlpInstanceIdOverride = this[DebugSettingsKeys.otlpInstanceId],
+        otlpApiKeyOverride = this[DebugSettingsKeys.otlpApiKey],
+        errorOnRecommendations = this[DebugSettingsKeys.errorRecommendations] ?: false,
+        errorOnIngredients = this[DebugSettingsKeys.errorIngredients] ?: false,
+        slowRecommendations = this[DebugSettingsKeys.slowRecommendations] ?: false,
+        slowIngredients = this[DebugSettingsKeys.slowIngredients] ?: false,
+        useV2PizzaSchema = this[DebugSettingsKeys.useV2PizzaSchema] ?: false,
+        skipAuthDepInTools = this[DebugSettingsKeys.skipAuthDepInTools] ?: false,
+    )
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/DebugSettings.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/DebugSettings.kt
@@ -37,6 +37,14 @@ data class DebugSettings(
     val slowIngredients: Boolean = false,
     val useV2PizzaSchema: Boolean = false,
     val skipAuthDepInTools: Boolean = false,
+    /**
+     * When `true`, the OTel-Android SDK is initialized with `diskBuffering { enabled = false }`,
+     * bypassing the on-device file queue and exporting via OTLP directly. Cuts end-to-end
+     * latency from ~30–45s to ~1–6s — useful for live demos where you want to see signals
+     * land in Grafana right after an action. Read once at app startup; toggling requires
+     * a restart.
+     */
+    val disableDiskBuffering: Boolean = false,
 ) {
     val hasActiveOverrides: Boolean
         get() = backendUrlOverride != null ||
@@ -48,7 +56,8 @@ data class DebugSettings(
             slowRecommendations ||
             slowIngredients ||
             useV2PizzaSchema ||
-            skipAuthDepInTools
+            skipAuthDepInTools ||
+            disableDiskBuffering
 
     /**
      * Backend expects:
@@ -82,6 +91,7 @@ private object DebugSettingsKeys {
     val slowIngredients = booleanPreferencesKey("debug_slow_ingredients")
     val useV2PizzaSchema = booleanPreferencesKey("debug_use_v2_pizza_schema")
     val skipAuthDepInTools = booleanPreferencesKey("debug_skip_auth_dep_in_tools")
+    val disableDiskBuffering = booleanPreferencesKey("debug_disable_disk_buffering")
 }
 
 @Singleton
@@ -125,6 +135,7 @@ class DebugSettingsRepository @Inject constructor(
     suspend fun setSlowIngredients(value: Boolean) = updateBoolean(DebugSettingsKeys.slowIngredients, value)
     suspend fun setUseV2PizzaSchema(value: Boolean) = updateBoolean(DebugSettingsKeys.useV2PizzaSchema, value)
     suspend fun setSkipAuthDepInTools(value: Boolean) = updateBoolean(DebugSettingsKeys.skipAuthDepInTools, value)
+    suspend fun setDisableDiskBuffering(value: Boolean) = updateBoolean(DebugSettingsKeys.disableDiskBuffering, value)
 
     /**
      * Persist all URL + OTLP credential overrides atomically. Empty / blank values
@@ -183,5 +194,6 @@ class DebugSettingsRepository @Inject constructor(
         slowIngredients = this[DebugSettingsKeys.slowIngredients] ?: false,
         useV2PizzaSchema = this[DebugSettingsKeys.useV2PizzaSchema] ?: false,
         skipAuthDepInTools = this[DebugSettingsKeys.skipAuthDepInTools] ?: false,
+        disableDiskBuffering = this[DebugSettingsKeys.disableDiskBuffering] ?: false,
     )
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/RuntimeConfig.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/RuntimeConfig.kt
@@ -1,0 +1,52 @@
+package com.grafana.quickpizza.core.config
+
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Immutable snapshot of the URLs and credentials the app was bootstrapped with.
+ *
+ * This is intentionally *not* reactive: these are the values [OTelService]
+ * initialized with and that [ApiClient] is using. Changing a saved override in
+ * [DebugSettings] will NOT change these values — the user must restart the app
+ * for the override to take effect.
+ *
+ * Why: keeping backend + collector + auth stable per session makes correlated
+ * traces/logs/metrics much easier to reason about when demoing.
+ */
+data class RuntimeConfig(
+    val backendBaseUrl: String,
+    val otlpEndpoint: String,
+    val otlpInstanceId: String,
+    val otlpApiKey: String,
+    val otlpAuthHeader: String?,
+)
+
+/**
+ * Resolves and holds the [RuntimeConfig] snapshot for the lifetime of the
+ * process. Built lazily on first access (which happens during
+ * [com.grafana.quickpizza.QuickPizzaApp.onCreate]).
+ */
+@Singleton
+class RuntimeConfigHolder @Inject constructor(
+    private val appConfig: AppConfig,
+    private val debugSettings: DebugSettingsRepository,
+) {
+    val current: RuntimeConfig by lazy {
+        // Read overrides synchronously at bootstrap. DataStore is async by
+        // design but the alternative — making OTelService.initialize() suspend —
+        // would require restructuring Application.onCreate. A one-shot blocking
+        // read at bootstrap is the conventional escape hatch.
+        val saved = runBlocking { debugSettings.snapshot() }
+        val instanceId = saved.otlpInstanceIdOverride ?: appConfig.otlpInstanceId
+        val apiKey = saved.otlpApiKeyOverride ?: appConfig.otlpApiKey
+        RuntimeConfig(
+            backendBaseUrl = saved.backendUrlOverride ?: appConfig.baseUrl,
+            otlpEndpoint = saved.otlpEndpointOverride ?: appConfig.otlpEndpoint,
+            otlpInstanceId = instanceId,
+            otlpApiKey = apiKey,
+            otlpAuthHeader = buildOtlpAuthHeader(instanceId, apiKey),
+        )
+    }
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/RuntimeConfig.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/RuntimeConfig.kt
@@ -21,6 +21,13 @@ data class RuntimeConfig(
     val otlpInstanceId: String,
     val otlpApiKey: String,
     val otlpAuthHeader: String?,
+    /**
+     * Whether the OTel-Android SDK was initialized with on-device disk buffering.
+     * Default `true` matches SDK behaviour (writes to disk first, ~30–45s latency).
+     * `false` makes the SDK export over OTLP directly (~1–6s latency) — controlled
+     * by the `Disable disk buffering` debug toggle.
+     */
+    val diskBufferingEnabled: Boolean,
 )
 
 /**
@@ -47,6 +54,7 @@ class RuntimeConfigHolder @Inject constructor(
             otlpInstanceId = instanceId,
             otlpApiKey = apiKey,
             otlpAuthHeader = buildOtlpAuthHeader(instanceId, apiKey),
+            diskBufferingEnabled = !saved.disableDiskBuffering,
         )
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/AppEvents.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/AppEvents.kt
@@ -1,0 +1,43 @@
+package com.grafana.quickpizza.core.o11y
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.logs.Logger
+import io.opentelemetry.api.logs.LoggerProvider
+import io.opentelemetry.api.logs.Severity
+
+/**
+ * Emit application-defined events (e.g. `pizza.requested`, `debug.test_event`).
+ *
+ * Follows the OpenTelemetry "Semantic conventions for events"
+ * (https://opentelemetry.io/docs/specs/semconv/general/events/):
+ *
+ *  - An event is a `LogRecord` whose top-level `EventName` field uniquely
+ *    identifies the event type. We set it via `LogRecordBuilder.setEventName`.
+ *    The previously-used `event.name` attribute is deprecated in favor of this
+ *    top-level field.
+ *  - Event names follow the OTel naming guidelines
+ *    (https://opentelemetry.io/docs/specs/semconv/general/naming/) — lowercase,
+ *    dot-separated, namespaced as `<namespace>.<event>`
+ *    (e.g. `pizza.requested`, `auth.logged_in`, `debug.test_event`).
+ *  - Context goes in attributes.
+ *  - Severity number is set (defaults to INFO).
+ *  - Body is intentionally left empty: per spec it should only carry a
+ *    human-readable display message, which we don't have for these events.
+ */
+interface AppEvents {
+    fun trackEvent(name: String, attributes: Map<String, String> = emptyMap())
+}
+
+class OtelEvents(loggerProvider: LoggerProvider) : AppEvents {
+    private val logger: Logger = loggerProvider
+        .loggerBuilder(OTelService.INSTRUMENTATION_SCOPE)
+        .build()
+
+    override fun trackEvent(name: String, attributes: Map<String, String>) {
+        val builder = logger.logRecordBuilder()
+            .setEventName(name)
+            .setSeverity(Severity.INFO)
+        attributes.forEach { (k, v) -> builder.setAttribute(AttributeKey.stringKey(k), v) }
+        builder.emit()
+    }
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/AppLogger.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/AppLogger.kt
@@ -1,6 +1,7 @@
 package com.grafana.quickpizza.core.o11y
 
 import android.util.Log
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.logs.LoggerProvider
 import io.opentelemetry.api.logs.Severity
@@ -9,11 +10,29 @@ import io.opentelemetry.api.logs.Severity
 // Protocol
 // ---------------------------------------------------------------------------
 
+/**
+ * Application logging facade.
+ *
+ * Two distinct error-level entry points:
+ *
+ *  - [error] — a "soft" application error with no `Throwable` involved.
+ *    Emitted as a plain ERROR-severity `LogRecord`. Intended to surface in
+ *    a logs view, but NOT to count toward exception/crash dashboards.
+ *  - [exception] — a caught `Throwable`. Emitted per the OpenTelemetry stable
+ *    "Semantic conventions for exceptions in logs"
+ *    (https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-logs/)
+ *    with `exception.type`, `exception.message`, `exception.stacktrace`
+ *    attributes. Also sets the top-level `EventName` to `"exception"` so
+ *    backends can filter exception/crash records on a single field.
+ *
+ * If you caught a `Throwable`, prefer [exception]. Use [error] only when no
+ * throwable is involved.
+ */
 interface AppLogger {
     fun debug(message: String, attributes: Map<String, String> = emptyMap())
     fun info(message: String, attributes: Map<String, String> = emptyMap())
     fun warning(message: String, attributes: Map<String, String> = emptyMap())
-    fun error(message: String, error: Throwable? = null, attributes: Map<String, String> = emptyMap())
+    fun error(message: String, attributes: Map<String, String> = emptyMap())
     fun exception(message: String, error: Throwable, attributes: Map<String, String> = emptyMap())
 }
 
@@ -31,8 +50,8 @@ class CompositeLogger(private val loggers: List<AppLogger>) : AppLogger {
     override fun warning(message: String, attributes: Map<String, String>) =
         loggers.forEach { it.warning(message, attributes) }
 
-    override fun error(message: String, error: Throwable?, attributes: Map<String, String>) =
-        loggers.forEach { it.error(message, error, attributes) }
+    override fun error(message: String, attributes: Map<String, String>) =
+        loggers.forEach { it.error(message, attributes) }
 
     override fun exception(message: String, error: Throwable, attributes: Map<String, String>) =
         loggers.forEach { it.exception(message, error, attributes) }
@@ -55,8 +74,8 @@ class LogcatLogger(private val tag: String = "QuickPizza") : AppLogger {
         Log.w(tag, message)
     }
 
-    override fun error(message: String, error: Throwable?, attributes: Map<String, String>) {
-        Log.e(tag, message, error)
+    override fun error(message: String, attributes: Map<String, String>) {
+        Log.e(tag, message)
     }
 
     override fun exception(message: String, error: Throwable, attributes: Map<String, String>) {
@@ -85,14 +104,8 @@ class OtelLogger(loggerProvider: LoggerProvider) : AppLogger {
         emit(message, Severity.WARN, attributes)
     }
 
-    override fun error(message: String, error: Throwable?, attributes: Map<String, String>) {
-        val attrs = attributes.toMutableMap()
-        if (error != null) {
-            attrs["error.type"] = error.javaClass.name
-            attrs["error.message"] = error.message ?: ""
-        }
-        val fullMessage = if (error != null) "$message: ${error.message}" else message
-        emit(fullMessage, Severity.ERROR, attrs)
+    override fun error(message: String, attributes: Map<String, String>) {
+        emit(message, Severity.ERROR, attributes)
     }
 
     override fun exception(message: String, error: Throwable, attributes: Map<String, String>) {
@@ -100,25 +113,24 @@ class OtelLogger(loggerProvider: LoggerProvider) : AppLogger {
             put("exception.type", error.javaClass.name)
             put("exception.message", error.message ?: "")
             put("exception.stacktrace", error.stackTraceToString())
-            put("error.type", error.javaClass.name)
         }
-        emit(message, Severity.ERROR, attrs, eventName = "exception")
+        val builder = logger.logRecordBuilder()
+            .setEventName("exception")
+            .setBody(message)
+            .setSeverity(Severity.ERROR)
+        attrs.forEach { (k, v) -> builder.setAttribute(AttributeKey.stringKey(k), v) }
+        builder.emit()
     }
 
     private fun emit(
         message: String,
         severity: Severity,
         attributes: Map<String, String>,
-        eventName: String? = null,
     ) {
         val builder = logger.logRecordBuilder()
             .setBody(message)
             .setSeverity(severity)
-        attributes.forEach { (k, v) -> builder.setAttribute(io.opentelemetry.api.common.AttributeKey.stringKey(k), v) }
-        builder.setAttribute(io.opentelemetry.api.common.AttributeKey.stringKey("level"), severity.name.lowercase())
-        if (eventName != null) {
-            builder.setAttribute(io.opentelemetry.api.common.AttributeKey.stringKey("event.name"), eventName)
-        }
+        attributes.forEach { (k, v) -> builder.setAttribute(AttributeKey.stringKey(k), v) }
         builder.emit()
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
@@ -26,6 +26,7 @@ class OTelService @Inject constructor(
         val snapshot = runtimeConfig.current
         val endpoint = snapshot.otlpEndpoint
         val authHeader = snapshot.otlpAuthHeader
+        val diskBufferingEnabled = snapshot.diskBufferingEnabled
 
         if (endpoint.isEmpty()) {
             Log.w(TAG, "OTLP endpoint not configured — running with noop telemetry")
@@ -40,6 +41,11 @@ class OTelService @Inject constructor(
                         baseHeaders = mapOf("Authorization" to authHeader)
                     }
                 }
+                // SDK default is `enabled = true`. Setting it explicitly keeps
+                // intent visible and lets the debug toggle flip it off for low-latency demos.
+                diskBuffering {
+                    enabled(diskBufferingEnabled)
+                }
                 resource {
                     put(AttributeKey.stringKey("service.name"), "quickpizza-android")
                     put(AttributeKey.stringKey("service.namespace"), "quickpizza")
@@ -48,7 +54,13 @@ class OTelService @Inject constructor(
             }
         }.onFailure { Log.e(TAG, "OTelService initialization failed", it) }.getOrNull()
 
-        if (rum != null) Log.i(TAG, "OTelService initialized, exporting to $endpoint")
+        if (rum != null) {
+            Log.i(
+                TAG,
+                "OTelService initialized, exporting to $endpoint " +
+                    "(diskBuffering=$diskBufferingEnabled)",
+            )
+        }
     }
 
     fun getTracer(instrumentationScope: String = INSTRUMENTATION_SCOPE) =

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
@@ -3,6 +3,7 @@ package com.grafana.quickpizza.core.o11y
 import android.app.Application
 import android.util.Log
 import com.grafana.quickpizza.core.config.AppConfig
+import com.grafana.quickpizza.core.config.RuntimeConfigHolder
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
 import io.opentelemetry.api.OpenTelemetry
@@ -14,6 +15,7 @@ import javax.inject.Singleton
 class OTelService @Inject constructor(
     private val application: Application,
     private val appConfig: AppConfig,
+    private val runtimeConfig: RuntimeConfigHolder,
 ) {
     private var rum: OpenTelemetryRum? = null
 
@@ -21,8 +23,9 @@ class OTelService @Inject constructor(
         get() = rum?.openTelemetry ?: OpenTelemetry.noop()
 
     fun initialize() {
-        val endpoint = appConfig.otlpEndpoint
-        val authHeader = appConfig.otlpAuthHeader
+        val snapshot = runtimeConfig.current
+        val endpoint = snapshot.otlpEndpoint
+        val authHeader = snapshot.otlpAuthHeader
 
         if (endpoint.isEmpty()) {
             Log.w(TAG, "OTLP endpoint not configured — running with noop telemetry")
@@ -33,7 +36,7 @@ class OTelService @Inject constructor(
             OpenTelemetryRumInitializer.initialize(application) {
                 httpExport {
                     baseUrl = endpoint
-                    if (authHeader.isNotEmpty()) {
+                    if (authHeader != null) {
                         baseHeaders = mapOf("Authorization" to authHeader)
                     }
                 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/storage/TokenStorage.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/storage/TokenStorage.kt
@@ -1,46 +1,89 @@
 package com.grafana.quickpizza.core.storage
 
 import android.content.Context
-import android.content.SharedPreferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.grafana.quickpizza.core.config.ApplicationScope
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private data class AuthState(val token: String?, val username: String?)
+
+private object AuthKeys {
+    val token = stringPreferencesKey("auth_token")
+    val username = stringPreferencesKey("auth_username")
+}
+
+private val Context.authDataStore: DataStore<Preferences> by preferencesDataStore(name = "auth")
+
+/**
+ * Persists the user's auth token and username.
+ *
+ * Reads ([token], [username]) are synchronous — they're called on every HTTP
+ * request and cannot afford a coroutine round-trip. Backed by a hot
+ * [StateFlow] seeded at construction with a one-shot blocking DataStore read,
+ * then kept in sync via [applicationScope].
+ *
+ * Writes ([setToken], [setUsername], [clear]) are `suspend` — DataStore writes
+ * are atomic and never touch the main thread.
+ */
 @Singleton
 class TokenStorage @Inject constructor(
     @ApplicationContext private val context: Context,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) {
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+    private val dataStore: DataStore<Preferences> = context.authDataStore
 
-    var token: String?
-        get() = prefs.getString(KEY_TOKEN, null)
-        set(value) {
-            if (value == null) {
-                prefs.edit().remove(KEY_TOKEN).apply()
-            } else {
-                prefs.edit().putString(KEY_TOKEN, value).apply()
-            }
-        }
-
-    var username: String?
-        get() = prefs.getString(KEY_USERNAME, null)
-        set(value) {
-            if (value == null) {
-                prefs.edit().remove(KEY_USERNAME).apply()
-            } else {
-                prefs.edit().putString(KEY_USERNAME, value).apply()
-            }
-        }
-
-    fun clear() {
-        token = null
-        username = null
+    private val flow = dataStore.data.map { prefs ->
+        AuthState(token = prefs[AuthKeys.token], username = prefs[AuthKeys.username])
     }
 
-    companion object {
-        private const val PREFS_FILE = "quickpizza_prefs"
-        private const val KEY_TOKEN = "auth_token"
-        private const val KEY_USERNAME = "auth_username"
+    private val _state: MutableStateFlow<AuthState> = MutableStateFlow(
+        runBlocking { flow.first() },
+    )
+
+    init {
+        applicationScope.launch {
+            flow.collect { _state.value = it }
+        }
+    }
+
+    val token: String? get() = _state.value.token
+    val username: String? get() = _state.value.username
+
+    /**
+     * Hot stream of token-presence changes. Emits the current value on subscription
+     * and a new value whenever [setToken] / [clear] mutate the underlying DataStore.
+     * Consumers that need to react to login / logout should observe this rather than
+     * polling [token] on a lifecycle event.
+     */
+    val tokenFlow: Flow<String?> = _state.map { it.token }.distinctUntilChanged()
+
+    suspend fun setToken(value: String?) = updateString(AuthKeys.token, value)
+    suspend fun setUsername(value: String?) = updateString(AuthKeys.username, value)
+
+    suspend fun clear() {
+        dataStore.edit { prefs ->
+            prefs.remove(AuthKeys.token)
+            prefs.remove(AuthKeys.username)
+        }
+    }
+
+    private suspend fun updateString(key: Preferences.Key<String>, value: String?) {
+        dataStore.edit { prefs ->
+            if (value == null) prefs.remove(key) else prefs[key] = value
+        }
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/di/AppModule.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/di/AppModule.kt
@@ -2,12 +2,16 @@ package com.grafana.quickpizza.di
 
 import com.grafana.quickpizza.core.api.ApiClient
 import com.grafana.quickpizza.core.api.buildBaseOkHttpClient
-import com.grafana.quickpizza.core.config.AppConfig
+import com.grafana.quickpizza.core.config.ApplicationScope
+import com.grafana.quickpizza.core.config.DebugSettingsRepository
+import com.grafana.quickpizza.core.config.RuntimeConfigHolder
+import com.grafana.quickpizza.core.o11y.AppEvents
 import com.grafana.quickpizza.core.o11y.AppLogger
 import com.grafana.quickpizza.core.o11y.AppTracer
 import com.grafana.quickpizza.core.o11y.CompositeLogger
 import com.grafana.quickpizza.core.o11y.LogcatLogger
 import com.grafana.quickpizza.core.o11y.OTelService
+import com.grafana.quickpizza.core.o11y.OtelEvents
 import com.grafana.quickpizza.core.o11y.OtelLogger
 import com.grafana.quickpizza.core.o11y.OtelTracer
 import com.grafana.quickpizza.core.storage.TokenStorage
@@ -16,12 +20,19 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTelemetry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import okhttp3.Call
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
+
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob())
 
     @Provides
     @Singleton
@@ -32,12 +43,14 @@ object AppModule {
     @Singleton
     fun provideApiClient(
         callFactory: Call.Factory,
-        appConfig: AppConfig,
+        runtimeConfig: RuntimeConfigHolder,
+        debugSettings: DebugSettingsRepository,
         tokenStorage: TokenStorage,
     ): ApiClient = ApiClient(
         callFactory = callFactory,
-        baseUrlProvider = { appConfig.baseUrl },
+        baseUrlProvider = { runtimeConfig.current.backendBaseUrl },
         tokenProvider = { tokenStorage.token },
+        errorHeadersProvider = { debugSettings.current.errorInjectionHeaders },
     )
 
     @Provides
@@ -53,4 +66,9 @@ object AppModule {
     @Singleton
     fun provideAppTracer(otelService: OTelService): AppTracer =
         OtelTracer(otelService.getTracer())
+
+    @Provides
+    @Singleton
+    fun provideAppEvents(otelService: OTelService): AppEvents =
+        OtelEvents(otelService.getLoggerProvider())
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/domain/AuthRepository.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/domain/AuthRepository.kt
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName
 import com.grafana.quickpizza.core.api.ApiClient
 import com.grafana.quickpizza.core.storage.TokenStorage
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,6 +22,14 @@ class AuthRepository @Inject constructor(
     val username: String?
         get() = tokenStorage.username
 
+    /**
+     * Hot stream of authentication state. Emits the current value on subscription
+     * and a new value whenever the token is set or cleared. Consumers should prefer
+     * this over the synchronous [isAuthenticated] getter when they need to react to
+     * login / logout transitions.
+     */
+    val isAuthenticatedFlow: Flow<Boolean> = tokenStorage.tokenFlow.map { it != null }
+
     suspend fun login(username: String, password: String) = withContext(Dispatchers.IO) {
         val response = apiClient.post(
             "/api/users/token/login",
@@ -31,11 +41,11 @@ class AuthRepository @Inject constructor(
         }
         val body = response.body?.string() ?: error("Empty response body")
         val loginResponse = Gson().fromJson(body, LoginResponse::class.java)
-        tokenStorage.token = loginResponse.token
-        tokenStorage.username = username
+        tokenStorage.setToken(loginResponse.token)
+        tokenStorage.setUsername(username)
     }
 
-    fun logout() {
+    suspend fun logout() {
         tokenStorage.clear()
     }
 

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/presentation/LoginScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/presentation/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.grafana.quickpizza.features.auth.presentation
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,10 +19,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -46,6 +48,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -69,7 +72,7 @@ fun LoginScreen(
                 title = { Text("Login") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = WarmCream),
@@ -206,32 +209,72 @@ fun LoginScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Hint box
-            Card(
+            HintCard(
+                icon = Icons.Default.Info,
+                tint = Color(0xFF1976D2),
+                container = Color(0xFFE3F2FD),
+                text = "Hint: Use \"default\" / \"12345678\" to login",
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            HintCard(
+                icon = Icons.Default.Star,
+                tint = Color(0xFF8D6E00),
+                container = Color(0xFFFFF8E1),
+                border = BorderStroke(1.dp, Color(0xFFFFE082)),
+                text = "To clear ratings, use \"studio-user\" / \"k6studiorocks\" " +
+                    "(the default user cannot delete ratings).",
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Plain centered tip — no card, matches the Flutter loginTip styling.
+            Text(
+                text = "Tip: You can create a new user via the POST " +
+                    "http://quickpizza.grafana.com/api/users endpoint. " +
+                    "Attach a JSON payload with username and password keys.",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFF9E9E9E),
+                textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(containerColor = Color(0xFFE3F2FD)),
-                shape = RoundedCornerShape(12.dp),
-            ) {
-                Row(
-                    modifier = Modifier.padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Info,
-                        contentDescription = null,
-                        tint = Color(0xFF1976D2),
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Text(
-                        text = "Hint: Use \"default\" / \"12345678\" to login",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Color(0xFF1976D2),
-                        modifier = Modifier.padding(start = 8.dp),
-                    )
-                }
-            }
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun HintCard(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    tint: Color,
+    container: Color,
+    text: String,
+    border: BorderStroke? = null,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = container),
+        shape = RoundedCornerShape(12.dp),
+        border = border,
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(18.dp),
+            )
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodySmall,
+                color = tint,
+                modifier = Modifier.padding(start = 8.dp),
+            )
         }
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/presentation/LoginViewModel.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/presentation/LoginViewModel.kt
@@ -51,7 +51,7 @@ class LoginViewModel @Inject constructor(
                 logger.info("User logged in", mapOf("username" to username))
                 onSuccess()
             } catch (e: Exception) {
-                logger.error("Login failed", e)
+                logger.exception("Login failed", e)
                 _state.update { it.copy(errorMessage = e.message ?: "Login failed") }
             } finally {
                 _state.update { it.copy(isLoading = false) }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/ConfigScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/ConfigScreen.kt
@@ -1,0 +1,297 @@
+package com.grafana.quickpizza.features.debug
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConfigScreen(
+    onBack: () -> Unit,
+    viewModel: ConfigViewModel = hiltViewModel(),
+) {
+    val ui by viewModel.state.collectAsState()
+
+    // Seed editable fields once from the persisted overrides. We don't
+    // reactively re-bind on every state change — that would clobber
+    // in-progress typing.
+    var backendField by rememberSaveable { mutableStateOf(ui.savedBackendOverride.orEmpty()) }
+    var otlpField by rememberSaveable { mutableStateOf(ui.savedOtlpOverride.orEmpty()) }
+    var instanceIdField by rememberSaveable { mutableStateOf(ui.savedOtlpInstanceIdOverride.orEmpty()) }
+    var apiKeyField by rememberSaveable { mutableStateOf(ui.savedOtlpApiKeyOverride.orEmpty()) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("Config") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            RestartRequiredBanner(ui.restartBanner)
+
+            Text(
+                "Override the URLs and OTLP credentials used by this app. Changes only take effect " +
+                    "after you kill and restart the app — this keeps traces, logs and metrics " +
+                    "correlated within a single session.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            ConfigField(
+                label = "Backend URL",
+                inUseValue = ui.backendInUse,
+                defaultValue = ui.defaultBackend,
+                hintText = "http://192.168.1.100:3333",
+                value = backendField,
+                onValueChange = { backendField = it },
+                keyboardType = KeyboardType.Uri,
+            )
+
+            ConfigField(
+                label = "OTLP endpoint",
+                inUseValue = ui.otlpInUse,
+                defaultValue = ui.defaultOtlp,
+                hintText = "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp",
+                value = otlpField,
+                onValueChange = { otlpField = it },
+                keyboardType = KeyboardType.Uri,
+            )
+
+            ConfigField(
+                label = "OTLP instance ID",
+                inUseValue = ui.otlpInstanceIdInUse,
+                defaultValue = ui.defaultOtlpInstanceId,
+                hintText = "1234567",
+                value = instanceIdField,
+                onValueChange = { instanceIdField = it },
+                keyboardType = KeyboardType.Number,
+                supportingText = "Numeric ID from your Grafana Cloud OTLP Gateway integration.",
+            )
+
+            SecretField(
+                label = "OTLP API key",
+                inUseValue = ui.otlpApiKeyInUse,
+                defaultValue = ui.defaultOtlpApiKey,
+                value = apiKeyField,
+                onValueChange = { apiKeyField = it },
+                supportingText = "Combined with the instance ID to build " +
+                    "Authorization: Basic base64(instanceId:apiKey).",
+            )
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !ui.saving,
+                onClick = {
+                    viewModel.save(
+                        backendUrl = backendField,
+                        otlpEndpoint = otlpField,
+                        otlpInstanceId = instanceIdField,
+                        otlpApiKey = apiKeyField,
+                    )
+                },
+            ) {
+                if (ui.saving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text("Save")
+                }
+            }
+
+            OutlinedButton(
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !ui.saving,
+                onClick = {
+                    viewModel.clear()
+                    backendField = ""
+                    otlpField = ""
+                    instanceIdField = ""
+                    apiKeyField = ""
+                },
+            ) {
+                Text("Use defaults (clear overrides)")
+            }
+
+            ui.statusMessage?.let { StatusCard(message = it) }
+        }
+    }
+}
+
+@Composable
+private fun ConfigField(
+    label: String,
+    inUseValue: String,
+    defaultValue: String,
+    hintText: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    supportingText: String? = null,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(label, style = MaterialTheme.typography.titleSmall)
+
+            LabelledMonoLine(label = "Currently in use", value = inUseValue.ifEmpty { "(not set)" })
+            if (defaultValue != inUseValue) {
+                LabelledMonoLine(label = "Default", value = defaultValue.ifEmpty { "(not set)" })
+            }
+
+            Spacer(Modifier.height(4.dp))
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = true,
+                label = { Text("Override (empty = use default)") },
+                placeholder = { Text(hintText) },
+                keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+                supportingText = supportingText?.let { { Text(it) } },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SecretField(
+    label: String,
+    inUseValue: String,
+    defaultValue: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    supportingText: String? = null,
+) {
+    var revealed by rememberSaveable { mutableStateOf(false) }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(label, style = MaterialTheme.typography.titleSmall)
+
+            LabelledMonoLine(label = "Currently in use", value = maskSecret(inUseValue))
+            if (defaultValue != inUseValue) {
+                LabelledMonoLine(label = "Default", value = maskSecret(defaultValue))
+            }
+
+            Spacer(Modifier.height(4.dp))
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = true,
+                label = { Text("Override (empty = use default)") },
+                placeholder = { Text("glc_xxxxxxxxxxxx") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                visualTransformation = if (revealed) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = {
+                    IconButton(onClick = { revealed = !revealed }) {
+                        Icon(
+                            imageVector = if (revealed) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            contentDescription = if (revealed) "Hide API key" else "Show API key",
+                        )
+                    }
+                },
+                supportingText = supportingText?.let { { Text(it) } },
+            )
+        }
+    }
+}
+
+private fun maskSecret(value: String): String {
+    if (value.isEmpty()) return "(not set)"
+    // For very short values, don't reveal anything — just bullets.
+    if (value.length <= 8) return "•".repeat(value.length.coerceAtLeast(4))
+    val head = value.take(4)
+    val tail = value.takeLast(4)
+    val middleBullets = (value.length - 8).coerceAtMost(8)
+    return head + "•".repeat(middleBullets) + tail
+}
+
+@Composable
+private fun LabelledMonoLine(label: String, value: String) {
+    Column {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+        )
+    }
+}
+
+@Composable
+private fun StatusCard(message: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = SuccessContainerCfg),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = SuccessOnContainerCfg)
+            Box(Modifier.weight(1f)) { Text(message, color = SuccessOnContainerCfg) }
+        }
+    }
+}
+
+private val SuccessContainerCfg = Color(0xFFE8F5E9)
+private val SuccessOnContainerCfg = Color(0xFF1B5E20)

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/ConfigViewModel.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/ConfigViewModel.kt
@@ -1,0 +1,117 @@
+package com.grafana.quickpizza.features.debug
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.grafana.quickpizza.core.config.AppConfig
+import com.grafana.quickpizza.core.config.DebugSettings
+import com.grafana.quickpizza.core.config.DebugSettingsRepository
+import com.grafana.quickpizza.core.config.RuntimeConfigHolder
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class ConfigUiState(
+    val backendInUse: String,
+    val otlpInUse: String,
+    val otlpInstanceIdInUse: String,
+    val otlpApiKeyInUse: String,
+    val defaultBackend: String,
+    val defaultOtlp: String,
+    val defaultOtlpInstanceId: String,
+    val defaultOtlpApiKey: String,
+    val savedBackendOverride: String?,
+    val savedOtlpOverride: String?,
+    val savedOtlpInstanceIdOverride: String?,
+    val savedOtlpApiKeyOverride: String?,
+    val saving: Boolean = false,
+    val statusMessage: String? = null,
+    val restartBanner: RestartBannerState = RestartBannerState.Hidden,
+)
+
+@HiltViewModel
+class ConfigViewModel @Inject constructor(
+    private val debugSettings: DebugSettingsRepository,
+    private val runtimeConfig: RuntimeConfigHolder,
+    private val appConfig: AppConfig,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(buildState(debugSettings.current))
+    val state: StateFlow<ConfigUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            debugSettings.state.collect { settings ->
+                _state.update { current ->
+                    buildState(settings).copy(
+                        saving = current.saving,
+                        statusMessage = current.statusMessage,
+                    )
+                }
+            }
+        }
+    }
+
+    fun save(
+        backendUrl: String,
+        otlpEndpoint: String,
+        otlpInstanceId: String,
+        otlpApiKey: String,
+    ) {
+        viewModelScope.launch {
+            _state.update { it.copy(saving = true, statusMessage = null) }
+            debugSettings.saveConfigOverrides(
+                backendUrl = backendUrl.ifBlank { null },
+                otlpEndpoint = otlpEndpoint.ifBlank { null },
+                otlpInstanceId = otlpInstanceId.ifBlank { null },
+                otlpApiKey = otlpApiKey.ifBlank { null },
+            )
+            _state.update {
+                it.copy(
+                    saving = false,
+                    statusMessage = "Saved. Kill and relaunch the app for changes to take effect.",
+                )
+            }
+        }
+    }
+
+    fun clear() {
+        viewModelScope.launch {
+            _state.update { it.copy(saving = true, statusMessage = null) }
+            debugSettings.saveConfigOverrides(
+                backendUrl = null,
+                otlpEndpoint = null,
+                otlpInstanceId = null,
+                otlpApiKey = null,
+            )
+            _state.update {
+                it.copy(
+                    saving = false,
+                    statusMessage = "Overrides cleared. Kill and relaunch to use defaults.",
+                )
+            }
+        }
+    }
+
+    private fun buildState(settings: DebugSettings): ConfigUiState {
+        val current = runtimeConfig.current
+        return ConfigUiState(
+            backendInUse = current.backendBaseUrl,
+            otlpInUse = current.otlpEndpoint,
+            otlpInstanceIdInUse = current.otlpInstanceId,
+            otlpApiKeyInUse = current.otlpApiKey,
+            defaultBackend = appConfig.baseUrl,
+            defaultOtlp = appConfig.otlpEndpoint,
+            defaultOtlpInstanceId = appConfig.otlpInstanceId,
+            defaultOtlpApiKey = appConfig.otlpApiKey,
+            savedBackendOverride = settings.backendUrlOverride,
+            savedOtlpOverride = settings.otlpEndpointOverride,
+            savedOtlpInstanceIdOverride = settings.otlpInstanceIdOverride,
+            savedOtlpApiKeyOverride = settings.otlpApiKeyOverride,
+            restartBanner = computeRestartBanner(settings, current),
+        )
+    }
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
@@ -2,124 +2,417 @@ package com.grafana.quickpizza.features.debug
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.grafana.quickpizza.core.config.DebugSettings
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DebugScreen(viewModel: DebugViewModel = hiltViewModel()) {
+fun DebugScreen(
+    onNavigateToConfig: () -> Unit,
+    viewModel: DebugViewModel = hiltViewModel(),
+) {
+    val ui by viewModel.state.collectAsState()
+
+    // Auto-clear the transient action message after 3s — same UX as the Flutter app.
+    LaunchedEffect(ui.lastActionMessage) {
+        if (ui.lastActionMessage != null) {
+            delay(3000)
+            viewModel.clearLastAction()
+        }
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
-        TopAppBar(title = { Text("Debug") })
+        TopAppBar(
+            title = { Text("Debug") },
+            actions = {
+                if (ui.settings.hasActiveOverrides) {
+                    TextButton(onClick = viewModel::resetAll) {
+                        Text("Reset All")
+                    }
+                }
+            },
+        )
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            RestartRequiredBanner(ui.restartBanner)
+
+            ConfigEntryCard(onClick = onNavigateToConfig)
+
             Text(
-                text = "Use these tools to test observability instrumentation.",
+                "Use these tools to simulate issues and exercise the observability " +
+                    "instrumentation during demos.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
-            // Log test exception
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text("Exception Logging", style = MaterialTheme.typography.titleSmall)
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        "Emits an exception log record via the OTel Logger. " +
-                            "Includes exception.type, exception.message, and exception.stacktrace attributes.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = viewModel::logTestException,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text("Log Test Exception")
-                    }
-                }
-            }
+            ErrorSimulationSection(settings = ui.settings, viewModel = viewModel)
 
-            // Trigger ANR
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(
-                        "ANR",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        "Blocks the main thread for 6 seconds, exceeding Android's 5s ANR threshold. " +
-                            "The system will show an ANR dialog and report it.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = viewModel::triggerAnr,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error,
-                        ),
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text("Trigger ANR")
-                    }
-                }
-            }
+            ClientDiagnosticsSection(viewModel = viewModel)
 
-            // Trigger crash
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(
-                        "Crash Reporting",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        "Triggers an unhandled exception. The OTel crash reporter will capture it " +
-                            "and send a crash log record before the app terminates.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = viewModel::triggerCrash,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error,
-                        ),
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text("Trigger Crash")
-                    }
-                }
+            ui.lastActionMessage?.let { LastActionCard(message = it) }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ConfigEntryCard(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Default.Settings, contentDescription = null)
+            Spacer(Modifier.width(16.dp))
+            Column(Modifier.weight(1f)) {
+                Text("Config", style = MaterialTheme.typography.titleSmall)
+                Text(
+                    "Change backend URL, OTLP endpoint, and OTLP credentials (requires restart)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "Open config",
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorSimulationSection(settings: DebugSettings, viewModel: DebugViewModel) {
+    SectionHeader("Error Simulation")
+    Text(
+        "Toggle these to simulate backend issues, client-side faults, and version drift. " +
+            "Takes effect immediately — no restart needed.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            ToggleRow(
+                title = "Slow Recommendations",
+                subtitle = "Adds delay to pizza recommendations",
+                checked = settings.slowRecommendations,
+                onCheckedChange = viewModel::setSlowRecommendations,
+            )
+            HorizontalDivider()
+            ToggleRow(
+                title = "Slow Ingredients",
+                subtitle = "Adds delay to ingredient loading",
+                checked = settings.slowIngredients,
+                onCheckedChange = viewModel::setSlowIngredients,
+            )
+            HorizontalDivider()
+            ToggleRow(
+                title = "Error on Recommendations",
+                subtitle = "Forces server errors on recommendations",
+                checked = settings.errorOnRecommendations,
+                onCheckedChange = viewModel::setErrorOnRecommendations,
+            )
+            HorizontalDivider()
+            ToggleRow(
+                title = "Error on Ingredients",
+                subtitle = "Forces server errors on ingredient loading",
+                checked = settings.errorOnIngredients,
+                onCheckedChange = viewModel::setErrorOnIngredients,
+            )
+            HorizontalDivider()
+            ToggleRow(
+                title = "Use v2 pizza response schema",
+                subtitle = "Experimental — simulates a client/backend schema drift",
+                checked = settings.useV2PizzaSchema,
+                onCheckedChange = viewModel::setUseV2PizzaSchema,
+            )
+            HorizontalDivider()
+            ToggleRow(
+                title = "Skip auth dep in tools provider",
+                subtitle = "Tools list won't refresh on login/logout — reproduces the bug",
+                checked = settings.skipAuthDepInTools,
+                onCheckedChange = viewModel::setSkipAuthDepInTools,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ClientDiagnosticsSection(viewModel: DebugViewModel) {
+    SectionHeader("Client Diagnostics")
+
+    QuickSignalsCard(viewModel)
+
+    DiagnosticActionCard(
+        title = "Handled Exception",
+        description = "Throws an exception inside a try/catch and reports it via the OTel logger as " +
+            "an exception log record. Tests the manual reporting path.",
+        buttonText = "Send Handled Exception",
+        onClick = viewModel::logTestException,
+    )
+
+    DiagnosticActionCard(
+        title = "ANR",
+        description = "Blocks the main thread for 6 seconds, exceeding Android's 5s ANR threshold. " +
+            "The system shows an ANR dialog and the OTel agent reports it.",
+        buttonText = "Trigger ANR",
+        danger = true,
+        onClick = viewModel::triggerAnr,
+    )
+
+    CrashCard(viewModel)
+}
+
+@Composable
+private fun QuickSignalsCard(viewModel: DebugViewModel) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Quick Signals", style = MaterialTheme.typography.titleSmall)
+            Text(
+                "Emit one-off signals (logs and custom events) to verify the OTel pipeline end-to-end.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(4.dp))
+            Button(modifier = Modifier.fillMaxWidth(), onClick = viewModel::sendDebugLog) {
+                Text("Send Debug Log")
+            }
+            Button(modifier = Modifier.fillMaxWidth(), onClick = viewModel::sendErrorLog) {
+                Text("Send Error Log")
+            }
+            Button(modifier = Modifier.fillMaxWidth(), onClick = viewModel::sendCustomEvent) {
+                Text("Send Custom Event")
             }
         }
     }
 }
+
+@Composable
+private fun CrashCard(viewModel: DebugViewModel) {
+    var pending by rememberSaveable { mutableStateOf<CrashKind?>(null) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                "Crash Reporting",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Text(
+                "Throws an unhandled exception. The OTel-Android agent's CrashReporter persists " +
+                    "the crash to disk and the exporter delivers it on the next app launch — the OS " +
+                    "terminates the app immediately.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { pending = CrashKind.RuntimeException },
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+            ) {
+                Text("Crash (RuntimeException)")
+            }
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { pending = CrashKind.NullPointer },
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+            ) {
+                Text("Crash (NPE)")
+            }
+        }
+    }
+
+    pending?.let { kind ->
+        AlertDialog(
+            onDismissRequest = { pending = null },
+            title = { Text(kind.dialogTitle) },
+            text = { Text(kind.dialogBody) },
+            confirmButton = {
+                TextButton(onClick = {
+                    pending = null
+                    when (kind) {
+                        CrashKind.RuntimeException -> viewModel.triggerCrashRuntimeException()
+                        CrashKind.NullPointer -> viewModel.triggerCrashNullPointer()
+                    }
+                }) { Text("Crash now", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pending = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+private enum class CrashKind(val dialogTitle: String, val dialogBody: String) {
+    RuntimeException(
+        dialogTitle = "Trigger crash?",
+        dialogBody = "The app will terminate. Relaunch it to see the crash report in your o11y backend.",
+    ),
+    NullPointer(
+        dialogTitle = "Trigger simulated NPE?",
+        dialogBody = "Simulates a real-world null-dereference bug. The app will terminate. Relaunch " +
+            "it to see the crash report in your o11y backend.",
+    ),
+}
+
+// ---------------------------------------------------------------------------
+// Reusable building blocks
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+    )
+}
+
+@Composable
+private fun ToggleRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun DiagnosticActionCard(
+    title: String,
+    description: String,
+    buttonText: String,
+    onClick: () -> Unit,
+    danger: Boolean = false,
+) {
+    // For non-danger cards, fall through to the default Card colors so the
+    // surface tint matches the other cards on the screen (Quick Signals etc).
+    // Overriding to MaterialTheme.colorScheme.surface here would make the card
+    // blend into the screen background and look like it has no container.
+    val cardColors = if (danger) {
+        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+    } else {
+        CardDefaults.cardColors()
+    }
+    val titleColor = if (danger) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onSurface
+    val bodyColor = titleColor.copy(alpha = 0.85f)
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = cardColors,
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(title, style = MaterialTheme.typography.titleSmall, color = titleColor)
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = bodyColor,
+            )
+            Spacer(Modifier.height(4.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onClick,
+                colors = if (danger) {
+                    ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                } else {
+                    ButtonDefaults.buttonColors()
+                },
+            ) {
+                Text(buttonText)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LastActionCard(message: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = SuccessContainer),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = SuccessOnContainer)
+            Text(message, color = SuccessOnContainer)
+        }
+    }
+}
+
+private val SuccessContainer = Color(0xFFE8F5E9)
+private val SuccessOnContainer = Color(0xFF1B5E20)

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
@@ -94,6 +94,8 @@ fun DebugScreen(
 
             ClientDiagnosticsSection(viewModel = viewModel)
 
+            OTelSdkSection(settings = ui.settings, viewModel = viewModel)
+
             ui.lastActionMessage?.let { LastActionCard(message = it) }
         }
     }
@@ -131,6 +133,29 @@ private fun ConfigEntryCard(onClick: () -> Unit) {
                 contentDescription = "Open config",
             )
         }
+    }
+}
+
+@Composable
+private fun OTelSdkSection(settings: DebugSettings, viewModel: DebugViewModel) {
+    SectionHeader("OpenTelemetry SDK")
+    Text(
+        "Tunes the OTel-Android SDK behavior. Read once at app startup — toggling " +
+            "requires a restart for the new value to take effect.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        // Switch UX is "ON = active override". Disk buffering is enabled by default
+        // in the SDK; flipping this ON disables it and trades offline resilience for
+        // ~30–45s lower end-to-end latency — useful for live demos.
+        ToggleRow(
+            title = "Disable disk buffering",
+            subtitle = "Default: off (SDK buffers to disk, ~30–45s latency). Turn on for " +
+                "near-real-time export (~1–6s) — signals are lost if the app is offline.",
+            checked = settings.disableDiskBuffering,
+            onCheckedChange = viewModel::setDisableDiskBuffering,
+        )
     }
 }
 

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugViewModel.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugViewModel.kt
@@ -42,11 +42,13 @@ fun computeRestartBanner(
     val savedOtlp = settings.otlpEndpointOverride ?: runtime.otlpEndpoint
     val savedInstanceId = settings.otlpInstanceIdOverride ?: runtime.otlpInstanceId
     val savedApiKey = settings.otlpApiKeyOverride ?: runtime.otlpApiKey
+    val savedDiskBufferingEnabled = !settings.disableDiskBuffering
     val changedFields = listOfNotNull(
         "Backend URL".takeIf { savedBackend != runtime.backendBaseUrl },
         "OTLP endpoint".takeIf { savedOtlp != runtime.otlpEndpoint },
         "OTLP instance ID".takeIf { savedInstanceId != runtime.otlpInstanceId },
         "OTLP API key".takeIf { savedApiKey != runtime.otlpApiKey },
+        "Disk buffering".takeIf { savedDiskBufferingEnabled != runtime.diskBufferingEnabled },
     )
     return if (changedFields.isEmpty()) {
         RestartBannerState.Hidden
@@ -94,6 +96,7 @@ class DebugViewModel @Inject constructor(
     fun setErrorOnIngredients(value: Boolean) = launch { debugSettings.setErrorOnIngredients(value) }
     fun setUseV2PizzaSchema(value: Boolean) = launch { debugSettings.setUseV2PizzaSchema(value) }
     fun setSkipAuthDepInTools(value: Boolean) = launch { debugSettings.setSkipAuthDepInTools(value) }
+    fun setDisableDiskBuffering(value: Boolean) = launch { debugSettings.setDisableDiskBuffering(value) }
 
     fun resetAll() = launch {
         debugSettings.resetAll()

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugViewModel.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugViewModel.kt
@@ -1,27 +1,187 @@
 package com.grafana.quickpizza.features.debug
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.grafana.quickpizza.core.config.DebugSettings
+import com.grafana.quickpizza.core.config.DebugSettingsRepository
+import com.grafana.quickpizza.core.config.RuntimeConfig
+import com.grafana.quickpizza.core.config.RuntimeConfigHolder
+import com.grafana.quickpizza.core.o11y.AppEvents
 import com.grafana.quickpizza.core.o11y.AppLogger
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private val DEBUG_TAB_CONTEXT = mapOf("debug.source" to "debug_tab")
+
+data class DebugUiState(
+    val settings: DebugSettings = DebugSettings(),
+    val restartBanner: RestartBannerState = RestartBannerState.Hidden,
+    val lastActionMessage: String? = null,
+)
+
+sealed interface RestartBannerState {
+    data object Hidden : RestartBannerState
+    data class Visible(val changedLabel: String) : RestartBannerState
+}
+
+/**
+ * Computes whether the persisted overrides differ from the URLs/credentials
+ * actually in use this session. Shared by [DebugViewModel] and
+ * [ConfigViewModel] so the banner is consistent on both screens.
+ */
+fun computeRestartBanner(
+    settings: DebugSettings,
+    runtime: RuntimeConfig,
+): RestartBannerState {
+    val savedBackend = settings.backendUrlOverride ?: runtime.backendBaseUrl
+    val savedOtlp = settings.otlpEndpointOverride ?: runtime.otlpEndpoint
+    val savedInstanceId = settings.otlpInstanceIdOverride ?: runtime.otlpInstanceId
+    val savedApiKey = settings.otlpApiKeyOverride ?: runtime.otlpApiKey
+    val changedFields = listOfNotNull(
+        "Backend URL".takeIf { savedBackend != runtime.backendBaseUrl },
+        "OTLP endpoint".takeIf { savedOtlp != runtime.otlpEndpoint },
+        "OTLP instance ID".takeIf { savedInstanceId != runtime.otlpInstanceId },
+        "OTLP API key".takeIf { savedApiKey != runtime.otlpApiKey },
+    )
+    return if (changedFields.isEmpty()) {
+        RestartBannerState.Hidden
+    } else {
+        RestartBannerState.Visible(changedFields.joinToString(", "))
+    }
+}
 
 @HiltViewModel
 class DebugViewModel @Inject constructor(
+    private val debugSettings: DebugSettingsRepository,
+    private val runtimeConfig: RuntimeConfigHolder,
     private val logger: AppLogger,
+    private val events: AppEvents,
 ) : ViewModel() {
 
-    fun logTestException() {
-        val error = RuntimeException("Test exception from Debug tab")
-        logger.exception("Test exception triggered by user", error)
+    private val _state = MutableStateFlow(
+        DebugUiState(
+            settings = debugSettings.current,
+            restartBanner = computeRestartBanner(debugSettings.current, runtimeConfig.current),
+        ),
+    )
+    val state: StateFlow<DebugUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            debugSettings.state.collect { settings ->
+                _state.update {
+                    it.copy(
+                        settings = settings,
+                        restartBanner = computeRestartBanner(settings, runtimeConfig.current),
+                    )
+                }
+            }
+        }
     }
 
-    fun triggerCrash() {
-        // This will be caught by the OTel crash reporter and generate a crash log
-        throw RuntimeException("Deliberate crash triggered from Debug tab")
+    // ---------------------------------------------------------------------
+    // Toggles (persisted)
+    // ---------------------------------------------------------------------
+
+    fun setSlowRecommendations(value: Boolean) = launch { debugSettings.setSlowRecommendations(value) }
+    fun setSlowIngredients(value: Boolean) = launch { debugSettings.setSlowIngredients(value) }
+    fun setErrorOnRecommendations(value: Boolean) = launch { debugSettings.setErrorOnRecommendations(value) }
+    fun setErrorOnIngredients(value: Boolean) = launch { debugSettings.setErrorOnIngredients(value) }
+    fun setUseV2PizzaSchema(value: Boolean) = launch { debugSettings.setUseV2PizzaSchema(value) }
+    fun setSkipAuthDepInTools(value: Boolean) = launch { debugSettings.setSkipAuthDepInTools(value) }
+
+    fun resetAll() = launch {
+        debugSettings.resetAll()
+        showAction("All debug settings reset")
+    }
+
+    // ---------------------------------------------------------------------
+    // Quick Signals
+    // ---------------------------------------------------------------------
+
+    fun sendDebugLog() {
+        logger.debug(
+            "Test debug log from Debug tab",
+            DEBUG_TAB_CONTEXT + ("debug.action" to "logger.debug"),
+        )
+        showAction("Sent debug log")
+    }
+
+    fun sendErrorLog() {
+        logger.error(
+            "Test error log from Debug tab",
+            attributes = DEBUG_TAB_CONTEXT + ("debug.action" to "logger.error"),
+        )
+        showAction("Sent error log")
+    }
+
+    fun sendCustomEvent() {
+        events.trackEvent(
+            "debug.test_event",
+            DEBUG_TAB_CONTEXT + ("debug.action" to "events.trackEvent"),
+        )
+        showAction("Sent custom event")
+    }
+
+    // ---------------------------------------------------------------------
+    // Diagnostics
+    // ---------------------------------------------------------------------
+
+    fun logTestException() {
+        try {
+            throw RuntimeException("Test exception from Debug tab")
+        } catch (e: Exception) {
+            logger.exception(
+                "Test exception triggered by user",
+                e,
+                DEBUG_TAB_CONTEXT + ("debug.action" to "logger.exception"),
+            )
+        }
+        showAction("Sent handled exception")
     }
 
     fun triggerAnr() {
-        // Block the main thread long enough to exceed Android's 5s ANR threshold
+        // Block the main thread long enough to exceed Android's 5s ANR threshold.
+        // Caller invokes from main thread; intentionally not dispatched off it.
         Thread.sleep(6000)
+    }
+
+    /**
+     * Throws an unhandled exception. The OTel-Android `CrashReporter` instrumentation
+     * catches this via `Thread.UncaughtExceptionHandler`, persists it to disk, and
+     * the exporter delivers it on the next app launch. The OS then terminates the app.
+     */
+    fun triggerCrashRuntimeException() {
+        throw RuntimeException("Deliberate crash from QuickPizza debug tab")
+    }
+
+    /**
+     * Triggers a [NullPointerException] via Kotlin's `!!` operator. Same delivery
+     * path as [triggerCrashRuntimeException] but mirrors a real-world null-deref bug.
+     */
+    fun triggerCrashNullPointer() {
+        val nothing: String? = null
+        nothing!!.length
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    fun clearLastAction() {
+        _state.update { it.copy(lastActionMessage = null) }
+    }
+
+    private fun showAction(message: String) {
+        _state.update { it.copy(lastActionMessage = message) }
+    }
+
+    private fun launch(block: suspend () -> Unit) {
+        viewModelScope.launch { block() }
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/RestartRequiredBanner.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/RestartRequiredBanner.kt
@@ -1,0 +1,59 @@
+package com.grafana.quickpizza.features.debug
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shown at the top of the Debug and Config screens whenever the saved
+ * URL overrides differ from the URLs currently in use in the session.
+ *
+ * Renders nothing when no restart is needed.
+ */
+@Composable
+fun RestartRequiredBanner(state: RestartBannerState, modifier: Modifier = Modifier) {
+    val visible = state as? RestartBannerState.Visible ?: return
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = AmberContainer),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Icon(Icons.Default.Warning, contentDescription = null, tint = AmberOnContainer)
+            Column {
+                Text(
+                    "Restart required",
+                    color = AmberOnContainer,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    "Kill and relaunch the app for the new ${visible.changedLabel} to take effect.",
+                    color = AmberOnContainer,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}
+
+private val AmberContainer = Color(0xFFFFECB3)
+private val AmberOnContainer = Color(0xFF7A4F00)

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/pizza/domain/PizzaRepository.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/pizza/domain/PizzaRepository.kt
@@ -1,9 +1,15 @@
 package com.grafana.quickpizza.features.pizza.domain
 
 import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.grafana.quickpizza.core.api.ApiClient
+import com.grafana.quickpizza.core.config.DebugSettingsRepository
+import com.grafana.quickpizza.features.pizza.models.Dough
+import com.grafana.quickpizza.features.pizza.models.Ingredient
+import com.grafana.quickpizza.features.pizza.models.Pizza
 import com.grafana.quickpizza.features.pizza.models.PizzaRecommendation
 import com.grafana.quickpizza.features.pizza.models.Restrictions
 import kotlinx.coroutines.Dispatchers
@@ -14,6 +20,7 @@ import javax.inject.Singleton
 @Singleton
 class PizzaRepository @Inject constructor(
     private val apiClient: ApiClient,
+    private val debugSettings: DebugSettingsRepository,
 ) {
     private val gson = Gson()
 
@@ -38,8 +45,46 @@ class PizzaRepository @Inject constructor(
         if (response.code == 401) return@withContext null
         if (!response.isSuccessful) error("Failed to get recommendation: HTTP ${response.code}")
         val body = response.body?.string() ?: error("Empty response body")
-        gson.fromJson(body, PizzaRecommendation::class.java)
+        if (debugSettings.current.useV2PizzaSchema) {
+            parseRecommendationV2(body)
+        } else {
+            gson.fromJson(body, PizzaRecommendation::class.java)
+        }
     }
+
+    /**
+     * Parses the upcoming v2 response schema. v2 renames `pizza.name` → `pizza.displayName`
+     * and `pizza.tool` → `pizza.tooling`. Throws if the expected v2 fields aren't present —
+     * this is intentional, the toggle exists to simulate a client that was upgraded ahead
+     * of the backend (or vice versa) so we can demo schema-drift telemetry.
+     */
+    private fun parseRecommendationV2(body: String): PizzaRecommendation {
+        val root = JsonParser.parseString(body).asJsonObject
+        val pizzaObj = root.getAsJsonObject("pizza") ?: error("v2 schema: missing 'pizza' object")
+        val pizza = Pizza(
+            id = pizzaObj.requireInt("id"),
+            name = pizzaObj.requireString("displayName"),
+            tool = pizzaObj.requireString("tooling"),
+            ingredients = pizzaObj.getAsJsonArray("ingredients")
+                ?.map { gson.fromJson(it, Ingredient::class.java) }
+                ?: emptyList(),
+            dough = pizzaObj.getAsJsonObject("dough")?.let { gson.fromJson(it, Dough::class.java) },
+        )
+        return PizzaRecommendation(
+            pizza = pizza,
+            quotation = root.get("quotation")?.takeIf { !it.isJsonNull }?.asString.orEmpty(),
+            calories = root.get("calories")?.takeIf { !it.isJsonNull }?.asInt,
+            vegetarian = root.get("vegetarian")?.takeIf { !it.isJsonNull }?.asBoolean,
+        )
+    }
+
+    private fun JsonObject.requireString(field: String): String =
+        get(field)?.takeIf { !it.isJsonNull }?.asString
+            ?: error("v2 schema: missing required string field '$field'")
+
+    private fun JsonObject.requireInt(field: String): Int =
+        get(field)?.takeIf { !it.isJsonNull }?.asInt
+            ?: error("v2 schema: missing required int field '$field'")
 
     suspend fun ratePizza(pizzaId: Int, stars: Int) = withContext(Dispatchers.IO) {
         val response = apiClient.post("/api/ratings", body = RatingRequest(pizzaId, stars))

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/pizza/presentation/HomeScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/pizza/presentation/HomeScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -32,15 +31,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import com.grafana.quickpizza.features.pizza.presentation.components.CustomizeSection
 import com.grafana.quickpizza.features.pizza.presentation.components.PizzaCard
 import com.grafana.quickpizza.features.pizza.presentation.components.RatingButtons
@@ -56,18 +52,6 @@ fun HomeScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
-
-    // Refresh auth state when returning from Login so the error clears automatically
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.refreshAuthState()
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
 
     LaunchedEffect(state.snackbarMessage) {
         state.snackbarMessage?.let {

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/pizza/presentation/HomeViewModel.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/pizza/presentation/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.grafana.quickpizza.features.pizza.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.grafana.quickpizza.core.config.DebugSettingsRepository
 import com.grafana.quickpizza.core.o11y.AppLogger
 import com.grafana.quickpizza.core.o11y.AppTracer
 import com.grafana.quickpizza.features.auth.domain.AuthRepository
@@ -9,14 +10,16 @@ import com.grafana.quickpizza.features.pizza.domain.PizzaRepository
 import com.grafana.quickpizza.features.pizza.models.PizzaRecommendation
 import com.grafana.quickpizza.features.pizza.models.Restrictions
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.async
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
 
 private const val MIN_CALORIES = 500
@@ -38,6 +41,7 @@ data class HomeUiState(
 class HomeViewModel @Inject constructor(
     private val pizzaRepository: PizzaRepository,
     private val authRepository: AuthRepository,
+    private val debugSettings: DebugSettingsRepository,
     private val logger: AppLogger,
     private val tracer: AppTracer,
 ) : ViewModel() {
@@ -46,18 +50,61 @@ class HomeViewModel @Inject constructor(
     val state: StateFlow<HomeUiState> = _state.asStateFlow()
 
     init {
-        viewModelScope.launch {
-            val isAuth = withContext(Dispatchers.IO) { authRepository.isAuthenticated }
-            _state.update { it.copy(isAuthenticated = isAuth) }
-        }
-        loadInitialData()
+        observeAuthState()
+        observeAuthForToolsRefresh()
+        loadQuote()
     }
 
-    private fun loadInitialData() {
+    /**
+     * Mirrors `_state.isAuthenticated` to the live token state. Also clears any
+     * stale "please sign in" error on a logged-out → logged-in transition.
+     */
+    private fun observeAuthState() {
         viewModelScope.launch {
-            val quoteDeferred = async { runCatching { pizzaRepository.getQuote() }.getOrDefault("") }
-            val toolsDeferred = async { runCatching { pizzaRepository.getTools() }.getOrDefault(emptyList()) }
-            _state.update { it.copy(quote = quoteDeferred.await(), availableTools = toolsDeferred.await()) }
+            authRepository.isAuthenticatedFlow.collect { isAuthed ->
+                _state.update { state ->
+                    val clearError = isAuthed &&
+                        state.errorMessage?.contains("sign in", ignoreCase = true) == true
+                    state.copy(
+                        isAuthenticated = isAuthed,
+                        errorMessage = if (clearError) null else state.errorMessage,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Refetches the available tools list whenever auth state changes — `/api/tools`
+     * requires a valid token, so a cold start while logged out leaves the list
+     * empty until we re-issue the request after login.
+     *
+     * The [DebugSettingsRepository.skipAuthDepInTools] toggle disables the auth
+     * dependency to reproduce the bug for demos.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeAuthForToolsRefresh() {
+        viewModelScope.launch {
+            debugSettings.state
+                .map { it.skipAuthDepInTools }
+                .distinctUntilChanged()
+                .flatMapLatest { skipAuth ->
+                    if (skipAuth) flowOf(Unit)
+                    else authRepository.isAuthenticatedFlow.map { }
+                }
+                .collect { refetchTools() }
+        }
+    }
+
+    private suspend fun refetchTools() {
+        val tools = runCatching { pizzaRepository.getTools() }.getOrDefault(emptyList())
+        _state.update { it.copy(availableTools = tools) }
+    }
+
+    private fun loadQuote() {
+        viewModelScope.launch {
+            val quote = runCatching { pizzaRepository.getQuote() }.getOrDefault("")
+            _state.update { it.copy(quote = quote) }
         }
     }
 
@@ -66,17 +113,31 @@ class HomeViewModel @Inject constructor(
             _state.update { it.copy(isLoading = true, errorMessage = null, ratingSubmitted = false, recommendation = null) }
             try {
                 val recommendation = tracer.withSpan("pizza.get_recommendation") { span ->
-                    span.setAttribute("vegetarian", _state.value.restrictions.mustBeVegetarian)
-                    span.setAttribute("max_calories", _state.value.restrictions.maxCaloriesPerSlice.toLong())
-                    pizzaRepository.getRecommendation(_state.value.restrictions)
+                    span.setAttribute("pizza.vegetarian", _state.value.restrictions.mustBeVegetarian)
+                    span.setAttribute("pizza.max_calories", _state.value.restrictions.maxCaloriesPerSlice.toLong())
+                    val result = pizzaRepository.getRecommendation(_state.value.restrictions)
+                    if (result != null) {
+                        span.setAttribute("pizza.id", result.pizza.id.toLong())
+                        span.setAttribute("pizza.name", result.pizza.name)
+                    }
+                    result
                 }
-                if (recommendation == null && !withContext(Dispatchers.IO) { authRepository.isAuthenticated }) {
+                if (recommendation == null && !_state.value.isAuthenticated) {
                     _state.update { it.copy(errorMessage = "Please sign in to get pizza recommendations") }
                 } else {
+                    if (recommendation != null) {
+                        logger.info(
+                            "Pizza recommendation fetched",
+                            mapOf(
+                                "pizza_id" to recommendation.pizza.id.toString(),
+                                "pizza_name" to recommendation.pizza.name,
+                            ),
+                        )
+                    }
                     _state.update { it.copy(recommendation = recommendation) }
                 }
             } catch (e: Exception) {
-                logger.error("Failed to get recommendation", e)
+                logger.exception("Failed to get recommendation", e)
                 _state.update { it.copy(errorMessage = e.message ?: "Failed to get recommendation") }
             } finally {
                 _state.update { it.copy(isLoading = false) }
@@ -89,8 +150,8 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 tracer.withSpan("pizza.rate") { span ->
-                    span.setAttribute("pizza_id", pizza.id.toLong())
-                    span.setAttribute("stars", stars.toLong())
+                    span.setAttribute("pizza.id", pizza.id.toLong())
+                    span.setAttribute("pizza.stars", stars.toLong())
                     pizzaRepository.ratePizza(pizza.id, stars)
                 }
                 _state.update { it.copy(ratingSubmitted = true) }
@@ -99,36 +160,25 @@ class HomeViewModel @Inject constructor(
                     mapOf("pizza_id" to pizza.id.toString(), "stars" to stars.toString()),
                 )
             } catch (e: Exception) {
-                logger.error("Rating failed", e)
+                logger.exception("Rating failed", e)
                 _state.update { it.copy(errorMessage = "Failed to submit rating") }
             }
         }
     }
 
-    fun refreshAuthState() {
+    fun logout(onLoggedOut: () -> Unit) {
         viewModelScope.launch {
-            val isAuth = withContext(Dispatchers.IO) { authRepository.isAuthenticated }
-            _state.update { state ->
-                state.copy(
-                    isAuthenticated = isAuth,
-                    errorMessage = if (isAuth && state.errorMessage?.contains("sign in", ignoreCase = true) == true) null
-                                   else state.errorMessage,
+            authRepository.logout()
+            // isAuthenticated is updated by observeAuthState() via the token flow.
+            _state.update {
+                it.copy(
+                    recommendation = null,
+                    errorMessage = null,
+                    ratingSubmitted = false,
                 )
             }
+            onLoggedOut()
         }
-    }
-
-    fun logout(onLoggedOut: () -> Unit) {
-        authRepository.logout()
-        _state.update {
-            it.copy(
-                isAuthenticated = false,
-                recommendation = null,
-                errorMessage = null,
-                ratingSubmitted = false,
-            )
-        }
-        onLoggedOut()
     }
 
     fun toggleExcludedTool(tool: String) {

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/profile/presentation/ProfileScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/profile/presentation/ProfileScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Favorite
@@ -79,7 +79,7 @@ fun ProfileScreen(
                 title = { Text("Profile") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = WarmCream),

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/profile/presentation/ProfileViewModel.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/profile/presentation/ProfileViewModel.kt
@@ -49,7 +49,7 @@ class ProfileViewModel @Inject constructor(
                 val ratings = ratingsRepository.getRatings()
                 _state.update { it.copy(ratings = ratings) }
             } catch (e: Exception) {
-                logger.error("Failed to load ratings", e)
+                logger.exception("Failed to load ratings", e)
                 _state.update { it.copy(errorMessage = e.message) }
             } finally {
                 _state.update { it.copy(isLoading = false) }
@@ -64,7 +64,7 @@ class ProfileViewModel @Inject constructor(
                 _state.update { it.copy(ratings = emptyList(), showRatingsClearedMessage = true) }
                 logger.info("Ratings cleared")
             } catch (e: Exception) {
-                logger.error("Failed to clear ratings", e)
+                logger.exception("Failed to clear ratings", e)
             }
         }
     }
@@ -74,8 +74,10 @@ class ProfileViewModel @Inject constructor(
     }
 
     fun signOut(onSignedOut: () -> Unit) {
-        authRepository.logout()
-        logger.info("User signed out")
-        onSignedOut()
+        viewModelScope.launch {
+            authRepository.logout()
+            logger.info("User signed out")
+            onSignedOut()
+        }
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/navigation/AppNavGraph.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/navigation/AppNavGraph.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.grafana.quickpizza.features.about.AboutScreen
 import com.grafana.quickpizza.features.auth.presentation.LoginScreen
+import com.grafana.quickpizza.features.debug.ConfigScreen
 import com.grafana.quickpizza.features.debug.DebugScreen
 import com.grafana.quickpizza.features.pizza.presentation.HomeScreen
 import com.grafana.quickpizza.features.profile.presentation.ProfileScreen
@@ -17,6 +18,7 @@ sealed class Screen(val route: String) {
     data object Profile : Screen("profile")
     data object About : Screen("about")
     data object Debug : Screen("debug")
+    data object DebugConfig : Screen("debug/config")
 }
 
 @Composable
@@ -52,7 +54,12 @@ fun AppNavGraph(
             )
         }
         composable(Screen.Debug.route) {
-            DebugScreen()
+            DebugScreen(
+                onNavigateToConfig = { navController.navigate(Screen.DebugConfig.route) },
+            )
+        }
+        composable(Screen.DebugConfig.route) {
+            ConfigScreen(onBack = { navController.popBackStack() })
         }
     }
 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/navigation/BottomNavBar.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/navigation/BottomNavBar.kt
@@ -27,7 +27,7 @@ private val bottomNavItems = listOf(
 )
 
 // Routes where the bottom bar should be hidden
-private val hiddenRoutes = setOf(Screen.Login.route, Screen.Profile.route)
+private val hiddenRoutes = setOf(Screen.Login.route, Screen.Profile.route, Screen.DebugConfig.route)
 
 @Composable
 fun BottomNavBar(navController: NavHostController) {

--- a/Mobiles/android/config.json.example
+++ b/Mobiles/android/config.json.example
@@ -2,8 +2,10 @@
   "_comment": "Copy this file to app/src/main/res/raw/config.json and fill in your values.",
   "OTLP_ENDPOINT": "",
   "_OTLP_ENDPOINT_comment": "e.g. https://otlp-gateway-prod-eu-west-0.grafana.net/otlp",
-  "OTLP_AUTH_HEADER": "",
-  "_OTLP_AUTH_HEADER_comment": "e.g. Basic <base64(instanceId:apiKey)>",
+  "OTLP_INSTANCE_ID": "",
+  "_OTLP_INSTANCE_ID_comment": "Your Grafana Cloud OTLP Gateway instance ID (numeric).",
+  "OTLP_API_KEY": "",
+  "_OTLP_API_KEY_comment": "Your Grafana Cloud access token (e.g. glc_xxxxxxxx). Combined with the instance ID, the app will compute Authorization: Basic <base64(instanceId:apiKey)>.",
   "BASE_URL": "",
   "_BASE_URL_comment": "Leave empty for emulator (uses http://10.0.2.2:3333 automatically). For physical devices, set to your machine's IP e.g. http://192.168.1.100:3333"
 }

--- a/Mobiles/android/gradle/libs.versions.toml
+++ b/Mobiles/android/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ activityCompose = "1.9.3"
 coreKtx = "1.15.0"
 lifecycle = "2.8.7"
 desugar = "2.1.4"
+datastore = "1.2.1"
 opentelemetryAndroid = "1.2.0-alpha"
 opentelemetryAndroidInstrumentation = "0.11.0-alpha"
 byteBuddy = "1.18.5"
@@ -53,6 +54,9 @@ opentelemetry-android-okhttp3-agent = { module = "io.opentelemetry.android.instr
 opentelemetry-okhttp3 = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0" }
 opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk" }
 opentelemetry-extension-kotlin = { module = "io.opentelemetry:opentelemetry-extension-kotlin" }
+
+# Persistence
+datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 # Desugaring
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }

--- a/Mobiles/docs/ANDROID_NATIVE_SETUP.md
+++ b/Mobiles/docs/ANDROID_NATIVE_SETUP.md
@@ -9,7 +9,7 @@ Setup guide for the native Android QuickPizza app (`Mobiles/android/`).
 ## Prerequisites
 
 - [Android Studio](https://developer.android.com/studio) (Hedgehog 2023.1.1+ recommended)
-- Android SDK with at least API 21 (Android 5.0 Lollipop) — the app's `minSdk`
+- Android SDK with at least API 23 (Android 6.0 Marshmallow) — the app's `minSdk`
 - A running QuickPizza backend (see root README)
 
 ---
@@ -28,7 +28,8 @@ Edit `config.json`:
 ```json
 {
   "OTLP_ENDPOINT": "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp",
-  "OTLP_AUTH_HEADER": "Basic <base64(instanceId:apiKey)>",
+  "OTLP_INSTANCE_ID": "1234567",
+  "OTLP_API_KEY": "glc_xxxxxxxxxxxx",
   "BASE_URL": ""
 }
 ```
@@ -36,8 +37,13 @@ Edit `config.json`:
 | Field | Description |
 |---|---|
 | `OTLP_ENDPOINT` | Your OTLP HTTP base URL (without `/v1/traces`). Leave empty to disable telemetry export. |
-| `OTLP_AUTH_HEADER` | Authorization header value, e.g. `Basic <base64>` or `Bearer <token>`. |
+| `OTLP_INSTANCE_ID` | Your Grafana Cloud OTLP Gateway instance ID (numeric). |
+| `OTLP_API_KEY` | Your Grafana Cloud access token (e.g. `glc_xxxxxxxx`). The app combines it with the instance ID to compute `Authorization: Basic base64(instanceId:apiKey)`. |
 | `BASE_URL` | QuickPizza backend URL. **Leave empty** to auto-detect (`http://10.0.2.2:3333` on emulator). Set to your machine's LAN IP for physical devices, e.g. `http://192.168.1.100:3333`. |
+
+> All four URL / credential fields can also be overridden at runtime from the in-app
+> **Debug → Config** screen without rebuilding. Overrides take effect after the next
+> app restart.
 
 > **Why `10.0.2.2` and not `localhost`?**
 > Android emulators route `localhost` to the emulator itself, not the host machine.
@@ -133,9 +139,7 @@ Ensure `gradle.properties` has `android.useFullClasspathForDexingTransform=true`
 - Physical device: Set `BASE_URL` to your machine's LAN IP
 
 **No telemetry in Grafana**
-- Check `OTLP_ENDPOINT` and `OTLP_AUTH_HEADER` in `config.json`
+- Check `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, and `OTLP_API_KEY` in `config.json` (or the
+  overrides set via the in-app **Debug → Config** screen)
 - Verify the endpoint accepts OTLP HTTP (not gRPC)
 - Use the **Debug** tab to trigger a test exception and confirm it arrives
-
-**`EncryptedSharedPreferences` error on first install**
-Clear the app data: **Settings → Apps → QuickPizza → Clear Data**


### PR DESCRIPTION
## Summary

Android port of #43 (Flutter). Expands the native Android demo's debug
tooling so we can drive the same realistic set of mobile observability
scenarios at runtime without rebuilds.

### Debug > Config sub-view

- Runtime overrides for backend URL, OTLP endpoint, OTLP instance ID,
  and OTLP API key — persisted to DataStore.
- API-key field masked by default with a show/hide toggle.
- Shared **Restart required** banner shown on both Debug and Config
  when saved overrides differ from what's actually in use this session.
- `RuntimeConfig` captured once at bootstrap so `OTelService` and
  `ApiClient` see the same URLs/credentials for the whole session →
  traces/logs/metrics stay correlated.

### Error simulation (persisted toggles)

- **Backend**: slow / error on recommendations + ingredients,
  propagated via `x-delay-*` / `x-error-*` headers.
- **Client**:
  - **v2 pizza schema** — simulates client/backend schema drift by
    parsing an alternate response shape.
  - **Skip auth dep in tools** — reproduces a forgotten reactive
    dependency where the tools list stops refreshing on login/logout.

### Client diagnostics

- **Quick Signals** card (debug log / error log / custom event) to prove
  the OTel pipeline end-to-end.
- **Handled Exception** card (manual reporting via `AppLogger.exception`).
- **ANR** card — blocks the main thread for 6s, exceeding Android's 5s
  threshold; reported by the OTel-Android agent.
- **Crash** card with two variants (`RuntimeException`, Kotlin NPE) —
  exercises the OTel-Android `CrashReporter` capture-on-crash +
  deliver-on-next-launch pipeline.

### Observability plumbing

- New `AppEvents` / `OtelEvents` emit logs with the top-level
  `EventName` field (per the OTel events semantic conventions).
- `AppLogger.exception()` follows the OTel exceptions semantic
  conventions (`exception.type`, `exception.message`,
  `exception.stacktrace`, `EventName=\"exception\"`). `LoginViewModel`
  and `ProfileViewModel` switched to use it.
- `MainActivity` emits `screen.view` events on Compose Navigation
  destination changes (Compose Navigation isn't covered by
  opentelemetry-android auto-instrumentation yet — see
  open-telemetry/opentelemetry-android#361).

### Auth refactor

- `TokenStorage` migrated EncryptedSharedPreferences → DataStore with a
  hot `tokenFlow`, seeded synchronously so `ApiClient`'s per-request
  reads stay sync.
- `HomeViewModel` reacts to auth state via the flow instead of
  refreshing on \`ON_RESUME\`.

### Config schema

\`OTLP_AUTH_HEADER\` split into \`OTLP_INSTANCE_ID\` + \`OTLP_API_KEY\`. The
app computes \`Authorization: Basic base64(instanceId:apiKey)\` at
runtime. \`config.json.example\` and \`Mobiles/docs/ANDROID_NATIVE_SETUP.md\`
updated.

### Dependencies

- Added \`androidx.datastore:datastore-preferences\` 1.2.1.
- Bumped \`minSdk\` 21 → 23 (DataStore Preferences 1.2.x requirement).

### Notes for reviewers

- Three intentional \`runBlocking { ... }\` reads at app bootstrap
  (\`RuntimeConfigHolder.current\`, \`DebugSettingsRepository._state\`
  init, \`TokenStorage._state\` init). DataStore is async-only, but
  \`OTelService.initialize()\` and \`ApiClient\`'s per-request
  \`tokenProvider\`/\`errorHeadersProvider\` lambdas are called
  synchronously. The comments at each call site explain the trade-off.
- No unit tests added in this PR. The pure-function candidates worth
  testing later: \`buildOtlpAuthHeader\`, \`DebugSettings.errorInjectionHeaders\`,
  \`RuntimeConfigHolder\` override resolution, \`computeRestartBanner\`.

## Screenshots

<img width="493" height="908" alt="Screenshot 2026-04-21 at 17 19 54" src="https://github.com/user-attachments/assets/a5c36a84-1941-44e9-a6c8-66fbcc9cc5de" />
<img width="493" height="908" alt="Screenshot 2026-04-21 at 17 20 01" src="https://github.com/user-attachments/assets/7ba69ef3-5ac4-46f1-b510-290957e8339b" />
<img width="493" height="908" alt="Screenshot 2026-04-21 at 17 20 19" src="https://github.com/user-attachments/assets/fd040989-2ee7-4eb6-904e-efe440dc4958" />


Made with [Cursor](https://cursor.com)