### PR TITLE
iOS: expand debug tab with config, error simulation, and telemetry diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The repository also contains a **native iOS demo app** (`Mobiles/ios/`) that dem
 - **Location:** `Mobiles/ios/`
 - **README:** `Mobiles/ios/README.md` — full setup instructions for running on a local simulator or BrowserStack
 - **Start backend:** `docker run --rm -d -p 3333:3333 ghcr.io/grafana/quickpizza-local:latest`
-- **Configure:** `cp Mobiles/ios/Config.xcconfig.example Mobiles/ios/Config.xcconfig` then fill in `OTLP_ENDPOINT` and `OTLP_AUTH_HEADER`
+- **Configure:** `cp Mobiles/ios/Config.xcconfig.example Mobiles/ios/Config.xcconfig` then fill in `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, and `OTLP_API_KEY`
 - **Run on simulator:** `bash Mobiles/ios/Scripts/sim-run.sh`
 - **OTLP target stack:** `mobileo11y.grafana-dev.net`
 
@@ -113,7 +113,7 @@ Three native/cross-platform clients that demonstrate mobile observability agains
 
 - **Stack:** Swift, SwiftUI (iOS 17+), Swift Package Manager, OpenTelemetry Swift
 - **Observability:** Manual spans + auto URLSession instrumentation, structured logs (OSLog + OTel), MetricKit crash/hang diagnostics, 15-min session tracking; in-app Debug tab for triggering test crashes
-- **Config:** `Config.xcconfig` → auto-generates `BuildConfig.generated.swift` — `OTLP_ENDPOINT`, `OTLP_AUTH_HEADER`
+- **Config:** `Config.xcconfig` → auto-generates `BuildConfig.generated.swift` — `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`
 - **Build:** Xcode (see `Mobiles/docs/XCODE_SETUP.md`)
 - **Resource attrs:** `service.name=quickpizza-ios`, `service.namespace=quickpizza`
 

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/MainActivity.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/MainActivity.kt
@@ -53,25 +53,15 @@ class MainActivity : ComponentActivity() {
 }
 
 /**
- * Emits a `screen.view` event on every [NavController] destination change.
+ * Emits an `app.screen.view` event on every [NavController] destination change.
  *
  * Jetpack Compose Navigation is not yet covered by opentelemetry-android's
  * auto-instrumentation (see open-telemetry/opentelemetry-android#361), so we
  * bridge it manually via [NavController.OnDestinationChangedListener].
  *
- * Attributes:
- *  - `nav.destination`          — current destination route
- *  - `nav.previous_destination` — route we came from (empty on first event)
- *  - `nav.kind`                 — `initial` | `push` | `pop` | `replace`
- *
- * We deliberately do NOT use the `screen.name` attribute key: the SDK's screen
- * attributes log processor unconditionally overwrites it with the visible
- * Activity/Fragment name (`MainActivity` for this single-Activity app), which
- * silently clobbers anything we set and bumps `dropped_attributes_count`.
- *
- * Consequence: auto-instrumented HTTP/ANR/crash records will still report
- * `screen.name=MainActivity`. Correlate to navigation destinations by
- * timestamp + `session.id`.
+ * Uses OTel semconv registered attribute `app.screen.name` for the screen
+ * identifier. We avoid `screen.name` because the SDK's ScreenAttributesLogProcessor
+ * unconditionally overwrites it with the Activity/Fragment name.
  */
 @Composable
 private fun TrackScreenViews(navController: NavHostController, appEvents: AppEvents) {
@@ -88,9 +78,9 @@ private fun TrackScreenViews(navController: NavHostController, appEvents: AppEve
                 else -> "replace"
             }
             appEvents.trackEvent(
-                "screen.view",
+                "app.screen.view",
                 mapOf(
-                    "nav.destination" to route,
+                    "app.screen.name" to route,
                     "nav.previous_destination" to (previousRoute ?: ""),
                     "nav.kind" to kind,
                 ),

--- a/Mobiles/ios/Config.xcconfig.example
+++ b/Mobiles/ios/Config.xcconfig.example
@@ -21,10 +21,10 @@ PORT = 3333
 // Example: http://localhost:4318
 // Example: https://otlp-gateway-prod-us-central-0.grafana.net/otlp
 // Leave empty to disable OTLP export (stdout only)
-OTLP_ENDPOINT = 
+OTLP_ENDPOINT =
 
-// OTLP Authorization header (optional, required for Grafana Cloud)
-// Format: Basic <base64_encoded_instance_id:api_token>
-// To generate: echo -n "instance_id:api_token" | base64
-// Leave empty if not using authentication
-OTLP_AUTH_HEADER = 
+// OTLP credentials for the Grafana Cloud OTLP Gateway (optional).
+// The app combines these into "Authorization: Basic base64(instanceId:apiKey)" at runtime.
+// Leave both empty if your OTLP receiver doesn't require auth.
+OTLP_INSTANCE_ID =
+OTLP_API_KEY =

--- a/Mobiles/ios/QuickPizzaIos/Bootstrap.swift
+++ b/Mobiles/ios/QuickPizzaIos/Bootstrap.swift
@@ -8,24 +8,27 @@ let pod = SwiftiePod()
 /// Called once at app launch from `QuickPizzaIosApp.init()`.
 enum Bootstrap {
     static func initialize() {
-        // 1. OpenTelemetry
-        let otelConfig = pod.resolve(otelConfigProvider)
+        // 1. Resolve the in-use URLs before anything else so OTelService and
+        //    APIClient see the same snapshot for the rest of the session.
+        let runtimeConfig = pod.resolve(runtimeConfigHolderProvider).current
+
+        // 2. OpenTelemetry (reads runtimeConfig via otelConfigProvider)
         _ = pod.resolve(otelServiceProvider)
 
-        // 2. Log startup
+        // 3. Log startup
         let config = pod.resolve(configServiceProvider)
         let logger = pod.resolve(loggerProvider)
-        if otelConfig.isOtlpEnabled {
+        if runtimeConfig.isOtlpEnabled {
             logger.info("OTel initialized with OTLP endpoint", attributes: [
-                "endpoint": otelConfig.endpointUrl ?? "",
-                "hasAuthHeader": otelConfig.authHeader != nil ? "yes" : "no",
+                "endpoint": runtimeConfig.otlpEndpoint,
+                "hasAuthHeader": runtimeConfig.otlpAuthHeader != nil ? "yes" : "no",
             ])
         } else {
             logger.info("OTel initialized in stdout-only mode (no OTLP endpoint configured)")
         }
         logger.info("QuickPizza iOS app started", attributes: [
             "version": config.appVersion,
-            "baseURL": config.baseURL,
+            "baseURL": runtimeConfig.backendBaseUrl,
         ])
     }
 }

--- a/Mobiles/ios/QuickPizzaIos/Core/API/APIClient.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/API/APIClient.swift
@@ -2,10 +2,11 @@ import Foundation
 import SwiftiePod
 
 let apiClientProvider = Provider<APIClientProtocol> { pod in
-    let config = pod.resolve(configServiceProvider)
+    let runtimeConfig = pod.resolve(runtimeConfigHolderProvider).current
     return APIClient(
-        baseURL: config.baseURL,
+        baseURL: runtimeConfig.backendBaseUrl,
         tokenStorage: pod.resolve(tokenStorageProvider),
+        debugSettings: pod.resolve(debugSettingsRepositoryProvider),
         logger: pod.resolve(loggerProvider)
     )
 }
@@ -14,6 +15,7 @@ let apiClientProvider = Provider<APIClientProtocol> { pod in
 final class APIClient: APIClientProtocol {
     private let baseURL: String
     private let tokenStorage: TokenStoring
+    private let debugSettings: DebugSettingsRepository
     private let logger: Logging
     private let session: URLSession
     private let timeout: TimeInterval = 10
@@ -23,14 +25,15 @@ final class APIClient: APIClientProtocol {
     init(
         baseURL: String,
         tokenStorage: TokenStoring,
+        debugSettings: DebugSettingsRepository,
         logger: Logging
     ) {
         self.baseURL = baseURL
         self.tokenStorage = tokenStorage
+        self.debugSettings = debugSettings
         self.logger = logger
         self.session = URLSession.shared
 
-        // Load initial token
         let stored = tokenStorage.loadSession()
         self.cachedToken = stored.token
     }
@@ -92,6 +95,9 @@ final class APIClient: APIClientProtocol {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if includeAuth, let token = cachedToken, !token.isEmpty {
             request.setValue("Token \(token)", forHTTPHeaderField: "Authorization")
+        }
+        for (name, value) in debugSettings.current.errorInjectionHeaders {
+            request.setValue(value, forHTTPHeaderField: name)
         }
     }
 

--- a/Mobiles/ios/QuickPizzaIos/Core/Config/ConfigService.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/Config/ConfigService.swift
@@ -9,6 +9,10 @@ let appVersionProvider = Provider<String> { pod in
     pod.resolve(configServiceProvider).appVersion
 }
 
+/// Bootstrap configuration loaded from `Config.xcconfig` (via `BuildConfig.generated.swift`).
+///
+/// Holds the build-time defaults only — runtime overrides (set by the user
+/// through Debug → Config) are applied on top by `RuntimeConfigHolder`.
 struct ConfigService {
     /// Base URL for the QuickPizza API.
     /// Set `BASE_URL` in Config.xcconfig (auto-generated into BuildConfig at build time).
@@ -33,14 +37,18 @@ struct ConfigService {
         return endpoint
     }
 
-    /// OTLP authorization header (e.g. "Basic <base64>").
-    /// Required when using Grafana Cloud OTLP gateway.
-    /// Set `OTLP_AUTH_HEADER` in Config.xcconfig (auto-generated into BuildConfig at build time).
-    var otlpAuthHeader: String? {
-        guard let header = BuildConfig.otlpAuthHeader, !header.isEmpty else {
-            return nil
-        }
-        return header
+    /// Numeric OTLP instance ID from your Grafana Cloud OTLP Gateway integration.
+    /// Combined with `otlpApiKey` at runtime to build the Authorization header.
+    /// Set `OTLP_INSTANCE_ID` in Config.xcconfig.
+    var otlpInstanceId: String {
+        BuildConfig.otlpInstanceId ?? ""
+    }
+
+    /// OTLP API key (Grafana Cloud access policy token, typically `glc_...`).
+    /// Combined with `otlpInstanceId` at runtime to build the Authorization header.
+    /// Set `OTLP_API_KEY` in Config.xcconfig.
+    var otlpApiKey: String {
+        BuildConfig.otlpApiKey ?? ""
     }
 
     /// Service name for OTel resource attributes.
@@ -49,8 +57,24 @@ struct ConfigService {
     /// Deployment environment for OTel resource attributes.
     let deploymentEnvironment = "production"
 
+    /// OTLP Authorization header derived from the build-time instance ID and API key.
+    /// `nil` when either credential is missing.
+    var otlpAuthHeader: String? {
+        Self.buildAuthHeader(instanceId: otlpInstanceId, apiKey: otlpApiKey)
+    }
+
     /// App version, read from the bundle.
     var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    }
+
+    /// Builds `Basic base64("<instanceId>:<apiKey>")`. Returns `nil` when
+    /// either credential is missing.
+    static func buildAuthHeader(instanceId: String, apiKey: String) -> String? {
+        let trimmedId = instanceId.trimmingCharacters(in: .whitespaces)
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespaces)
+        guard !trimmedId.isEmpty, !trimmedKey.isEmpty else { return nil }
+        let token = Data("\(trimmedId):\(trimmedKey)".utf8).base64EncodedString()
+        return "Basic \(token)"
     }
 }

--- a/Mobiles/ios/QuickPizzaIos/Core/Config/DebugSettings.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/Config/DebugSettings.swift
@@ -1,0 +1,228 @@
+import Foundation
+import Observation
+import SwiftiePod
+
+let debugSettingsRepositoryProvider = Provider<DebugSettingsRepository> { _ in
+    DebugSettingsRepository(store: UserDefaults.standard)
+}
+
+// MARK: - KeyValueStore
+
+protocol KeyValueStore {
+    func string(forKey key: String) -> String?
+    func bool(forKey key: String) -> Bool
+    func set(_ value: Any?, forKey key: String)
+    func removeObject(forKey key: String)
+}
+
+extension UserDefaults: KeyValueStore {}
+
+// MARK: - DebugSettings
+
+/// Snapshot of all values persisted by `DebugSettingsRepository`.
+///
+/// URL overrides are nullable — `nil` means "no override, use the build-time default".
+/// Boolean toggles default to `false`.
+struct DebugSettings: Equatable {
+    var backendUrlOverride: String? = nil
+    var otlpEndpointOverride: String? = nil
+    var otlpInstanceIdOverride: String? = nil
+    var otlpApiKeyOverride: String? = nil
+    var errorOnRecommendations: Bool = false
+    var errorOnIngredients: Bool = false
+    var slowRecommendations: Bool = false
+    var slowIngredients: Bool = false
+    var useV2PizzaSchema: Bool = false
+    var skipAuthDepInTools: Bool = false
+
+    var hasActiveOverrides: Bool {
+        backendUrlOverride != nil ||
+            otlpEndpointOverride != nil ||
+            otlpInstanceIdOverride != nil ||
+            otlpApiKeyOverride != nil ||
+            errorOnRecommendations ||
+            errorOnIngredients ||
+            slowRecommendations ||
+            slowIngredients ||
+            useV2PizzaSchema ||
+            skipAuthDepInTools
+    }
+
+    /// Backend expects:
+    ///  * `x-error-*` headers — value is the error message (any non-empty string)
+    ///  * `x-delay-*` headers — value is a Go duration string (e.g. `3s`, `500ms`)
+    ///
+    /// Delay values are tuned so both toggles produce ~3s of user-visible
+    /// slowness. `record-recommendation` is called once per `POST /api/pizza`,
+    /// so 3s → ~3s. `get-ingredients` is called four times per request
+    /// (oil, tomato, mozzarella, topping), so 750ms → ~3s total.
+    var errorInjectionHeaders: [String: String] {
+        var headers: [String: String] = [:]
+        if errorOnRecommendations {
+            headers["x-error-record-recommendation"] = "simulated recommendation service failure"
+        }
+        if errorOnIngredients {
+            headers["x-error-get-ingredients"] = "simulated ingredient lookup failure"
+        }
+        if slowRecommendations {
+            headers["x-delay-record-recommendation"] = "3s"
+        }
+        if slowIngredients {
+            headers["x-delay-get-ingredients"] = "750ms"
+        }
+        return headers
+    }
+}
+
+// MARK: - Repository
+
+private enum DebugSettingsKey {
+    static let backendUrl = "debug_backend_url"
+    static let otlpEndpoint = "debug_otlp_endpoint"
+    static let otlpInstanceId = "debug_otlp_instance_id"
+    static let otlpApiKey = "debug_otlp_api_key"
+    static let errorRecommendations = "debug_error_recommendations"
+    static let errorIngredients = "debug_error_ingredients"
+    static let slowRecommendations = "debug_slow_recommendations"
+    static let slowIngredients = "debug_slow_ingredients"
+    static let useV2PizzaSchema = "debug_use_v2_pizza_schema"
+    static let skipAuthDepInTools = "debug_skip_auth_dep_in_tools"
+}
+
+/// Persists `DebugSettings` in a `KeyValueStore` and exposes a hot
+/// snapshot (`current`). Marked `@Observable` so consumers can stream
+/// changes via `Observations { repo.current }` (Swift 6.2).
+@Observable
+final class DebugSettingsRepository {
+    @ObservationIgnored private let store: KeyValueStore
+
+    private(set) var current: DebugSettings
+
+    init(store: KeyValueStore) {
+        self.store = store
+        self.current = Self.load(from: store)
+    }
+
+    // MARK: Mutators (URL overrides)
+
+    /// Persist all URL + OTLP credential overrides atomically. Empty / blank
+    /// values clear the corresponding override.
+    func saveConfigOverrides(
+        backendUrl: String?,
+        otlpEndpoint: String?,
+        otlpInstanceId: String?,
+        otlpApiKey: String?
+    ) {
+        setString(DebugSettingsKey.backendUrl, value: normalize(backendUrl))
+        setString(DebugSettingsKey.otlpEndpoint, value: normalize(otlpEndpoint))
+        setString(DebugSettingsKey.otlpInstanceId, value: normalize(otlpInstanceId))
+        setString(DebugSettingsKey.otlpApiKey, value: normalize(otlpApiKey))
+        publish()
+    }
+
+    func setBackendUrlOverride(_ value: String?) {
+        setString(DebugSettingsKey.backendUrl, value: normalize(value))
+        publish()
+    }
+
+    func setOtlpEndpointOverride(_ value: String?) {
+        setString(DebugSettingsKey.otlpEndpoint, value: normalize(value))
+        publish()
+    }
+
+    func setOtlpInstanceIdOverride(_ value: String?) {
+        setString(DebugSettingsKey.otlpInstanceId, value: normalize(value))
+        publish()
+    }
+
+    func setOtlpApiKeyOverride(_ value: String?) {
+        setString(DebugSettingsKey.otlpApiKey, value: normalize(value))
+        publish()
+    }
+
+    // MARK: Mutators (toggles)
+
+    func setErrorOnRecommendations(_ value: Bool) {
+        store.set(value, forKey: DebugSettingsKey.errorRecommendations)
+        publish()
+    }
+
+    func setErrorOnIngredients(_ value: Bool) {
+        store.set(value, forKey: DebugSettingsKey.errorIngredients)
+        publish()
+    }
+
+    func setSlowRecommendations(_ value: Bool) {
+        store.set(value, forKey: DebugSettingsKey.slowRecommendations)
+        publish()
+    }
+
+    func setSlowIngredients(_ value: Bool) {
+        store.set(value, forKey: DebugSettingsKey.slowIngredients)
+        publish()
+    }
+
+    func setUseV2PizzaSchema(_ value: Bool) {
+        store.set(value, forKey: DebugSettingsKey.useV2PizzaSchema)
+        publish()
+    }
+
+    func setSkipAuthDepInTools(_ value: Bool) {
+        store.set(value, forKey: DebugSettingsKey.skipAuthDepInTools)
+        publish()
+    }
+
+    func resetAll() {
+        for key in [
+            DebugSettingsKey.backendUrl,
+            DebugSettingsKey.otlpEndpoint,
+            DebugSettingsKey.otlpInstanceId,
+            DebugSettingsKey.otlpApiKey,
+            DebugSettingsKey.errorRecommendations,
+            DebugSettingsKey.errorIngredients,
+            DebugSettingsKey.slowRecommendations,
+            DebugSettingsKey.slowIngredients,
+            DebugSettingsKey.useV2PizzaSchema,
+            DebugSettingsKey.skipAuthDepInTools,
+        ] {
+            store.removeObject(forKey: key)
+        }
+        publish()
+    }
+
+    // MARK: Private
+
+    private func setString(_ key: String, value: String?) {
+        if let value {
+            store.set(value, forKey: key)
+        } else {
+            store.removeObject(forKey: key)
+        }
+    }
+
+    private func normalize(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let trimmed, !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private func publish() {
+        current = Self.load(from: store)
+    }
+
+    private static func load(from store: KeyValueStore) -> DebugSettings {
+        DebugSettings(
+            backendUrlOverride: store.string(forKey: DebugSettingsKey.backendUrl),
+            otlpEndpointOverride: store.string(forKey: DebugSettingsKey.otlpEndpoint),
+            otlpInstanceIdOverride: store.string(forKey: DebugSettingsKey.otlpInstanceId),
+            otlpApiKeyOverride: store.string(forKey: DebugSettingsKey.otlpApiKey),
+            errorOnRecommendations: store.bool(forKey: DebugSettingsKey.errorRecommendations),
+            errorOnIngredients: store.bool(forKey: DebugSettingsKey.errorIngredients),
+            slowRecommendations: store.bool(forKey: DebugSettingsKey.slowRecommendations),
+            slowIngredients: store.bool(forKey: DebugSettingsKey.slowIngredients),
+            useV2PizzaSchema: store.bool(forKey: DebugSettingsKey.useV2PizzaSchema),
+            skipAuthDepInTools: store.bool(forKey: DebugSettingsKey.skipAuthDepInTools)
+        )
+    }
+}

--- a/Mobiles/ios/QuickPizzaIos/Core/Config/RuntimeConfig.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/Config/RuntimeConfig.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SwiftiePod
+
+let runtimeConfigHolderProvider = Provider<RuntimeConfigHolder> { pod in
+    RuntimeConfigHolder(
+        configService: pod.resolve(configServiceProvider),
+        debugSettings: pod.resolve(debugSettingsRepositoryProvider)
+    )
+}
+
+/// Immutable snapshot of the URLs and credentials the app was bootstrapped with.
+///
+/// This is intentionally *not* reactive: these are the values `OTelService`
+/// initialized with and that `APIClient` is using. Changing a saved override in
+/// `DebugSettings` will NOT change these values — the user must restart the app
+/// for the override to take effect.
+///
+/// Why: keeping backend + collector + auth stable per session makes correlated
+/// traces/logs/metrics much easier to reason about when demoing.
+struct RuntimeConfig {
+    let backendBaseUrl: String
+    let otlpEndpoint: String
+    let otlpInstanceId: String
+    let otlpApiKey: String
+
+    /// OTLP Authorization header derived from the resolved instance ID and API key.
+    /// `nil` when either credential is missing.
+    var otlpAuthHeader: String? {
+        ConfigService.buildAuthHeader(instanceId: otlpInstanceId, apiKey: otlpApiKey)
+    }
+
+    /// Whether OTLP export is enabled (endpoint is configured).
+    var isOtlpEnabled: Bool {
+        !otlpEndpoint.isEmpty
+    }
+}
+
+/// Resolves and holds the `RuntimeConfig` snapshot for the lifetime of the
+/// process. Built lazily on first access (which happens during
+/// `Bootstrap.initialize()`).
+final class RuntimeConfigHolder {
+    private let configService: ConfigService
+    private let debugSettings: DebugSettingsRepository
+
+    private(set) lazy var current: RuntimeConfig = resolve()
+
+    init(configService: ConfigService, debugSettings: DebugSettingsRepository) {
+        self.configService = configService
+        self.debugSettings = debugSettings
+    }
+
+    private func resolve() -> RuntimeConfig {
+        let saved = debugSettings.current
+        let instanceId = saved.otlpInstanceIdOverride ?? configService.otlpInstanceId
+        let apiKey = saved.otlpApiKeyOverride ?? configService.otlpApiKey
+        return RuntimeConfig(
+            backendBaseUrl: saved.backendUrlOverride ?? configService.baseURL,
+            otlpEndpoint: saved.otlpEndpointOverride ?? (configService.otlpEndpoint ?? ""),
+            otlpInstanceId: instanceId,
+            otlpApiKey: apiKey
+        )
+    }
+}

--- a/Mobiles/ios/QuickPizzaIos/Core/O11y/AppEvents.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/O11y/AppEvents.swift
@@ -1,0 +1,74 @@
+import Foundation
+import OpenTelemetryApi
+import SwiftUI
+import SwiftiePod
+
+let appEventsProvider = Provider<AppEvents> { pod in
+    OtelEvents(otelService: pod.resolve(otelServiceProvider))
+}
+
+/// Emit application-defined events (e.g. `pizza.requested`, `debug.test_event`).
+///
+/// Follows the OpenTelemetry "Semantic conventions for events":
+///
+///  - An event is a `LogRecord` whose top-level `EventName` field uniquely
+///    identifies the event type. We set it via `LogRecordBuilder.setEventName`.
+///  - Event names follow the OTel naming guidelines — lowercase,
+///    dot-separated, namespaced as `<namespace>.<event>`
+///    (e.g. `pizza.requested`, `auth.logged_in`, `debug.test_event`).
+///  - Context goes in attributes.
+///  - Severity number is set (defaults to INFO).
+///  - Body is intentionally left empty: per spec it should only carry a
+///    human-readable display message, which we don't have for these events.
+protocol AppEvents {
+    func trackEvent(_ name: String, attributes: [String: String])
+}
+
+extension AppEvents {
+    func trackEvent(_ name: String, attributes: [String: String] = [:]) {
+        trackEvent(name, attributes: attributes)
+    }
+
+    /// Emits a screen view event following OTel semconv `app.screen.*` conventions.
+    /// No official event exists yet, so we use `app.screen.view` as the event name
+    /// with the registered `app.screen.name` attribute key.
+    func trackScreenView(_ screenName: String) {
+        trackEvent("app.screen.view", attributes: [
+            "app.screen.name": screenName,
+        ])
+    }
+}
+
+final class OtelEvents: AppEvents {
+    private let otelLogger: OpenTelemetryApi.Logger
+
+    init(otelService: OTelService) {
+        self.otelLogger = otelService.getLogger()
+    }
+
+    func trackEvent(_ name: String, attributes: [String: String]) {
+        var otelAttributes = attributes.reduce(
+            into: [String: OpenTelemetryApi.AttributeValue]()
+        ) { result, pair in
+            result[pair.key] = .string(pair.value)
+        }
+        otelAttributes["level"] = .string("INFO")
+
+        let builder = otelLogger
+            .logRecordBuilder()
+            .setTimestamp(Date())
+            .setAttributes(otelAttributes)
+            .setSeverity(.info)
+        _ = builder.setEventName(name)
+        builder.emit()
+    }
+}
+
+// MARK: - SwiftUI View Modifier
+
+extension View {
+    func trackScreenView(_ screenName: String) -> some View {
+        let events: AppEvents = pod.resolve(appEventsProvider)
+        return onAppear { events.trackScreenView(screenName) }
+    }
+}

--- a/Mobiles/ios/QuickPizzaIos/Core/O11y/Config/OTelConfig.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/O11y/Config/OTelConfig.swift
@@ -2,10 +2,17 @@ import Foundation
 import SwiftiePod
 
 let otelConfigProvider = Provider { pod in
-    OTelConfig(configService: pod.resolve(configServiceProvider))
+    OTelConfig(
+        configService: pod.resolve(configServiceProvider),
+        runtimeConfig: pod.resolve(runtimeConfigHolderProvider).current
+    )
 }
 
 /// Configuration values for OpenTelemetry instrumentation.
+///
+/// URL/credential fields are sourced from `RuntimeConfig` (the per-session
+/// snapshot, which respects user overrides from Debug → Config). Resource
+/// attributes (service name, version, environment) come from `ConfigService`.
 struct OTelConfig {
     let endpointUrl: String?
     let authHeader: String?
@@ -13,12 +20,15 @@ struct OTelConfig {
     let deploymentEnvironment: String
     let appVersion: String
 
-    let instrumentationScopeName = "quickpizza-ios"
-    let instrumentationScopeVersion = "1.0.0"
+    static let defaultScopeName = "quickpizza-ios"
+    static let defaultScopeVersion = "1.0.0"
 
-    init(configService: ConfigService) {
-        self.endpointUrl = configService.otlpEndpoint
-        self.authHeader = configService.otlpAuthHeader
+    let instrumentationScopeName = OTelConfig.defaultScopeName
+    let instrumentationScopeVersion = OTelConfig.defaultScopeVersion
+
+    init(configService: ConfigService, runtimeConfig: RuntimeConfig) {
+        self.endpointUrl = runtimeConfig.isOtlpEnabled ? runtimeConfig.otlpEndpoint : nil
+        self.authHeader = runtimeConfig.otlpAuthHeader
         self.serviceName = configService.serviceName
         self.deploymentEnvironment = configService.deploymentEnvironment
         self.appVersion = configService.appVersion

--- a/Mobiles/ios/QuickPizzaIos/Core/O11y/OTelService.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/O11y/OTelService.swift
@@ -162,17 +162,15 @@ final class OTelService {
     // MARK: - Accessors
 
     func getTracer() -> Tracer {
-        let config = otelConfig ?? OTelConfig(configService: ConfigService())
         return OpenTelemetry.instance.tracerProvider.get(
-            instrumentationName: config.instrumentationScopeName,
-            instrumentationVersion: config.instrumentationScopeVersion
+            instrumentationName: otelConfig?.instrumentationScopeName ?? OTelConfig.defaultScopeName,
+            instrumentationVersion: otelConfig?.instrumentationScopeVersion ?? OTelConfig.defaultScopeVersion
         )
     }
 
     func getLogger() -> OpenTelemetryApi.Logger {
-        let config = otelConfig ?? OTelConfig(configService: ConfigService())
         return OpenTelemetry.instance.loggerProvider.loggerBuilder(
-            instrumentationScopeName: config.instrumentationScopeName
+            instrumentationScopeName: otelConfig?.instrumentationScopeName ?? OTelConfig.defaultScopeName
         ).build()
     }
 }

--- a/Mobiles/ios/QuickPizzaIos/Features/About/Presentation/AboutView.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/About/Presentation/AboutView.swift
@@ -122,6 +122,7 @@ struct AboutView: View {
             .padding(.horizontal, 16)
         }
         .background(AppColors.background)
+        .trackScreenView("about")
     }
 
     private var features: [String] {

--- a/Mobiles/ios/QuickPizzaIos/Features/Auth/Presentation/LoginView.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Auth/Presentation/LoginView.swift
@@ -101,6 +101,22 @@ struct LoginView: View {
                     .background(Color.blue.opacity(0.06))
                     .clipShape(RoundedRectangle(cornerRadius: 8))
 
+                    HStack(spacing: 8) {
+                        Image(systemName: "star.fill")
+                            .foregroundStyle(Color.orange)
+                        Text("To clear ratings, use \"studio-user\" / \"k6studiorocks\" (the default user cannot delete ratings).")
+                            .font(.caption)
+                            .foregroundStyle(Color(red: 0.45, green: 0.30, blue: 0.00))
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.orange.opacity(0.12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.orange.opacity(0.35), lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
                     Text("Tip: You can create a new user via the POST http://quickpizza.grafana.com/api/users endpoint. Attach a JSON payload with username and password keys.")
                         .font(.caption2)
                         .foregroundStyle(AppColors.textSecondary)
@@ -110,6 +126,7 @@ struct LoginView: View {
                 .padding(24)
             }
             .background(AppColors.background)
+            .trackScreenView("login")
             .navigationTitle("Login")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/ConfigView.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/ConfigView.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+import SwiftiePod
+
+struct ConfigView: View {
+    @State private var viewModel = pod.resolve(configViewModelProvider)
+    @State private var backendField = ""
+    @State private var otlpField = ""
+    @State private var instanceIdField = ""
+    @State private var apiKeyField = ""
+    @State private var apiKeyRevealed = false
+    @State private var didSeedFields = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                RestartRequiredBanner(state: viewModel.state.restartBanner)
+
+                Text("Override the URLs and OTLP credentials used by this app. Changes only take effect after you kill and restart the app — this keeps traces, logs and metrics correlated within a single session.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                ConfigField(
+                    label: "Backend URL",
+                    inUseValue: viewModel.state.backendInUse,
+                    defaultValue: viewModel.state.defaultBackend,
+                    hintText: "http://192.168.1.100:3333",
+                    value: $backendField,
+                    keyboardType: .URL
+                )
+
+                ConfigField(
+                    label: "OTLP endpoint",
+                    inUseValue: viewModel.state.otlpInUse,
+                    defaultValue: viewModel.state.defaultOtlp,
+                    hintText: "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp",
+                    value: $otlpField,
+                    keyboardType: .URL
+                )
+
+                ConfigField(
+                    label: "OTLP instance ID",
+                    inUseValue: viewModel.state.otlpInstanceIdInUse,
+                    defaultValue: viewModel.state.defaultOtlpInstanceId,
+                    hintText: "1234567",
+                    value: $instanceIdField,
+                    keyboardType: .numberPad,
+                    supportingText: "Numeric ID from your Grafana Cloud OTLP Gateway integration."
+                )
+
+                SecretField(
+                    label: "OTLP API key",
+                    inUseValue: viewModel.state.otlpApiKeyInUse,
+                    defaultValue: viewModel.state.defaultOtlpApiKey,
+                    value: $apiKeyField,
+                    revealed: $apiKeyRevealed,
+                    supportingText: "Combined with the instance ID to build Authorization: Basic base64(instanceId:apiKey)."
+                )
+
+                Button {
+                    viewModel.save(
+                        backendUrl: backendField,
+                        otlpEndpoint: otlpField,
+                        otlpInstanceId: instanceIdField,
+                        otlpApiKey: apiKeyField
+                    )
+                } label: {
+                    if viewModel.state.saving {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text("Save")
+                    }
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(viewModel.state.saving)
+
+                Button {
+                    viewModel.clear()
+                    backendField = ""
+                    otlpField = ""
+                    instanceIdField = ""
+                    apiKeyField = ""
+                } label: {
+                    Text("Use defaults (clear overrides)")
+                }
+                .buttonStyle(SecondaryButtonStyle())
+                .disabled(viewModel.state.saving)
+
+                if let statusMessage = viewModel.state.statusMessage {
+                    StatusCard(message: statusMessage)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+        }
+        .background(AppColors.background)
+        .navigationTitle("Config")
+        .task {
+            if !didSeedFields {
+                backendField = viewModel.state.savedBackendOverride ?? ""
+                otlpField = viewModel.state.savedOtlpOverride ?? ""
+                instanceIdField = viewModel.state.savedOtlpInstanceIdOverride ?? ""
+                apiKeyField = viewModel.state.savedOtlpApiKeyOverride ?? ""
+                didSeedFields = true
+            }
+            await viewModel.observeSettings()
+        }
+    }
+}
+
+// MARK: - Config Field
+
+private struct ConfigField: View {
+    let label: String
+    let inUseValue: String
+    let defaultValue: String
+    let hintText: String
+    @Binding var value: String
+    var keyboardType: UIKeyboardType = .default
+    var supportingText: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label).font(.headline)
+
+            LabelledMonoLine(label: "Currently in use", value: inUseValue.isEmpty ? "(not set)" : inUseValue)
+            if defaultValue != inUseValue {
+                LabelledMonoLine(label: "Default", value: defaultValue.isEmpty ? "(not set)" : defaultValue)
+            }
+
+            TextField("Override (empty = use default)", text: $value, prompt: Text(hintText))
+                .textFieldStyle(.roundedBorder)
+                .keyboardType(keyboardType)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
+
+            if let supportingText {
+                Text(supportingText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(16)
+        .background(AppColors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+    }
+}
+
+// MARK: - Secret Field
+
+private struct SecretField: View {
+    let label: String
+    let inUseValue: String
+    let defaultValue: String
+    @Binding var value: String
+    @Binding var revealed: Bool
+    var supportingText: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label).font(.headline)
+
+            LabelledMonoLine(label: "Currently in use", value: maskSecret(inUseValue))
+            if defaultValue != inUseValue {
+                LabelledMonoLine(label: "Default", value: maskSecret(defaultValue))
+            }
+
+            HStack {
+                Group {
+                    if revealed {
+                        TextField("Override (empty = use default)", text: $value, prompt: Text("glc_xxxxxxxxxxxx"))
+                    } else {
+                        SecureField("Override (empty = use default)", text: $value, prompt: Text("glc_xxxxxxxxxxxx"))
+                    }
+                }
+                .textFieldStyle(.roundedBorder)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
+
+                Button {
+                    revealed.toggle()
+                } label: {
+                    Image(systemName: revealed ? "eye.slash" : "eye")
+                }
+            }
+
+            if let supportingText {
+                Text(supportingText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(16)
+        .background(AppColors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+    }
+}
+
+private func maskSecret(_ value: String) -> String {
+    if value.isEmpty { return "(not set)" }
+    if value.count <= 8 { return String(repeating: "•", count: max(value.count, 4)) }
+    let head = String(value.prefix(4))
+    let tail = String(value.suffix(4))
+    let middleBullets = min(value.count - 8, 8)
+    return head + String(repeating: "•", count: middleBullets) + tail
+}
+
+// MARK: - Reusable Components
+
+private struct LabelledMonoLine: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(.callout, design: .monospaced))
+        }
+    }
+}
+
+private struct StatusCard: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(AppColors.success)
+            Text(message)
+                .font(.subheadline)
+            Spacer()
+        }
+        .padding(12)
+        .background(Color(red: 0.91, green: 0.96, blue: 0.91))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ConfigView()
+    }
+}

--- a/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/ConfigViewModel.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/ConfigViewModel.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Observation
+import SwiftUI
+import SwiftiePod
+
+let configViewModelProvider = Provider(scope: AlwaysCreateNewScope()) { pod in
+    ConfigViewModel(
+        debugSettings: pod.resolve(debugSettingsRepositoryProvider),
+        runtimeConfig: pod.resolve(runtimeConfigHolderProvider),
+        configService: pod.resolve(configServiceProvider)
+    )
+}
+
+// MARK: - UI State
+
+struct ConfigUiState: Equatable {
+    var backendInUse: String
+    var otlpInUse: String
+    var otlpInstanceIdInUse: String
+    var otlpApiKeyInUse: String
+    var defaultBackend: String
+    var defaultOtlp: String
+    var defaultOtlpInstanceId: String
+    var defaultOtlpApiKey: String
+    var savedBackendOverride: String?
+    var savedOtlpOverride: String?
+    var savedOtlpInstanceIdOverride: String?
+    var savedOtlpApiKeyOverride: String?
+    var saving: Bool = false
+    var statusMessage: String? = nil
+    var restartBanner: RestartBannerState = .hidden
+}
+
+// MARK: - ViewModel
+
+@Observable
+class ConfigViewModel {
+    private let debugSettings: DebugSettingsRepository
+    private let runtimeConfig: RuntimeConfigHolder
+    private let configService: ConfigService
+
+    var state: ConfigUiState
+
+    init(
+        debugSettings: DebugSettingsRepository,
+        runtimeConfig: RuntimeConfigHolder,
+        configService: ConfigService
+    ) {
+        self.debugSettings = debugSettings
+        self.runtimeConfig = runtimeConfig
+        self.configService = configService
+        self.state = Self.buildState(
+            settings: debugSettings.current,
+            runtime: runtimeConfig.current,
+            config: configService
+        )
+    }
+
+    /// Called from `.task {}` — listens for settings changes and updates UI state.
+    func observeSettings() async {
+        for await settings in Observations({ self.debugSettings.current }) {
+            let saving = state.saving
+            let statusMessage = state.statusMessage
+            state = Self.buildState(
+                settings: settings,
+                runtime: runtimeConfig.current,
+                config: configService
+            )
+            state.saving = saving
+            state.statusMessage = statusMessage
+        }
+    }
+
+    func save(
+        backendUrl: String,
+        otlpEndpoint: String,
+        otlpInstanceId: String,
+        otlpApiKey: String
+    ) {
+        state.saving = true
+        state.statusMessage = nil
+        debugSettings.saveConfigOverrides(
+            backendUrl: backendUrl.isEmpty ? nil : backendUrl,
+            otlpEndpoint: otlpEndpoint.isEmpty ? nil : otlpEndpoint,
+            otlpInstanceId: otlpInstanceId.isEmpty ? nil : otlpInstanceId,
+            otlpApiKey: otlpApiKey.isEmpty ? nil : otlpApiKey
+        )
+        state.saving = false
+        state.statusMessage = "Saved. Kill and relaunch the app for changes to take effect."
+    }
+
+    func clear() {
+        state.saving = true
+        state.statusMessage = nil
+        debugSettings.saveConfigOverrides(
+            backendUrl: nil,
+            otlpEndpoint: nil,
+            otlpInstanceId: nil,
+            otlpApiKey: nil
+        )
+        state.saving = false
+        state.statusMessage = "Overrides cleared. Kill and relaunch to use defaults."
+    }
+
+    private static func buildState(
+        settings: DebugSettings,
+        runtime: RuntimeConfig,
+        config: ConfigService
+    ) -> ConfigUiState {
+        ConfigUiState(
+            backendInUse: runtime.backendBaseUrl,
+            otlpInUse: runtime.otlpEndpoint,
+            otlpInstanceIdInUse: runtime.otlpInstanceId,
+            otlpApiKeyInUse: runtime.otlpApiKey,
+            defaultBackend: config.baseURL,
+            defaultOtlp: config.otlpEndpoint ?? "",
+            defaultOtlpInstanceId: config.otlpInstanceId,
+            defaultOtlpApiKey: config.otlpApiKey,
+            savedBackendOverride: settings.backendUrlOverride,
+            savedOtlpOverride: settings.otlpEndpointOverride,
+            savedOtlpInstanceIdOverride: settings.otlpInstanceIdOverride,
+            savedOtlpApiKeyOverride: settings.otlpApiKeyOverride,
+            restartBanner: computeRestartBanner(settings: settings, runtime: runtime)
+        )
+    }
+}

--- a/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugView.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugView.swift
@@ -3,71 +3,348 @@ import SwiftiePod
 
 struct DebugView: View {
     @State private var viewModel = pod.resolve(debugViewModelProvider)
-    @State private var showCrashConfirmation = false
+    @State private var showConfig = false
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 20) {
-                VStack(spacing: 8) {
-                    Text("Debug Tools")
-                        .font(.title2)
-                        .fontWeight(.bold)
-                        .foregroundStyle(AppColors.textPrimary)
+            VStack(spacing: 16) {
+                RestartRequiredBanner(state: viewModel.state.restartBanner)
 
-                    Text("Use these actions to validate OpenTelemetry exception and crash behavior.")
-                        .font(.subheadline)
-                        .multilineTextAlignment(.center)
-                        .foregroundStyle(AppColors.textSecondary)
+                ConfigEntryCard { showConfig = true }
+
+                Text("Use these tools to simulate issues and exercise the observability instrumentation during demos.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                ErrorSimulationSection(viewModel: viewModel)
+
+                ClientDiagnosticsSection(viewModel: viewModel)
+
+                if let message = viewModel.state.lastActionMessage {
+                    LastActionCard(message: message)
                 }
-                .padding(.top, 16)
-
-                VStack(spacing: 12) {
-                    Button {
-                        viewModel.sendExceptionEvent()
-                    } label: {
-                        Label("Send logger.exception", systemImage: "exclamationmark.bubble.fill")
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
-
-                    Button {
-                        showCrashConfirmation = true
-                    } label: {
-                        Label("Trigger test crash", systemImage: "bolt.horizontal.circle.fill")
-                    }
-                    .buttonStyle(SecondaryButtonStyle())
-                }
-
-                if let lastActionMessage = viewModel.lastActionMessage {
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(AppColors.success)
-                        Text(lastActionMessage)
-                            .font(.subheadline)
-                            .foregroundStyle(AppColors.textPrimary)
-                        Spacer()
-                    }
-                    .padding(12)
-                    .background(AppColors.cardBackground)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
-
-                Text("Crash button intentionally terminates the app via fatalError.")
-                    .font(.caption)
-                    .foregroundStyle(AppColors.textSecondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 Spacer(minLength: 40)
             }
             .padding(.horizontal, 16)
+            .padding(.top, 8)
         }
         .background(AppColors.background)
-        .alert("Trigger test crash?", isPresented: $showCrashConfirmation) {
-            Button("Crash now", role: .destructive) {
-                viewModel.triggerCrash()
+        .trackScreenView("debug")
+        .navigationTitle("Debug")
+        .toolbar {
+            if viewModel.state.settings.hasActiveOverrides {
+                Button("Reset All") { viewModel.resetAll() }
             }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This will immediately terminate the app.")
+        }
+        .navigationDestination(isPresented: $showConfig) {
+            ConfigView()
+        }
+        .task {
+            await viewModel.observeSettings()
+        }
+        .onChange(of: viewModel.state.lastActionMessage) { _, newValue in
+            if newValue != nil {
+                Task {
+                    try? await Task.sleep(for: .seconds(3))
+                    viewModel.clearLastAction()
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Config Entry Card
+
+private struct ConfigEntryCard: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 16) {
+                Image(systemName: "gearshape.fill")
+                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Config")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text("Change backend URL, OTLP endpoint, and OTLP credentials (requires restart)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .foregroundStyle(.secondary)
+            }
+            .padding(16)
+            .background(AppColors.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Error Simulation Section
+
+private struct ErrorSimulationSection: View {
+    let viewModel: DebugViewModel
+
+    var body: some View {
+        SectionHeader("Error Simulation")
+        Text("Toggle these to simulate backend issues, client-side faults, and version drift. Takes effect immediately — no restart needed.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        VStack(spacing: 0) {
+            ToggleRow(title: "Slow Recommendations", subtitle: "Adds delay to pizza recommendations", isOn: viewModel.state.settings.slowRecommendations) {
+                viewModel.setSlowRecommendations($0)
+            }
+            Divider()
+            ToggleRow(title: "Slow Ingredients", subtitle: "Adds delay to ingredient loading", isOn: viewModel.state.settings.slowIngredients) {
+                viewModel.setSlowIngredients($0)
+            }
+            Divider()
+            ToggleRow(title: "Error on Recommendations", subtitle: "Forces server errors on recommendations", isOn: viewModel.state.settings.errorOnRecommendations) {
+                viewModel.setErrorOnRecommendations($0)
+            }
+            Divider()
+            ToggleRow(title: "Error on Ingredients", subtitle: "Forces server errors on ingredient loading", isOn: viewModel.state.settings.errorOnIngredients) {
+                viewModel.setErrorOnIngredients($0)
+            }
+            Divider()
+            ToggleRow(title: "Use v2 pizza response schema", subtitle: "Experimental — simulates a client/backend schema drift", isOn: viewModel.state.settings.useV2PizzaSchema) {
+                viewModel.setUseV2PizzaSchema($0)
+            }
+            Divider()
+            ToggleRow(title: "Skip auth dep in tools provider", subtitle: "Tools list won't refresh on login/logout — reproduces the bug", isOn: viewModel.state.settings.skipAuthDepInTools) {
+                viewModel.setSkipAuthDepInTools($0)
+            }
+        }
+        .background(AppColors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+    }
+}
+
+// MARK: - Client Diagnostics Section
+
+private struct ClientDiagnosticsSection: View {
+    let viewModel: DebugViewModel
+
+    var body: some View {
+        SectionHeader("Client Diagnostics")
+
+        QuickSignalsCard(viewModel: viewModel)
+
+        DiagnosticActionCard(
+            title: "Handled Exception",
+            description: "Throws an exception inside a try/catch and reports it via the OTel logger as an exception log record. Tests the manual reporting path.",
+            buttonText: "Send Handled Exception",
+            action: viewModel.logTestException
+        )
+
+        CrashCard(viewModel: viewModel)
+    }
+}
+
+// MARK: - Quick Signals Card
+
+private struct QuickSignalsCard: View {
+    let viewModel: DebugViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Quick Signals").font(.headline)
+            Text("Emit one-off signals (logs and custom events) to verify the OTel pipeline end-to-end.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer().frame(height: 4)
+            Button("Send Debug Log") { viewModel.sendDebugLog() }
+                .buttonStyle(PrimaryButtonStyle())
+            Button("Send Error Log") { viewModel.sendErrorLog() }
+                .buttonStyle(PrimaryButtonStyle())
+            Button("Send Custom Event") { viewModel.sendCustomEvent() }
+                .buttonStyle(PrimaryButtonStyle())
+        }
+        .padding(16)
+        .background(AppColors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+    }
+}
+
+// MARK: - Diagnostic Action Card
+
+private struct DiagnosticActionCard: View {
+    let title: String
+    let description: String
+    let buttonText: String
+    let action: () -> Void
+    var danger: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+                .foregroundStyle(danger ? Color.red : .primary)
+            Text(description)
+                .font(.caption)
+                .foregroundStyle(danger ? Color.red.opacity(0.85) : .secondary)
+            Spacer().frame(height: 4)
+            if danger {
+                Button(buttonText, action: action)
+                    .buttonStyle(SecondaryButtonStyle())
+            } else {
+                Button(buttonText, action: action)
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(16)
+        .background(danger ? Color.red.opacity(0.08) : AppColors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+    }
+}
+
+// MARK: - Crash Card
+
+private enum CrashKind: Identifiable {
+    case fatalError
+    case forceUnwrap
+
+    var id: String {
+        switch self {
+        case .fatalError: return "fatalError"
+        case .forceUnwrap: return "forceUnwrap"
+        }
+    }
+
+    var dialogTitle: String {
+        switch self {
+        case .fatalError: return "Trigger crash?"
+        case .forceUnwrap: return "Trigger simulated nil force-unwrap?"
+        }
+    }
+
+    var dialogBody: String {
+        switch self {
+        case .fatalError:
+            return "The app will terminate. Relaunch it after the crash. MetricKit crash diagnostics are delivered by iOS later and may not appear immediately in your observability backend."
+        case .forceUnwrap:
+            return "Simulates a real-world nil-dereference bug. Relaunch after the crash. MetricKit crash diagnostics are delivered by iOS later and may not appear immediately in your observability backend."
+        }
+    }
+}
+
+private struct CrashCard: View {
+    let viewModel: DebugViewModel
+    @State private var pending: CrashKind?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Crash Reporting").font(.headline).foregroundStyle(.red)
+            Text("Terminates the app to exercise iOS MetricKit crash diagnostics. MetricKit delivery is OS-managed and can be delayed; manual crashes may not show up in Grafana Cloud immediately. Use Xcode's simulated MetricKit payload to verify the OTel export path.")
+                .font(.caption)
+                .foregroundStyle(Color.red.opacity(0.85))
+            Spacer().frame(height: 4)
+            Button("Crash (fatalError)") { pending = .fatalError }
+                .buttonStyle(SecondaryButtonStyle())
+            Button("Crash (force-unwrap nil)") { pending = .forceUnwrap }
+                .buttonStyle(SecondaryButtonStyle())
+        }
+        .padding(16)
+        .background(Color.red.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+        .alert(item: $pending) { kind in
+            Alert(
+                title: Text(kind.dialogTitle),
+                message: Text(kind.dialogBody),
+                primaryButton: .destructive(Text("Crash now")) {
+                    switch kind {
+                    case .fatalError: viewModel.triggerCrashFatalError()
+                    case .forceUnwrap: viewModel.triggerCrashForceUnwrap()
+                    }
+                },
+                secondaryButton: .cancel()
+            )
+        }
+    }
+}
+
+// MARK: - Reusable Building Blocks
+
+private struct SectionHeader: View {
+    let title: String
+    init(_ title: String) { self.title = title }
+
+    var body: some View {
+        Text(title)
+            .font(.title3)
+            .fontWeight(.bold)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ToggleRow: View {
+    let title: String
+    let subtitle: String
+    let isOn: Bool
+    let onChanged: (Bool) -> Void
+
+    var body: some View {
+        Toggle(isOn: Binding(get: { isOn }, set: onChanged)) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.body)
+                Text(subtitle).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+}
+
+private struct LastActionCard: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(AppColors.success)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(AppColors.textPrimary)
+            Spacer()
+        }
+        .padding(12)
+        .background(Color(red: 0.91, green: 0.96, blue: 0.91))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Restart Required Banner
+
+struct RestartRequiredBanner: View {
+    let state: RestartBannerState
+
+    var body: some View {
+        if case .visible(let changedLabel) = state {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Color(red: 0.48, green: 0.31, blue: 0.0))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Restart required")
+                        .font(.headline)
+                        .foregroundStyle(Color(red: 0.48, green: 0.31, blue: 0.0))
+                    Text("Kill and relaunch the app for the new \(changedLabel) to take effect.")
+                        .font(.subheadline)
+                        .foregroundStyle(Color(red: 0.48, green: 0.31, blue: 0.0))
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(red: 1.0, green: 0.93, blue: 0.70))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
     }
 }

--- a/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugViewModel.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Debug/Presentation/DebugViewModel.swift
@@ -1,44 +1,180 @@
 import Foundation
+import Observation
 import SwiftUI
 import SwiftiePod
 
 let debugViewModelProvider = Provider(scope: AlwaysCreateNewScope()) { pod in
-    DebugViewModel(logger: pod.resolve(loggerProvider))
+    DebugViewModel(
+        debugSettings: pod.resolve(debugSettingsRepositoryProvider),
+        runtimeConfig: pod.resolve(runtimeConfigHolderProvider),
+        logger: pod.resolve(loggerProvider),
+        events: pod.resolve(appEventsProvider)
+    )
 }
+
+private let DEBUG_TAB_CONTEXT: [String: String] = ["debug.source": "debug_tab"]
+
+// MARK: - UI State
+
+struct DebugUiState: Equatable {
+    var settings: DebugSettings = DebugSettings()
+    var restartBanner: RestartBannerState = .hidden
+    var lastActionMessage: String? = nil
+}
+
+enum RestartBannerState: Equatable {
+    case hidden
+    case visible(changedLabel: String)
+}
+
+/// Computes whether the persisted overrides differ from the URLs/credentials
+/// actually in use this session. Shared by `DebugViewModel` and
+/// `ConfigViewModel` so the banner is consistent on both screens.
+func computeRestartBanner(
+    settings: DebugSettings,
+    runtime: RuntimeConfig
+) -> RestartBannerState {
+    let savedBackend = settings.backendUrlOverride ?? runtime.backendBaseUrl
+    let savedOtlp = settings.otlpEndpointOverride ?? runtime.otlpEndpoint
+    let savedInstanceId = settings.otlpInstanceIdOverride ?? runtime.otlpInstanceId
+    let savedApiKey = settings.otlpApiKeyOverride ?? runtime.otlpApiKey
+
+    let changedFields = [
+        savedBackend != runtime.backendBaseUrl ? "Backend URL" : nil,
+        savedOtlp != runtime.otlpEndpoint ? "OTLP endpoint" : nil,
+        savedInstanceId != runtime.otlpInstanceId ? "OTLP instance ID" : nil,
+        savedApiKey != runtime.otlpApiKey ? "OTLP API key" : nil,
+    ].compactMap { $0 }
+
+    if changedFields.isEmpty {
+        return .hidden
+    } else {
+        return .visible(changedLabel: changedFields.joined(separator: ", "))
+    }
+}
+
+// MARK: - ViewModel
 
 @Observable
 class DebugViewModel {
+    private let debugSettings: DebugSettingsRepository
+    private let runtimeConfig: RuntimeConfigHolder
     private let logger: Logging
+    private let events: AppEvents
 
-    var lastActionMessage: String?
+    var state: DebugUiState
 
-    init(logger: Logging) {
+    init(
+        debugSettings: DebugSettingsRepository,
+        runtimeConfig: RuntimeConfigHolder,
+        logger: Logging,
+        events: AppEvents
+    ) {
+        self.debugSettings = debugSettings
+        self.runtimeConfig = runtimeConfig
         self.logger = logger
+        self.events = events
+        self.state = DebugUiState(
+            settings: debugSettings.current,
+            restartBanner: computeRestartBanner(
+                settings: debugSettings.current,
+                runtime: runtimeConfig.current
+            )
+        )
     }
 
-    func sendExceptionEvent() {
+    /// Called from `.task {}` — listens for settings changes and updates UI state.
+    func observeSettings() async {
+        for await settings in Observations({ self.debugSettings.current }) {
+            state.settings = settings
+            state.restartBanner = computeRestartBanner(
+                settings: settings,
+                runtime: runtimeConfig.current
+            )
+        }
+    }
+
+    // MARK: Toggles (persisted)
+
+    func setSlowRecommendations(_ value: Bool) { debugSettings.setSlowRecommendations(value) }
+    func setSlowIngredients(_ value: Bool) { debugSettings.setSlowIngredients(value) }
+    func setErrorOnRecommendations(_ value: Bool) { debugSettings.setErrorOnRecommendations(value) }
+    func setErrorOnIngredients(_ value: Bool) { debugSettings.setErrorOnIngredients(value) }
+    func setUseV2PizzaSchema(_ value: Bool) { debugSettings.setUseV2PizzaSchema(value) }
+    func setSkipAuthDepInTools(_ value: Bool) { debugSettings.setSkipAuthDepInTools(value) }
+
+    func resetAll() {
+        debugSettings.resetAll()
+        showAction("All debug settings reset")
+    }
+
+    // MARK: Quick Signals
+
+    func sendDebugLog() {
+        logger.debug(
+            "Test debug log from Debug tab",
+            attributes: DEBUG_TAB_CONTEXT.merging(["debug.action": "logger.debug"]) { _, new in new }
+        )
+        showAction("Sent debug log")
+    }
+
+    func sendErrorLog() {
+        logger.error(
+            "Test error log from Debug tab",
+            attributes: DEBUG_TAB_CONTEXT.merging(["debug.action": "logger.error"]) { _, new in new }
+        )
+        showAction("Sent error log")
+    }
+
+    func sendCustomEvent() {
+        events.trackEvent(
+            "debug.test_event",
+            attributes: DEBUG_TAB_CONTEXT.merging(["debug.action": "events.trackEvent"]) { _, new in new }
+        )
+        showAction("Sent custom event")
+    }
+
+    // MARK: Diagnostics
+
+    func logTestException() {
         let error = DebugTestError.simulatedException
         logger.exception(
-            "Debug tab sent custom logger.exception event",
+            "Test exception triggered by user",
             error: error,
-            attributes: [
-                "debug.action": "logger.exception",
-                "debug.source": "debug_tab",
-            ]
+            attributes: DEBUG_TAB_CONTEXT.merging(["debug.action": "logger.exception"]) { _, new in new }
         )
-        lastActionMessage = "Sent custom exception log"
+        showAction("Sent handled exception")
     }
 
-    func triggerCrash() -> Never {
+    /// Crashes the app via `fatalError`. The OTel crash reporter persists
+    /// the crash to disk; the exporter delivers it on the next app launch.
+    func triggerCrashFatalError() -> Never {
         logger.error(
             "Debug tab is about to trigger a fatalError crash",
-            error: nil,
-            attributes: [
-                "debug.action": "crash",
-                "debug.source": "debug_tab",
-            ]
+            attributes: DEBUG_TAB_CONTEXT.merging(["debug.action": "crash_fatal_error"]) { _, new in new }
         )
-        fatalError("Debug crash triggered from Debug tab")
+        fatalError("Debug crash triggered from Debug tab (fatalError)")
+    }
+
+    /// Crashes via force-unwrapping nil — exercises the same crash pipeline
+    /// but mirrors a real-world nil-dereference bug.
+    func triggerCrashForceUnwrap() {
+        logger.error(
+            "Debug tab is about to trigger a force-unwrap crash",
+            attributes: DEBUG_TAB_CONTEXT.merging(["debug.action": "crash_force_unwrap"]) { _, new in new }
+        )
+        let nothing: String? = nil
+        _ = nothing!.count
+    }
+
+    // MARK: Helpers
+
+    func clearLastAction() {
+        state.lastActionMessage = nil
+    }
+
+    private func showAction(_ message: String) {
+        state.lastActionMessage = message
     }
 }
 

--- a/Mobiles/ios/QuickPizzaIos/Features/Pizza/Domain/PizzaRepository.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Pizza/Domain/PizzaRepository.swift
@@ -4,6 +4,7 @@ import SwiftiePod
 let pizzaRepositoryProvider = Provider<PizzaRepositoryProtocol> { pod in
     PizzaRepository(
         apiClient: pod.resolve(apiClientProvider),
+        debugSettings: pod.resolve(debugSettingsRepositoryProvider),
         logger: pod.resolve(loggerProvider),
         tracer: pod.resolve(tracerProvider)
     )
@@ -12,11 +13,13 @@ let pizzaRepositoryProvider = Provider<PizzaRepositoryProtocol> { pod in
 /// Concrete implementation of PizzaRepositoryProtocol.
 final class PizzaRepository: PizzaRepositoryProtocol {
     private let apiClient: APIClientProtocol
+    private let debugSettings: DebugSettingsRepository
     private let logger: Logging
     private let tracer: Tracing
 
-    init(apiClient: APIClientProtocol, logger: Logging, tracer: Tracing) {
+    init(apiClient: APIClientProtocol, debugSettings: DebugSettingsRepository, logger: Logging, tracer: Tracing) {
         self.apiClient = apiClient
+        self.debugSettings = debugSettings
         self.logger = logger
         self.tracer = tracer
     }
@@ -64,7 +67,12 @@ final class PizzaRepository: PizzaRepositoryProtocol {
             span.setAttribute(key: "http.status_code", value: response.statusCode)
 
             if response.statusCode == 200 {
-                let recommendation = try JSONDecoder().decode(PizzaRecommendation.self, from: data)
+                let recommendation: PizzaRecommendation
+                if debugSettings.current.useV2PizzaSchema {
+                    recommendation = try parseRecommendationV2(data)
+                } else {
+                    recommendation = try JSONDecoder().decode(PizzaRecommendation.self, from: data)
+                }
                 span.setAttribute(key: "pizza.id", value: recommendation.pizza.id)
                 span.setAttribute(key: "pizza.name", value: recommendation.pizza.name)
                 logger.info("Pizza recommendation fetched", attributes: [
@@ -85,6 +93,62 @@ final class PizzaRepository: PizzaRepositoryProtocol {
             }
             return nil
         }
+    }
+
+    /// Parses the upcoming v2 response schema. v2 renames `pizza.name` → `pizza.displayName`
+    /// and `pizza.tool` → `pizza.tooling`. Throws if the expected v2 fields aren't present —
+    /// this is intentional, the toggle exists to simulate a client that was upgraded ahead
+    /// of the backend (or vice versa) so we can demo schema-drift telemetry.
+    private func parseRecommendationV2(_ data: Data) throws -> PizzaRecommendation {
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let pizzaObj = root["pizza"] as? [String: Any] else {
+            throw PizzaError.v2SchemaError("missing 'pizza' object")
+        }
+        guard let id = pizzaObj["id"] as? Int else {
+            throw PizzaError.v2SchemaError("missing required int field 'id'")
+        }
+        guard let displayName = pizzaObj["displayName"] as? String else {
+            throw PizzaError.v2SchemaError("missing required string field 'displayName'")
+        }
+        guard let tooling = pizzaObj["tooling"] as? String else {
+            throw PizzaError.v2SchemaError("missing required string field 'tooling'")
+        }
+
+        let ingredients: [Ingredient]
+        if let ingredientsArray = pizzaObj["ingredients"] as? [[String: Any]] {
+            ingredients = ingredientsArray.compactMap { dict in
+                guard let iId = (dict["ID"] as? Int) ?? (dict["id"] as? Int),
+                      let name = dict["name"] as? String else { return nil }
+                return Ingredient(
+                    id: iId,
+                    name: name,
+                    caloriesPerSlice: dict["caloriesPerSlice"] as? Int,
+                    vegetarian: dict["vegetarian"] as? Bool
+                )
+            }
+        } else {
+            ingredients = []
+        }
+
+        var dough: Dough?
+        if let doughObj = pizzaObj["dough"] as? [String: Any],
+           let dId = (doughObj["ID"] as? Int) ?? (doughObj["id"] as? Int),
+           let dName = doughObj["name"] as? String {
+            dough = Dough(id: dId, name: dName, caloriesPerSlice: doughObj["caloriesPerSlice"] as? Int)
+        }
+
+        let pizza = Pizza(
+            id: id,
+            name: displayName,
+            dough: dough ?? Dough(id: 0, name: "Unknown"),
+            ingredients: ingredients,
+            tool: tooling
+        )
+        return PizzaRecommendation(
+            pizza: pizza,
+            calories: root["calories"] as? Int,
+            vegetarian: root["vegetarian"] as? Bool
+        )
     }
 
     func ratePizza(pizzaId: Int, stars: Int) async throws {
@@ -115,12 +179,14 @@ enum PizzaError: LocalizedError {
     case forbidden(String)
     case serverError
     case ratingFailed
+    case v2SchemaError(String)
 
     var errorDescription: String? {
         switch self {
         case .forbidden(let msg): return msg
         case .serverError: return "Server error — please try again later"
         case .ratingFailed: return "Failed to submit rating"
+        case .v2SchemaError(let detail): return "v2 schema parse error: \(detail)"
         }
     }
 }

--- a/Mobiles/ios/QuickPizzaIos/Features/Pizza/Presentation/HomeView.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Pizza/Presentation/HomeView.swift
@@ -94,6 +94,7 @@ struct HomeView: View {
             .padding(.horizontal, 16)
         }
         .background(AppColors.background)
+        .trackScreenView("home")
         .task {
             await viewModel.start()
         }

--- a/Mobiles/ios/QuickPizzaIos/Features/Pizza/Presentation/HomeViewModel.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Pizza/Presentation/HomeViewModel.swift
@@ -5,6 +5,7 @@ let homeViewModelProvider = Provider(scope: AlwaysCreateNewScope()) { pod in
     HomeViewModel(
         pizzaRepository: pod.resolve(pizzaRepositoryProvider),
         authService: pod.resolve(authRepositoryProvider),
+        debugSettings: pod.resolve(debugSettingsRepositoryProvider),
         logger: pod.resolve(loggerProvider)
     )
 }
@@ -13,6 +14,7 @@ let homeViewModelProvider = Provider(scope: AlwaysCreateNewScope()) { pod in
 class HomeViewModel {
     private let pizzaRepository: PizzaRepositoryProtocol
     private let authService: AuthServiceProtocol
+    private let debugSettings: DebugSettingsRepository
     private let logger: Logging
 
     // View state
@@ -27,10 +29,12 @@ class HomeViewModel {
     init(
         pizzaRepository: PizzaRepositoryProtocol,
         authService: AuthServiceProtocol,
+        debugSettings: DebugSettingsRepository,
         logger: Logging
     ) {
         self.pizzaRepository = pizzaRepository
         self.authService = authService
+        self.debugSettings = debugSettings
         self.logger = logger
     }
 
@@ -42,8 +46,6 @@ class HomeViewModel {
     /// Loads initial data and listens for logout events.
     /// Auto-cancelled when the view disappears (structured concurrency).
     func start() async {
-        // Catch any auth changes that happened while the view was off-screen
-        // (e.g. logout from another tab while the listener task was cancelled).
         if !isAuthenticated {
             clearRecommendationState()
         }
@@ -53,11 +55,7 @@ class HomeViewModel {
                 await self.loadInitialData()
             }
             group.addTask { @MainActor in
-                for await _ in self.authService.authStateChanged {
-                    if !self.authService.isAuthenticated {
-                        self.clearRecommendationState()
-                    }
-                }
+                await self.observeAuthState()
             }
         }
     }
@@ -69,6 +67,24 @@ class HomeViewModel {
         let (fetchedQuote, fetchedTools) = await (quoteTask, toolsTask)
         quote = fetchedQuote
         availableTools = fetchedTools
+    }
+
+    /// Observes auth state changes. When the user logs in/out:
+    ///  - Clears stale recommendation state on logout
+    ///  - Refetches `/api/tools` (requires a valid token)
+    ///
+    /// The `skipAuthDepInTools` debug toggle disables the tools refresh
+    /// to reproduce a real-world bug where the tools list goes stale.
+    private func observeAuthState() async {
+        for await _ in authService.authStateChanged {
+            if !authService.isAuthenticated {
+                clearRecommendationState()
+            }
+            if !debugSettings.current.skipAuthDepInTools {
+                let tools = await pizzaRepository.getTools()
+                availableTools = tools
+            }
+        }
     }
 
     func getRecommendation() async {
@@ -113,9 +129,7 @@ class HomeViewModel {
             restrictions.excludedTools.append(tool)
         }
     }
-    
-    /// Clears the pizza recommendation and any errors.
-    /// Called when the user logs out.
+
     func clearRecommendationState() {
         recommendation = nil
         errorMessage = nil

--- a/Mobiles/ios/QuickPizzaIos/Features/Profile/Presentation/ProfileView.swift
+++ b/Mobiles/ios/QuickPizzaIos/Features/Profile/Presentation/ProfileView.swift
@@ -142,6 +142,7 @@ struct ProfileView: View {
                 .padding(16)
             }
             .background(AppColors.background)
+            .trackScreenView("profile")
             .navigationTitle("Profile")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Mobiles/ios/QuickPizzaIos/Navigation/MainShell.swift
+++ b/Mobiles/ios/QuickPizzaIos/Navigation/MainShell.swift
@@ -8,25 +8,16 @@ struct MainShell: View {
     var body: some View {
         NavigationStack {
             TabView(selection: $viewModel.selectedTab) {
-                // Home tab
                 HomeView()
-                    .tabItem {
-                        Label("Home", systemImage: "house.fill")
-                    }
+                    .tabItem { Label("Home", systemImage: "house.fill") }
                     .tag(0)
 
-                // About tab
                 AboutView()
-                    .tabItem {
-                        Label("About", systemImage: "info.circle")
-                    }
+                    .tabItem { Label("About", systemImage: "info.circle") }
                     .tag(1)
 
-                // Debug tab
                 DebugView()
-                    .tabItem {
-                        Label("Debug", systemImage: "ladybug.fill")
-                    }
+                    .tabItem { Label("Debug", systemImage: "ladybug.fill") }
                     .tag(2)
             }
             .tint(AppColors.primary)

--- a/Mobiles/ios/QuickPizzaIos/Navigation/MainShellViewModel.swift
+++ b/Mobiles/ios/QuickPizzaIos/Navigation/MainShellViewModel.swift
@@ -2,28 +2,25 @@ import SwiftUI
 import SwiftiePod
 
 let mainShellViewModelProvider = Provider(scope: AlwaysCreateNewScope()) { pod in
-    MainShellViewModel(
-        tokenStorage: pod.resolve(tokenStorageProvider)
-    )
+    MainShellViewModel(tokenStorage: pod.resolve(tokenStorageProvider))
 }
 
 @Observable
 class MainShellViewModel {
     private let tokenStorage: TokenStoring
-    
-    // View state
+
     var showLogin = false
     var showProfile = false
     var selectedTab = 0
-    
+
     var isAuthenticated: Bool {
         tokenStorage.loadSession().isAuthenticated
     }
-    
+
     init(tokenStorage: TokenStoring) {
         self.tokenStorage = tokenStorage
     }
-    
+
     func showAuthSheet() {
         if isAuthenticated {
             showProfile = true

--- a/Mobiles/ios/README.md
+++ b/Mobiles/ios/README.md
@@ -8,12 +8,12 @@ It connects to the QuickPizza backend and sends traces/logs to an OTLP collector
 
 ## Prerequisites
 
-| Requirement | Notes |
-|---|---|
-| macOS (Apple Silicon or Intel) | Any recent macOS version |
-| [Xcode](https://apps.apple.com/app/xcode/id497799835) | Install from Mac App Store (~15 GB) |
-| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | For running the backend locally |
-| Git | To clone this repository |
+| Requirement                                                       | Notes                               |
+| ----------------------------------------------------------------- | ----------------------------------- |
+| macOS (Apple Silicon or Intel)                                    | Any recent macOS version            |
+| [Xcode](https://apps.apple.com/app/xcode/id497799835)             | Install from Mac App Store (~15 GB) |
+| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | For running the backend locally     |
+| Git                                                               | To clone this repository            |
 
 > **Note for AI agents:** These are the only tools needed. No CocoaPods, no Homebrew, no Swift Package Manager setup — the Xcode project handles all dependencies automatically.
 
@@ -63,7 +63,8 @@ PORT = 3333
 
 # OTLP — leave empty to skip telemetry export for now
 OTLP_ENDPOINT =
-OTLP_AUTH_HEADER =
+OTLP_INSTANCE_ID =
+OTLP_API_KEY =
 ```
 
 > The `$()` in the URL is an Xcode xcconfig escape for `://` — leave it as-is.
@@ -78,6 +79,7 @@ bash Scripts/sim-run.sh
 ```
 
 The script will:
+
 1. Auto-detect an available iPhone simulator
 2. Build the app with `xcodebuild`
 3. Boot the simulator if needed
@@ -124,27 +126,18 @@ To find your `clusterSlug`, Instance ID, and API token:
 2. Find the stack and click through to its details — the **cluster slug** and **numeric Instance ID** are listed there
 3. Generate an API token with scopes: `metrics:write`, `logs:write`, `traces:write`
 
-### Generate the auth header
-
-```bash
-echo -n "<instance_id>:<api_token>" | base64
-```
-
-Example:
-
-```bash
-echo -n "123456:glc_abc123..." | base64
-# => MTIzNDU2OmdsY19hYmMxMjMu...
-```
-
 ### Update Config.xcconfig
+
+The app computes `Authorization: Basic base64(instanceId:apiKey)` at runtime,
+so you only need to provide the raw values:
 
 ```
 BASE_URL = http:/$()/localhost:3333
 PORT = 3333
 
 OTLP_ENDPOINT = https://otlp-gateway-<clusterSlug>.grafana-dev.net/otlp
-OTLP_AUTH_HEADER = Basic MTIzNDU2OmdsY19hYmMxMjMu...
+OTLP_INSTANCE_ID = 123456
+OTLP_API_KEY = glc_abc123...
 ```
 
 Then re-run the app:
@@ -166,6 +159,7 @@ open Mobiles/ios/QuickPizzaIos.xcodeproj
 ```
 
 Then:
+
 - Select a simulator from the device picker in the toolbar
 - Press **Cmd+R** to build and run
 
@@ -234,6 +228,7 @@ ngrok http 3333
 ```
 
 Then set:
+
 ```
 BASE_URL = https:/$()/abc123.ngrok.io
 ```
@@ -244,14 +239,19 @@ BASE_URL = https:/$()/abc123.ngrok.io
 
 The app uses the [OpenTelemetry Swift SDK](https://github.com/open-telemetry/opentelemetry-swift).
 
-| Signal | What is instrumented |
-|---|---|
-| **Traces** | Every API call (pizza recommendations, ratings, auth) |
-| **Logs** | App lifecycle events, errors |
+| Signal     | What is instrumented                                        |
+| ---------- | ----------------------------------------------------------- |
+| **Traces** | Every API call (pizza recommendations, ratings, auth)       |
+| **Logs**   | App lifecycle events, errors, custom events                 |
+| **Events** | `screen.view` on tab changes, custom events via `AppEvents` |
 
 Configuration is read from `Config.xcconfig` at build time and injected into
 `BuildConfig.generated.swift` (auto-generated, gitignored). The `OTelService`
-initialises the SDK on app launch using these values.
+initializes the SDK on app launch using these values.
+
+Runtime overrides for backend URL, OTLP endpoint, and credentials can be set
+from the **Debug → Config** screen without rebuilding. These are persisted in
+`UserDefaults` and applied on the next app launch via `RuntimeConfigHolder`.
 
 When `OTLP_ENDPOINT` is empty, telemetry is written to the Xcode console only
 (via `OSLog`). When set, it is exported over OTLP/HTTP to your collector.
@@ -282,5 +282,5 @@ xcrun simctl list devices available
 **Traces not appearing in Grafana**
 
 - Double-check `OTLP_ENDPOINT` has no trailing slash
-- Verify the base64 auth header: `echo -n "id:token" | base64`
+- Verify `OTLP_INSTANCE_ID` and `OTLP_API_KEY` are correct in `Config.xcconfig`
 - Check the Xcode console for `[OTel]` error messages

--- a/Mobiles/ios/Scripts/generate-config.sh
+++ b/Mobiles/ios/Scripts/generate-config.sh
@@ -29,7 +29,8 @@ function get_xcconfig_value() {
 BASE_URL=$(get_xcconfig_value "BASE_URL")
 PORT=$(get_xcconfig_value "PORT")
 OTLP_ENDPOINT=$(get_xcconfig_value "OTLP_ENDPOINT")
-OTLP_AUTH_HEADER=$(get_xcconfig_value "OTLP_AUTH_HEADER")
+OTLP_INSTANCE_ID=$(get_xcconfig_value "OTLP_INSTANCE_ID")
+OTLP_API_KEY=$(get_xcconfig_value "OTLP_API_KEY")
 
 # Generate Swift file with proper optional handling
 cat > "$OUTPUT_FILE" << EOF
@@ -42,33 +43,21 @@ import Foundation
 enum BuildConfig {
 EOF
 
-# Add baseURL
-if [ -n "$BASE_URL" ]; then
-    echo "    static let baseURL: String? = \"$BASE_URL\"" >> "$OUTPUT_FILE"
-else
-    echo "    static let baseURL: String? = nil" >> "$OUTPUT_FILE"
-fi
+function emit_string_optional() {
+    local name=$1
+    local value=$2
+    if [ -n "$value" ]; then
+        echo "    static let ${name}: String? = \"${value}\"" >> "$OUTPUT_FILE"
+    else
+        echo "    static let ${name}: String? = nil" >> "$OUTPUT_FILE"
+    fi
+}
 
-# Add port
-if [ -n "$PORT" ]; then
-    echo "    static let port: String? = \"$PORT\"" >> "$OUTPUT_FILE"
-else
-    echo "    static let port: String? = nil" >> "$OUTPUT_FILE"
-fi
-
-# Add otlpEndpoint
-if [ -n "$OTLP_ENDPOINT" ]; then
-    echo "    static let otlpEndpoint: String? = \"$OTLP_ENDPOINT\"" >> "$OUTPUT_FILE"
-else
-    echo "    static let otlpEndpoint: String? = nil" >> "$OUTPUT_FILE"
-fi
-
-# Add otlpAuthHeader
-if [ -n "$OTLP_AUTH_HEADER" ]; then
-    echo "    static let otlpAuthHeader: String? = \"$OTLP_AUTH_HEADER\"" >> "$OUTPUT_FILE"
-else
-    echo "    static let otlpAuthHeader: String? = nil" >> "$OUTPUT_FILE"
-fi
+emit_string_optional "baseURL"        "$BASE_URL"
+emit_string_optional "port"           "$PORT"
+emit_string_optional "otlpEndpoint"   "$OTLP_ENDPOINT"
+emit_string_optional "otlpInstanceId" "$OTLP_INSTANCE_ID"
+emit_string_optional "otlpApiKey"     "$OTLP_API_KEY"
 
 echo "}" >> "$OUTPUT_FILE"
 


### PR DESCRIPTION
## Summary

Expands the native iOS demo's debug tooling so we can drive the same realistic mobile observability scenarios already added for Flutter and Android.

### Debug > Config sub-view

- Runtime overrides for backend URL, OTLP endpoint, OTLP instance ID, and OTLP API key.
- API-key field masked by default with a show/hide toggle.
- Shared "Restart required" banner when saved overrides differ from values in use this session.
- `RuntimeConfig` captured once at bootstrap so `OTelService` and `APIClient` use the same URLs/credentials for the whole session.

### Error simulation

- Backend slow/error toggles for recommendations and ingredients via `x-delay-*` / `x-error-*` headers.
- Client toggles for v2 pizza schema parsing and skipped auth dependency in tools refresh.

### Client diagnostics

- Quick Signals card for debug log, error log, and custom event.
- Handled exception reporting via OTel logger.
- Crash card with `fatalError` and force-unwrap variants for MetricKit crash diagnostics.

### Observability plumbing

- Adds `AppEvents` to emit OTel events with top-level event names.
- Adds screen view events using `app.screen.view` / `app.screen.name`.
- Updates iOS config schema from `OTLP_AUTH_HEADER` to `OTLP_INSTANCE_ID` + `OTLP_API_KEY`.

## Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 -paired with ultra - 2026-04-27 at 13 53 22" src="https://github.com/user-attachments/assets/8a52ff85-ea58-4a81-8cb4-ce90705ba26f" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 -paired with ultra - 2026-04-27 at 13 53 29" src="https://github.com/user-attachments/assets/68a358a9-4961-498f-a324-064b0f0ebb8a" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 -paired with ultra - 2026-04-27 at 13 53 33" src="https://github.com/user-attachments/assets/79cde37e-745e-47a0-b0a1-171f8057be18" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 -paired with ultra - 2026-04-27 at 13 53 38" src="https://github.com/user-attachments/assets/4ba68e9e-70d8-43c3-965a-116c766a74bf" />


## Test plan

- `git diff --check origin/main...HEAD`
- iOS simulator build:
  `xcodebuild -project Mobiles/ios/QuickPizzaIos.xcodeproj -scheme QuickPizzaIos -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`

Made with [Cursor](https://cursor.com)