### PR TITLE
docs(mobile): add reusable Mobile OTel RUM dashboard and setup guide

### DIFF
--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -120,7 +120,7 @@ nav.destination          = current Compose route
 
 Where to view the data on the demo stack:
 
-- **Dashboard:** "Android & iOS OTel RUM" on your Grafana Cloud stack
+- **Dashboard:** import and configure the shared [Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md)
 - **Explore Tempo:** filter by `resource.service.name="quickpizza-android"`
 - **Explore Loki:** filter by `service_name="quickpizza-android"`
 

--- a/Mobiles/dashboards/mobile-otel-rum-dashboard.json
+++ b/Mobiles/dashboards/mobile-otel-rum-dashboard.json
@@ -2580,30 +2580,6 @@
                     },
                     "refId": "A"
                   }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "grafanacloud-logs"
-                      },
-                      "group": "loki",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "direction": "backward",
-                        "editorMode": "code",
-                        "expr": "sum by (event_name) (count_over_time({service_name=~\"$service_name\"} | event_name=\"device.anr\" [$__auto]))",
-                        "instant": false,
-                        "legendFormat": "ANR",
-                        "queryType": "range",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
                 }
               ],
               "queryOptions": {},
@@ -2726,6 +2702,7 @@
                       "spec": {
                         "direction": "backward",
                         "expr": "{service_name=~\"$service_name\"} | event_name=~\"exception|device.crash|device.anr\" | line_format \"[{{.os_name}}|{{.event_name}}]{{if .exception_type}} {{.exception_type}}{{if .exception_message}}: {{.exception_message}}{{end}}{{end}}{{if .screen_name}} | screen:{{.screen_name}}{{end}}\"",
+                        "maxLines": 10,
                         "queryType": "range"
                       },
                       "version": "v0"

--- a/Mobiles/dashboards/mobile-otel-rum-dashboard.json
+++ b/Mobiles/dashboards/mobile-otel-rum-dashboard.json
@@ -1,0 +1,3304 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "mobile-otel-rum-dashboard"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "Reusable Grafana 13+ dashboard for native Android and iOS apps instrumented with OpenTelemetry and sending OTLP logs/traces to Grafana Cloud.",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 1,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<div style=\"background:linear-gradient(135deg,#0d1117,#161b22);border-radius:8px;padding:16px 24px;display:flex;align-items:center;gap:16px;box-shadow:0 2px 12px rgba(0,0,0,0.5);border-left:4px solid #f5a800\"><div style=\"font-size:48px\">📱</div><div><div style=\"font-size:22px;font-weight:700;color:#fff\">Android &amp; iOS OTel App Observability</div><div style=\"font-size:13px;color:rgba(255,255,255,0.75);margin-top:6px\">Observability for mobile apps instrumented with <a href=\"https://github.com/open-telemetry/opentelemetry-android\" target=\"_blank\" style=\"color:#3DDC84;text-decoration:none;font-weight:600\">OpenTelemetry Android</a> and <a href=\"https://github.com/open-telemetry/opentelemetry-swift\" target=\"_blank\" style=\"color:#007AFF;text-decoration:none;font-weight:600\">OpenTelemetry Swift</a></div></div></div>",
+                "mode": "html"
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-20": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-traces"
+                      },
+                      "group": "tempo",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "limit": 500,
+                        "metricsQueryType": "range",
+                        "query": "{ resource.service.name =~ \"$service_name\" && span.session.id =~ \"${session_id}.*\" } | select(status)",
+                        "queryType": "traceql",
+                        "range": true,
+                        "spss": 3,
+                        "tableType": "traces"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Traces from the QuickPizza Android app. Filtered by the selected Session ID — shows all traces when no Session ID is set.",
+          "id": 20,
+          "links": [],
+          "title": "Traces — $session_id",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "error": {
+                                "color": "red",
+                                "text": "❌ Error"
+                              },
+                              "ok": {
+                                "color": "green",
+                                "text": "✅ OK"
+                              },
+                              "unset": {
+                                "color": "text",
+                                "text": "— Unset"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "frameIndex": 0,
+                "showHeader": true
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-21": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=~\"${session_id}\" | event_name = \"\" | line_format \"{{if .name}}[{{.name}}]{{if .metrickit_diagnostic_crash_exception_type}} signal:{{.metrickit_diagnostic_crash_exception_signal}} mach:{{.metrickit_diagnostic_crash_exception_mach_exception_type}} reason:{{.metrickit_diagnostic_crash_exception_code}}{{end}}{{if .metrickit_diagnostic_hang_hang_duration}} hang:{{.metrickit_diagnostic_hang_hang_duration}}{{end}}{{if .metrickit_diagnostic_cpu_exception_total_cpu_time}} cpu:{{.metrickit_diagnostic_cpu_exception_total_cpu_time}} sampled:{{.metrickit_diagnostic_cpu_exception_total_sampled_time}}{{end}}{{if .metrickit_diagnostic_disk_write_exception_total_writes_caused}} writes:{{.metrickit_diagnostic_disk_write_exception_total_writes_caused}}{{end}}{{if .metrickit_diagnostic_app_launch_launch_duration}} launch:{{.metrickit_diagnostic_app_launch_launch_duration}}{{end}}{{else}}{{__line__}}{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 21,
+          "links": [],
+          "title": "Logs — $session_id",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "displayedFields": [],
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": true
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-22": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=~\"${session_id}\" | event_name =~ \".+\" | event_name != \"exception\" | event_name != \"device.anr\" | line_format \"[{{.event_name}}]{{if .nav_destination}} {{.nav_previous_destination}} → {{.nav_destination}} ({{.nav_kind}}){{else if .app_screen_name}} → {{.app_screen_name}}{{end}}{{if .app_jank_frame_count}} frames:{{.app_jank_frame_count}} period:{{.app_jank_period}}ms{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 22,
+          "links": [],
+          "title": "Events — $session_id",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "displayedFields": [],
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": true
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-24": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=~\"${session_id}\" | detected_level=\"error\" | event_name=\"exception\" | line_format \"{{__line__}}{{if .exception_type}} [{{.exception_type}}{{if .exception_message}}: {{.exception_message}}{{end}}]{{end}}{{if .screen_name}} | screen:{{.screen_name}}{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Non-crash errors and caught exceptions — app continued running after these.",
+          "id": 24,
+          "links": [],
+          "title": "Errors & Handled Exceptions — $session_id",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "displayedFields": [],
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": true,
+                "wrapLogMessage": true
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-25": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=~\"${session_id}\" | event_name=\"device.crash\" | line_format \"[{{.exception_type}}]{{if .exception_message}} {{.exception_message}}{{end}} | screen:{{.screen_name}} | thread:{{.thread_name}} | battery:{{.battery_percent}}% heap:{{.heap_free}}b net:{{.network_connection_type}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Uncaught exceptions that caused the app to terminate (event_name=device.crash). Always on the main thread.",
+          "id": 25,
+          "links": [],
+          "title": "Crashes — $session_id",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "displayedFields": [],
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": true,
+                "wrapLogMessage": true
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-28": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | event_name=\"rum.sdk.init.started\" | session_id=~\".+\" | label_format device_model_name=\"{{or .device_model_name .device_model_identifier}}\", device_manufacturer=\"{{if .device_manufacturer}}{{.device_manufacturer}}{{else}}Apple{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | event_name=\"session.start\" | os_name=\"iOS\" | session_id=~\".+\" | label_format device_model_name=\"{{or .device_model_name .device_model_identifier}}\", device_manufacturer=\"{{if .device_manufacturer}}{{.device_manufacturer}}{{else}}Apple{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 1
+              },
+              "transformations": [
+                {
+                  "group": "extractFields",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "format": "json",
+                      "source": "labels"
+                    }
+                  }
+                },
+                {
+                  "group": "merge",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "group": "filterFieldsByName",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "names": [
+                          "session_id",
+                          "timestamp",
+                          "device_model_name",
+                          "device_manufacturer",
+                          "service_version",
+                          "os_version",
+                          "os_name"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "indexByName": {
+                        "device_manufacturer": 2,
+                        "device_model_name": 3,
+                        "os_name": 6,
+                        "os_version": 5,
+                        "service_version": 4,
+                        "session_id": 1,
+                        "timestamp": 0
+                      },
+                      "renameByName": {
+                        "device_manufacturer": "Manufacturer",
+                        "device_model_name": "Device",
+                        "os_name": "Platform",
+                        "os_version": "OS version",
+                        "service_version": "App version",
+                        "timestamp": "Session start"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Click a session ID to load it in the timeline below.",
+          "id": 28,
+          "links": [],
+          "title": "Sessions — click to select",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": false,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "links": [
+                    {
+                      "targetBlank": false,
+                      "title": "Select this session",
+                      "url": "/d/rofnlbb?${__url.params:exclude:var-session_id}&var-session_id=${__data.fields.session_id}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "OS version"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 102
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "App version"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 96
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Device"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 182
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Manufacturer"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 127
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "API level"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 86
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Session start"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 194
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "session_id"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 323
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": true,
+                "frameIndex": 0,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Session start"
+                  }
+                ]
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-38": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | event_name=\"rum.sdk.init.started\" | session_id=\"$session_id\" | label_format device_model_name=\"{{or .device_model_name .device_model_identifier}}\", device_manufacturer=\"{{if .device_manufacturer}}{{.device_manufacturer}}{{else}}Apple{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | event_name=\"session.start\" | os_name=\"iOS\" | session_id=\"$session_id\" | label_format device_model_name=\"{{or .device_model_name .device_model_identifier}}\", device_manufacturer=\"{{if .device_manufacturer}}{{.device_manufacturer}}{{else}}Apple{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 1
+              },
+              "transformations": [
+                {
+                  "group": "extractFields",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "format": "json",
+                      "source": "labels"
+                    }
+                  }
+                },
+                {
+                  "group": "merge",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "group": "filterFieldsByName",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "names": [
+                          "device_manufacturer",
+                          "device_model_name",
+                          "os_name",
+                          "os_version",
+                          "android_os_api_level",
+                          "service_version",
+                          "app_install_id",
+                          "telemetry_sdk_name",
+                          "telemetry_sdk_version",
+                          "telemetry_sdk_language",
+                          "network_connection_type"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "renameByName": {
+                        "android_os_api_level": "API Level",
+                        "app_install_id": "App Install ID",
+                        "device_manufacturer": "Manufacturer",
+                        "device_model_name": "Device",
+                        "network_connection_type": "Network",
+                        "os_name": "OS Name",
+                        "os_version": "OS Version",
+                        "service_version": "App Version",
+                        "telemetry_sdk_language": "SDK Language",
+                        "telemetry_sdk_name": "SDK Name",
+                        "telemetry_sdk_version": "SDK Version"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Metadata for the selected session.",
+          "id": 38,
+          "links": [],
+          "title": "Session Info — $session_id",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "left",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": false,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "frameIndex": 0,
+                "showHeader": true,
+                "sortBy": []
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-39": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "forward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=\"$session_id\" | line_format \"{{if or .event_name .name}}[{{or .event_name .name}}]{{if .nav_destination}} {{.nav_previous_destination}} → {{.nav_destination}} ({{.nav_kind}}){{else if .app_screen_name}} → {{.app_screen_name}}{{end}}{{if .exception_message}} {{.exception_type}}: {{.exception_message}}{{end}}{{if .app_jank_frame_count}} frames:{{.app_jank_frame_count}} period:{{.app_jank_period}}ms{{end}}{{if .metrickit_diagnostic_crash_exception_type}} signal:{{.metrickit_diagnostic_crash_exception_signal}} mach:{{.metrickit_diagnostic_crash_exception_mach_exception_type}} reason:{{.metrickit_diagnostic_crash_exception_code}}{{end}}{{if .metrickit_diagnostic_hang_hang_duration}} hang:{{.metrickit_diagnostic_hang_hang_duration}}{{end}}{{if .metrickit_diagnostic_cpu_exception_total_cpu_time}} cpu:{{.metrickit_diagnostic_cpu_exception_total_cpu_time}} sampled:{{.metrickit_diagnostic_cpu_exception_total_sampled_time}}{{end}}{{if .metrickit_diagnostic_disk_write_exception_total_writes_caused}} writes:{{.metrickit_diagnostic_disk_write_exception_total_writes_caused}}{{end}}{{if .metrickit_diagnostic_app_launch_launch_duration}} launch:{{.metrickit_diagnostic_app_launch_launch_duration}}{{end}}{{else}}{{__line__}}{{end}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "All log events for the selected session in chronological order. Shows the user's navigation path and what happened.",
+          "id": 39,
+          "links": [],
+          "title": "Session Timeline — $session_id",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "displayedFields": [],
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLevel": true,
+                "showLogAttributes": false,
+                "showTime": true,
+                "sortOrder": "Ascending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": true
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-60": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=~\"${session_id}\" | event_name=\"device.anr\" | line_format \"[device.anr]{{if .exception_type}} {{.exception_type}}{{if .exception_message}}: {{.exception_message}}{{end}}{{end}} | screen:{{.screen_name}} | thread:{{.thread_name}}\"",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "App Not Responding events (event_name=device.anr). Main thread blocked >5s.",
+          "id": 60,
+          "links": [],
+          "title": "ANRs — $session_id",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "displayedFields": [],
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": true,
+                "wrapLogMessage": true
+              }
+            },
+            "version": "13.1.0-24985018030"
+          }
+        }
+      },
+      "panel-73": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by(service_name) (count_over_time({service_name=~\"$service_name\"} | event_name=\"session.start\" [$__auto]))",
+                        "instant": false,
+                        "legendFormat": "{{service_name}} Sessions",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "count(sum by (unified_id) (count_over_time({service_name=~\"$service_name\"} | label_format unified_id=\"{{or .app_installation_id .device_id}}\" | unified_id=~\".+\" [$__auto])))",
+                        "instant": false,
+                        "legendFormat": "Active devices",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Number of session starts per time bucket — reflects app activity and user volume across iOS and Android",
+          "id": 73,
+          "links": [],
+          "title": "Sessions over time",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "super-light-green",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "always",
+                    "showValues": false,
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Active devices"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.axisPlacement",
+                        "value": "right"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "(?i).*ios.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "(?i).*android.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": true,
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-74": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(count_over_time({service_name=~\"$service_name\"} | logfmt | event_name=~\"exception|device.crash|device.anr\" [$__auto])) or vector(0)",
+                        "instant": false,
+                        "legendFormat": "Errors",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "(\n  count(\n    count_over_time(\n      {service_name=~\"$service_name\"}\n      | logfmt\n      | event_name=~\"exception|device.crash|device.anr\"\n      | keep session_id\n      [$__auto]\n    )\n  )\n  /\n  count(\n    count_over_time(\n      {service_name=~\"$service_name\"}\n      | logfmt\n      | session_id != \"\"\n      | keep session_id\n      [$__auto]\n    )\n  )\n) * 100 or vector(0)",
+                        "instant": false,
+                        "legendFormat": "Affected sessions",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Counts all log events where event_name matches:\n- **exception** — handled or unhandled exceptions\n- **device.crash** — application crashes\n- **device.anr** — Application Not Responding (ANR) events",
+          "id": 74,
+          "links": [],
+          "title": "Errors over time",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-red",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Errors"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 40
+                      },
+                      {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                      },
+                      {
+                        "id": "custom.showPoints",
+                        "value": "auto"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Affected sessions"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.axisPlacement",
+                        "value": "right"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "dash": [
+                            2,
+                            12
+                          ],
+                          "fill": "dash"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 10
+                      },
+                      {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                      },
+                      {
+                        "id": "custom.showPoints",
+                        "value": "auto"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": true,
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-75": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "count(sum by (session_id) (count_over_time({service_name=~\"$service_name\"} | session_id=~\".+\" [$__range])))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Count of unique session IDs — each represents a distinct app session",
+          "id": 75,
+          "links": [],
+          "title": "App Sessions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "super-light-green",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-76": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "count(sum by (unified_id) (count_over_time({service_name=~\"$service_name\"} | label_format unified_id=\"{{or .app_installation_id .device_id}}\" | unified_id=~\".+\" [$__auto])))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Unique devices seen in the selected time range, identified by app_installation_id (Android) or device_id (iOS)",
+          "id": 76,
+          "links": [],
+          "title": "Active Devices",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "purple",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-77": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum(count_over_time({service_name=~\"$service_name\"} | detected_level=\"error\" | event_name=\"exception\" [$__range]))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Count of handled exceptions (non-fatal) — event_name=exception with detected_level=error. App continued running after these.",
+          "id": 77,
+          "links": [],
+          "title": "Errors",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "orange",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "orange",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-78": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum(count_over_time({service_name=~\"$service_name\"} | event_name=\"device.crash\" [$__range]))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Count of uncaught exceptions that caused the app to crash (event_name=device.crash). Works for Android. iOS uses the same event name convention but this is unverified — no iOS crash data available yet to confirm.",
+          "id": 78,
+          "links": [],
+          "title": "Crashes",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-red",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-79": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum(count_over_time({service_name=~\"$service_name\"} | event_name=\"device.anr\" [$__range]))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "App Not Responding events — main thread blocked >5s (event_name=device.anr). Android-only. Severe UX failure: app freezes.",
+          "id": 79,
+          "links": [],
+          "title": "ANRs",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-orange",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-orange",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-80": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count(sum by (session_id) (count_over_time({service_name=~\"$service_name\"} | session_id=~\".+\" [$__range])))",
+                        "instant": true,
+                        "legendFormat": "total",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count(sum by (session_id) (count_over_time({service_name=~\"$service_name\"} | event_name=\"device.crash\" | session_id=~\".+\" [$__range])))",
+                        "instant": true,
+                        "legendFormat": "with_crashes",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "__expr__"
+                      },
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "(1 - ($B / $A)) * 100",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Percentage of sessions with zero crashes — quality SLO target (e.g., 97%). Crash detection uses event_name=device.crash. Works for Android; iOS crash detection unverified — update query if iOS uses a different event name.",
+          "id": 80,
+          "links": [],
+          "title": "Crash-Free Sessions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "max": 100,
+                  "min": 0,
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 90
+                      },
+                      {
+                        "color": "green",
+                        "value": 97
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-81": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count by (device_model_identifier)(sum by (unified_id, device_model_identifier)(count_over_time({service_name=~\"$service_name\"} | label_format unified_id=\"{{or .app_installation_id .device_id}}\" | unified_id=~\".+\" [$__range])))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Time": true
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Unique device count per device model identifier",
+          "id": 81,
+          "links": [],
+          "title": "📱 Devices by Model",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "device_model_identifier"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Device Model"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Devices"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Devices"
+                  }
+                ]
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-82": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count by (os_name, os_version_display)(sum by (unified_id, os_name, os_version_display)(count_over_time({service_name=~\"$service_name\"} | label_format unified_id=\"{{or .app_installation_id .device_id}}\", os_version_display=\"{{.os_version}}{{if .android_os_api_level}} ({{.android_os_api_level}}){{end}}\" | unified_id=~\".+\" [$__range])))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Time": true
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Unique device count per OS and version. API Level shown for Android rows.",
+          "id": 82,
+          "links": [],
+          "title": "📱 Devices by OS Version",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "os_name"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Platform"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "os_version_display"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "OS Version"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 160
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Devices"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 131
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Devices"
+                  }
+                ]
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-83": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count by (os_name, service_version)(sum by (unified_id, os_name, service_version)(count_over_time({service_name=~\"$service_name\"} | label_format unified_id=\"{{or .app_installation_id .device_id}}\" | unified_id=~\".+\" [$__range])))",
+                        "instant": true,
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Time": true
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Unique device count per app version",
+          "id": 83,
+          "links": [],
+          "title": "📱 App Versions",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "os_name"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Platform"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "service_version"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "App Version"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Devices"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Devices"
+                  }
+                ]
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-84": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by (exception_type) (count_over_time({service_name=~\"$service_name\"} | event_name=\"device.crash\" [$__auto]))",
+                        "instant": false,
+                        "legendFormat": "{{exception_type}}",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Breakdown of uncaught exceptions that caused the app to crash (event_name=device.crash), by exception type.",
+          "id": 84,
+          "links": [],
+          "title": "Crashes by Type",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#73BF69",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "percent",
+                  "value"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true,
+                  "values": [
+                    "value",
+                    "percent"
+                  ]
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-85": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by (exception_type) (count_over_time({service_name=~\"$service_name\"} | event_name=\"exception\" | exception_type=~\".+\" [$__auto]))",
+                        "instant": false,
+                        "legendFormat": "{{exception_type}}",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by (event_name) (count_over_time({service_name=~\"$service_name\"} | event_name=\"device.anr\" [$__auto]))",
+                        "instant": false,
+                        "legendFormat": "ANR",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Breakdown of non-crash errors and caught exceptions by type. Does not include crashes — those are in Crashes by Type.",
+          "id": 85,
+          "links": [],
+          "title": "Errors & Handled Exceptions by Type",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#73BF69",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "percent",
+                  "value"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true,
+                  "values": [
+                    "value",
+                    "percent"
+                  ]
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-86": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 86,
+          "links": [],
+          "title": "",
+          "transparent": true,
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "# 📱 Android & iOS Mobile Observability — OpenTelemetry RUM  \n\nReal User Monitoring for Android and iOS apps instrumented with the [OpenTelemetry Android SDK](https://github.com/open-telemetry/opentelemetry-android) and [OpenTelemetry Swift](https://github.com/open-telemetry/opentelemetry-swift).  \n\n---  \n\n## 🗂️ Tabs  \n\n**Overview** — Session volume, errors, crashes, ANRs, device breakdown. Daily health check. ANRs are Android-only and always 0 for iOS.  \n\n**Session Explorer** — Lists all sessions. Click a row to set the Session ID filter and drill into a single user session across all other tabs.  \n\n**Traces / Logs / Events / Errors / Crashes / ANRs** — Per-signal views, filtered to the selected session when a Session ID is set.  \n\n---  \n\n## ⚙️ Setup  \n\n**Mobile service names** — This dashboard filters on the OpenTelemetry resource attribute `service.name`.\n\nEdit the `Mobile service names` dashboard variable and add the `service.name` values for your Android and iOS apps, for example `my-app-android, my-app-ios`. You can also type a service name directly into the dropdown because custom values are enabled.\n\nThis list is intentionally configured manually. Grafana Cloud stacks often contain backend services in the same Loki/Tempo data sources, so an automatic `service_name` dropdown would include unrelated services.  \n\n**Session ID** — Set automatically when clicking a session row. Paste a known ID to jump directly to a session.  \n\n**OTLP endpoint** — Both SDKs send data via OTLP. Configure `OTLP_ENDPOINT` and `OTLP_AUTH_HEADER` in your app. See [Send data via OTLP](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/).  \n\n---  \n\n## 📚 Further Reading  \n\n| Topic | Link |  \n|---|---|  \n| OpenTelemetry Android SDK | [open-telemetry/opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android) |  \n| OpenTelemetry Swift SDK | [open-telemetry/opentelemetry-swift](https://github.com/open-telemetry/opentelemetry-swift) |  \n| OTel concepts | [opentelemetry.io/docs](https://opentelemetry.io/docs/) |  ",
+                "mode": "markdown"
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      },
+      "panel-87": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "expr": "{service_name=~\"$service_name\"} | event_name=~\"exception|device.crash|device.anr\" | line_format \"[{{.os_name}}|{{.event_name}}]{{if .exception_type}} {{.exception_type}}{{if .exception_message}}: {{.exception_message}}{{end}}{{end}}{{if .screen_name}} | screen:{{.screen_name}}{{end}}\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Last 10 errors, crashes, and ANRs across selected services. Click a row to expand details.",
+          "id": 87,
+          "links": [],
+          "title": "🔴 Most Recent Errors",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showLogAttributes": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.1.0-25544626454"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "TabsLayout",
+      "spec": {
+        "tabs": [
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-1"
+                        },
+                        "height": 4,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-73"
+                        },
+                        "height": 8,
+                        "width": 24,
+                        "x": 0,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-74"
+                        },
+                        "height": 7,
+                        "width": 24,
+                        "x": 0,
+                        "y": 12
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-75"
+                        },
+                        "height": 4,
+                        "width": 12,
+                        "x": 0,
+                        "y": 19
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-76"
+                        },
+                        "height": 4,
+                        "width": 12,
+                        "x": 12,
+                        "y": 19
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-77"
+                        },
+                        "height": 4,
+                        "width": 6,
+                        "x": 0,
+                        "y": 23
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-78"
+                        },
+                        "height": 4,
+                        "width": 6,
+                        "x": 6,
+                        "y": 23
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-79"
+                        },
+                        "height": 4,
+                        "width": 6,
+                        "x": 12,
+                        "y": 23
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-80"
+                        },
+                        "height": 4,
+                        "width": 6,
+                        "x": 18,
+                        "y": 23
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-81"
+                        },
+                        "height": 6,
+                        "width": 8,
+                        "x": 0,
+                        "y": 27
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-82"
+                        },
+                        "height": 6,
+                        "width": 8,
+                        "x": 8,
+                        "y": 27
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-83"
+                        },
+                        "height": 6,
+                        "width": 8,
+                        "x": 16,
+                        "y": 27
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-84"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 33
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-85"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 33
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-87"
+                        },
+                        "height": 8,
+                        "width": 24,
+                        "x": 0,
+                        "y": 41
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Overview"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-28"
+                        },
+                        "height": 10,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-38"
+                        },
+                        "height": 4,
+                        "width": 24,
+                        "x": 0,
+                        "y": 10
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-39"
+                        },
+                        "height": 21,
+                        "width": 24,
+                        "x": 0,
+                        "y": 14
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Session Explorer"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "fillScreen": true,
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-20"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Traces"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "fillScreen": true,
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-21"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Logs"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "fillScreen": true,
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-22"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Events"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "fillScreen": true,
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-24"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Errors"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "fillScreen": true,
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-25"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "tall"
+                }
+              },
+              "title": "Crashes"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "fillScreen": true,
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-60"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "ANRs"
+            }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-86"
+                        },
+                        "height": 40,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "ℹ️ About"
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preferences": {
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": []
+        }
+      }
+    },
+    "preload": false,
+    "tags": [
+      "mobile",
+      "opentelemetry",
+      "rum"
+    ],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-7d",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "Mobile OTel RUM Dashboard",
+    "variables": [
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": [
+              "quickpizza-android",
+              "quickpizza-ios"
+            ],
+            "value": [
+              "quickpizza-android",
+              "quickpizza-ios"
+            ]
+          },
+          "hide": "dontHide",
+          "includeAll": true,
+          "label": "Mobile service names",
+          "multi": true,
+          "name": "service_name",
+          "options": [],
+          "query": "quickpizza-android, quickpizza-ios",
+          "skipUrlSync": false,
+          "valuesFormat": "csv"
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "hide": "dontHide",
+          "label": "Session ID",
+          "name": "session_id",
+          "query": "",
+          "skipUrlSync": false
+        }
+      }
+    ]
+  }
+}

--- a/Mobiles/dashboards/mobile-otel-rum-dashboard.json
+++ b/Mobiles/dashboards/mobile-otel-rum-dashboard.json
@@ -1756,7 +1756,7 @@
               "transformations": []
             }
           },
-          "description": "Count of uncaught exceptions that caused the app to crash (event_name=device.crash). Works for Android. iOS uses the same event name convention but this is unverified \u2014 no iOS crash data available yet to confirm.",
+          "description": "Counts Android crash events reported as event_name=\"device.crash\". iOS OpenTelemetry crash diagnostics are delivered through MetricKit and are not currently included until their event shape is verified.",
           "id": 78,
           "links": [],
           "title": "Crashes",
@@ -1962,7 +1962,7 @@
               "transformations": []
             }
           },
-          "description": "Percentage of sessions with zero crashes \u2014 quality SLO target (e.g., 97%). Crash detection uses event_name=device.crash. Works for Android; iOS crash detection unverified \u2014 update query if iOS uses a different event name.",
+          "description": "Percentage of sessions without Android event_name=\"device.crash\" events. iOS OpenTelemetry crash diagnostics are delivered through MetricKit and are not currently included, so this panel should not be used as an iOS crash-free SLO yet.",
           "id": 80,
           "links": [],
           "title": "Crash-Free Sessions",
@@ -2492,7 +2492,7 @@
               "transformations": []
             }
           },
-          "description": "Breakdown of uncaught exceptions that caused the app to crash (event_name=device.crash), by exception type.",
+          "description": "Breakdown of Android crash events reported as event_name=\"device.crash\", by exception type. iOS MetricKit crash diagnostics are not currently included.",
           "id": 84,
           "links": [],
           "title": "Crashes by Type",

--- a/Mobiles/dashboards/mobile-otel-rum-dashboard.json
+++ b/Mobiles/dashboards/mobile-otel-rum-dashboard.json
@@ -59,7 +59,7 @@
                   "showLineNumbers": false,
                   "showMiniMap": false
                 },
-                "content": "<div style=\"background:linear-gradient(135deg,#0d1117,#161b22);border-radius:8px;padding:16px 24px;display:flex;align-items:center;gap:16px;box-shadow:0 2px 12px rgba(0,0,0,0.5);border-left:4px solid #f5a800\"><div style=\"font-size:48px\">📱</div><div><div style=\"font-size:22px;font-weight:700;color:#fff\">Android &amp; iOS OTel App Observability</div><div style=\"font-size:13px;color:rgba(255,255,255,0.75);margin-top:6px\">Observability for mobile apps instrumented with <a href=\"https://github.com/open-telemetry/opentelemetry-android\" target=\"_blank\" style=\"color:#3DDC84;text-decoration:none;font-weight:600\">OpenTelemetry Android</a> and <a href=\"https://github.com/open-telemetry/opentelemetry-swift\" target=\"_blank\" style=\"color:#007AFF;text-decoration:none;font-weight:600\">OpenTelemetry Swift</a></div></div></div>",
+                "content": "<div style=\"background:linear-gradient(135deg,#0d1117,#161b22);border-radius:8px;padding:16px 24px;display:flex;align-items:center;gap:16px;box-shadow:0 2px 12px rgba(0,0,0,0.5);border-left:4px solid #f5a800\"><div style=\"font-size:48px\">\ud83d\udcf1</div><div><div style=\"font-size:22px;font-weight:700;color:#fff\">Android &amp; iOS OTel App Observability</div><div style=\"font-size:13px;color:rgba(255,255,255,0.75);margin-top:6px\">Observability for mobile apps instrumented with <a href=\"https://github.com/open-telemetry/opentelemetry-android\" target=\"_blank\" style=\"color:#3DDC84;text-decoration:none;font-weight:600\">OpenTelemetry Android</a> and <a href=\"https://github.com/open-telemetry/opentelemetry-swift\" target=\"_blank\" style=\"color:#007AFF;text-decoration:none;font-weight:600\">OpenTelemetry Swift</a></div></div></div>",
                 "mode": "html"
               }
             },
@@ -103,10 +103,10 @@
               "transformations": []
             }
           },
-          "description": "Traces from the QuickPizza Android app. Filtered by the selected Session ID — shows all traces when no Session ID is set.",
+          "description": "Traces from the QuickPizza Android app. Filtered by the selected Session ID \u2014 shows all traces when no Session ID is set.",
           "id": 20,
           "links": [],
-          "title": "Traces — $session_id",
+          "title": "Traces \u2014 $session_id",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -161,15 +161,15 @@
                             "options": {
                               "error": {
                                 "color": "red",
-                                "text": "❌ Error"
+                                "text": "\u274c Error"
                               },
                               "ok": {
                                 "color": "green",
-                                "text": "✅ OK"
+                                "text": "\u2705 OK"
                               },
                               "unset": {
                                 "color": "text",
-                                "text": "— Unset"
+                                "text": "\u2014 Unset"
                               }
                             },
                             "type": "value"
@@ -228,7 +228,7 @@
           "description": "",
           "id": 21,
           "links": [],
-          "title": "Logs — $session_id",
+          "title": "Logs \u2014 $session_id",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -280,7 +280,7 @@
                       "spec": {
                         "direction": "backward",
                         "editorMode": "code",
-                        "expr": "{service_name=~\"$service_name\"} | session_id=~\"${session_id}\" | event_name =~ \".+\" | event_name != \"exception\" | event_name != \"device.anr\" | line_format \"[{{.event_name}}]{{if .nav_destination}} {{.nav_previous_destination}} → {{.nav_destination}} ({{.nav_kind}}){{else if .app_screen_name}} → {{.app_screen_name}}{{end}}{{if .app_jank_frame_count}} frames:{{.app_jank_frame_count}} period:{{.app_jank_period}}ms{{end}}\"",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=~\"${session_id}\" | event_name =~ \".+\" | event_name != \"exception\" | event_name != \"device.anr\" | line_format \"[{{.event_name}}]{{if .nav_destination}} {{.nav_previous_destination}} \u2192 {{.nav_destination}} ({{.nav_kind}}){{else if .app_screen_name}} \u2192 {{.app_screen_name}}{{end}}{{if .app_jank_frame_count}} frames:{{.app_jank_frame_count}} period:{{.app_jank_period}}ms{{end}}\"",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -298,7 +298,7 @@
           "description": "",
           "id": 22,
           "links": [],
-          "title": "Events — $session_id",
+          "title": "Events \u2014 $session_id",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -365,10 +365,10 @@
               "transformations": []
             }
           },
-          "description": "Non-crash errors and caught exceptions — app continued running after these.",
+          "description": "Non-crash errors and caught exceptions \u2014 app continued running after these.",
           "id": 24,
           "links": [],
-          "title": "Errors & Handled Exceptions — $session_id",
+          "title": "Errors & Handled Exceptions \u2014 $session_id",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -438,7 +438,7 @@
           "description": "Uncaught exceptions that caused the app to terminate (event_name=device.crash). Always on the main thread.",
           "id": 25,
           "links": [],
-          "title": "Crashes — $session_id",
+          "title": "Crashes \u2014 $session_id",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -595,7 +595,7 @@
           "description": "Click a session ID to load it in the timeline below.",
           "id": 28,
           "links": [],
-          "title": "Sessions — click to select",
+          "title": "Sessions \u2014 click to select",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -617,7 +617,7 @@
                     {
                       "targetBlank": false,
                       "title": "Select this session",
-                      "url": "/d/rofnlbb?${__url.params:exclude:var-session_id}&var-session_id=${__data.fields.session_id}"
+                      "url": "/d/${__dashboard.uid}?${__url.params:exclude:var-session_id}&var-session_id=${__data.fields.session_id}"
                     }
                   ],
                   "thresholds": {
@@ -863,7 +863,7 @@
           "description": "Metadata for the selected session.",
           "id": 38,
           "links": [],
-          "title": "Session Info — $session_id",
+          "title": "Session Info \u2014 $session_id",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -929,7 +929,7 @@
                       "spec": {
                         "direction": "forward",
                         "editorMode": "code",
-                        "expr": "{service_name=~\"$service_name\"} | session_id=\"$session_id\" | line_format \"{{if or .event_name .name}}[{{or .event_name .name}}]{{if .nav_destination}} {{.nav_previous_destination}} → {{.nav_destination}} ({{.nav_kind}}){{else if .app_screen_name}} → {{.app_screen_name}}{{end}}{{if .exception_message}} {{.exception_type}}: {{.exception_message}}{{end}}{{if .app_jank_frame_count}} frames:{{.app_jank_frame_count}} period:{{.app_jank_period}}ms{{end}}{{if .metrickit_diagnostic_crash_exception_type}} signal:{{.metrickit_diagnostic_crash_exception_signal}} mach:{{.metrickit_diagnostic_crash_exception_mach_exception_type}} reason:{{.metrickit_diagnostic_crash_exception_code}}{{end}}{{if .metrickit_diagnostic_hang_hang_duration}} hang:{{.metrickit_diagnostic_hang_hang_duration}}{{end}}{{if .metrickit_diagnostic_cpu_exception_total_cpu_time}} cpu:{{.metrickit_diagnostic_cpu_exception_total_cpu_time}} sampled:{{.metrickit_diagnostic_cpu_exception_total_sampled_time}}{{end}}{{if .metrickit_diagnostic_disk_write_exception_total_writes_caused}} writes:{{.metrickit_diagnostic_disk_write_exception_total_writes_caused}}{{end}}{{if .metrickit_diagnostic_app_launch_launch_duration}} launch:{{.metrickit_diagnostic_app_launch_launch_duration}}{{end}}{{else}}{{__line__}}{{end}}\"",
+                        "expr": "{service_name=~\"$service_name\"} | session_id=\"$session_id\" | line_format \"{{if or .event_name .name}}[{{or .event_name .name}}]{{if .nav_destination}} {{.nav_previous_destination}} \u2192 {{.nav_destination}} ({{.nav_kind}}){{else if .app_screen_name}} \u2192 {{.app_screen_name}}{{end}}{{if .exception_message}} {{.exception_type}}: {{.exception_message}}{{end}}{{if .app_jank_frame_count}} frames:{{.app_jank_frame_count}} period:{{.app_jank_period}}ms{{end}}{{if .metrickit_diagnostic_crash_exception_type}} signal:{{.metrickit_diagnostic_crash_exception_signal}} mach:{{.metrickit_diagnostic_crash_exception_mach_exception_type}} reason:{{.metrickit_diagnostic_crash_exception_code}}{{end}}{{if .metrickit_diagnostic_hang_hang_duration}} hang:{{.metrickit_diagnostic_hang_hang_duration}}{{end}}{{if .metrickit_diagnostic_cpu_exception_total_cpu_time}} cpu:{{.metrickit_diagnostic_cpu_exception_total_cpu_time}} sampled:{{.metrickit_diagnostic_cpu_exception_total_sampled_time}}{{end}}{{if .metrickit_diagnostic_disk_write_exception_total_writes_caused}} writes:{{.metrickit_diagnostic_disk_write_exception_total_writes_caused}}{{end}}{{if .metrickit_diagnostic_app_launch_launch_duration}} launch:{{.metrickit_diagnostic_app_launch_launch_duration}}{{end}}{{else}}{{__line__}}{{end}}\"",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -947,7 +947,7 @@
           "description": "All log events for the selected session in chronological order. Shows the user's navigation path and what happened.",
           "id": 39,
           "links": [],
-          "title": "Session Timeline — $session_id",
+          "title": "Session Timeline \u2014 $session_id",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -1015,7 +1015,7 @@
           "description": "App Not Responding events (event_name=device.anr). Main thread blocked >5s.",
           "id": 60,
           "links": [],
-          "title": "ANRs — $session_id",
+          "title": "ANRs \u2014 $session_id",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -1107,7 +1107,7 @@
               "transformations": []
             }
           },
-          "description": "Number of session starts per time bucket — reflects app activity and user volume across iOS and Android",
+          "description": "Number of session starts per time bucket \u2014 reflects app activity and user volume across iOS and Android",
           "id": 73,
           "links": [],
           "title": "Sessions over time",
@@ -1293,7 +1293,7 @@
               "transformations": []
             }
           },
-          "description": "Counts all log events where event_name matches:\n- **exception** — handled or unhandled exceptions\n- **device.crash** — application crashes\n- **device.anr** — Application Not Responding (ANR) events",
+          "description": "Counts all log events where event_name matches:\n- **exception** \u2014 handled or unhandled exceptions\n- **device.crash** \u2014 application crashes\n- **device.anr** \u2014 Application Not Responding (ANR) events",
           "id": 74,
           "links": [],
           "title": "Errors over time",
@@ -1508,7 +1508,7 @@
               "transformations": []
             }
           },
-          "description": "Count of unique session IDs — each represents a distinct app session",
+          "description": "Count of unique session IDs \u2014 each represents a distinct app session",
           "id": 75,
           "links": [],
           "title": "App Sessions",
@@ -1674,7 +1674,7 @@
               "transformations": []
             }
           },
-          "description": "Count of handled exceptions (non-fatal) — event_name=exception with detected_level=error. App continued running after these.",
+          "description": "Count of handled exceptions (non-fatal) \u2014 event_name=exception with detected_level=error. App continued running after these.",
           "id": 77,
           "links": [],
           "title": "Errors",
@@ -1756,7 +1756,7 @@
               "transformations": []
             }
           },
-          "description": "Count of uncaught exceptions that caused the app to crash (event_name=device.crash). Works for Android. iOS uses the same event name convention but this is unverified — no iOS crash data available yet to confirm.",
+          "description": "Count of uncaught exceptions that caused the app to crash (event_name=device.crash). Works for Android. iOS uses the same event name convention but this is unverified \u2014 no iOS crash data available yet to confirm.",
           "id": 78,
           "links": [],
           "title": "Crashes",
@@ -1838,7 +1838,7 @@
               "transformations": []
             }
           },
-          "description": "App Not Responding events — main thread blocked >5s (event_name=device.anr). Android-only. Severe UX failure: app freezes.",
+          "description": "App Not Responding events \u2014 main thread blocked >5s (event_name=device.anr). Android-only. Severe UX failure: app freezes.",
           "id": 79,
           "links": [],
           "title": "ANRs",
@@ -1962,7 +1962,7 @@
               "transformations": []
             }
           },
-          "description": "Percentage of sessions with zero crashes — quality SLO target (e.g., 97%). Crash detection uses event_name=device.crash. Works for Android; iOS crash detection unverified — update query if iOS uses a different event name.",
+          "description": "Percentage of sessions with zero crashes \u2014 quality SLO target (e.g., 97%). Crash detection uses event_name=device.crash. Works for Android; iOS crash detection unverified \u2014 update query if iOS uses a different event name.",
           "id": 80,
           "links": [],
           "title": "Crash-Free Sessions",
@@ -2070,7 +2070,7 @@
           "description": "Unique device count per device model identifier",
           "id": 81,
           "links": [],
-          "title": "📱 Devices by Model",
+          "title": "\ud83d\udcf1 Devices by Model",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -2204,7 +2204,7 @@
           "description": "Unique device count per OS and version. API Level shown for Android rows.",
           "id": 82,
           "links": [],
-          "title": "📱 Devices by OS Version",
+          "title": "\ud83d\udcf1 Devices by OS Version",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -2358,7 +2358,7 @@
           "description": "Unique device count per app version",
           "id": 83,
           "links": [],
-          "title": "📱 App Versions",
+          "title": "\ud83d\udcf1 App Versions",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -2610,7 +2610,7 @@
               "transformations": []
             }
           },
-          "description": "Breakdown of non-crash errors and caught exceptions by type. Does not include crashes — those are in Crashes by Type.",
+          "description": "Breakdown of non-crash errors and caught exceptions by type. Does not include crashes \u2014 those are in Crashes by Type.",
           "id": 85,
           "links": [],
           "title": "Errors & Handled Exceptions by Type",
@@ -2698,7 +2698,7 @@
                   "showLineNumbers": false,
                   "showMiniMap": false
                 },
-                "content": "# 📱 Android & iOS Mobile Observability — OpenTelemetry RUM  \n\nReal User Monitoring for Android and iOS apps instrumented with the [OpenTelemetry Android SDK](https://github.com/open-telemetry/opentelemetry-android) and [OpenTelemetry Swift](https://github.com/open-telemetry/opentelemetry-swift).  \n\n---  \n\n## 🗂️ Tabs  \n\n**Overview** — Session volume, errors, crashes, ANRs, device breakdown. Daily health check. ANRs are Android-only and always 0 for iOS.  \n\n**Session Explorer** — Lists all sessions. Click a row to set the Session ID filter and drill into a single user session across all other tabs.  \n\n**Traces / Logs / Events / Errors / Crashes / ANRs** — Per-signal views, filtered to the selected session when a Session ID is set.  \n\n---  \n\n## ⚙️ Setup  \n\n**Mobile service names** — This dashboard filters on the OpenTelemetry resource attribute `service.name`.\n\nEdit the `Mobile service names` dashboard variable and add the `service.name` values for your Android and iOS apps, for example `my-app-android, my-app-ios`. You can also type a service name directly into the dropdown because custom values are enabled.\n\nThis list is intentionally configured manually. Grafana Cloud stacks often contain backend services in the same Loki/Tempo data sources, so an automatic `service_name` dropdown would include unrelated services.  \n\n**Session ID** — Set automatically when clicking a session row. Paste a known ID to jump directly to a session.  \n\n**OTLP endpoint** — Both SDKs send data via OTLP. Configure `OTLP_ENDPOINT` and `OTLP_AUTH_HEADER` in your app. See [Send data via OTLP](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/).  \n\n---  \n\n## 📚 Further Reading  \n\n| Topic | Link |  \n|---|---|  \n| OpenTelemetry Android SDK | [open-telemetry/opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android) |  \n| OpenTelemetry Swift SDK | [open-telemetry/opentelemetry-swift](https://github.com/open-telemetry/opentelemetry-swift) |  \n| OTel concepts | [opentelemetry.io/docs](https://opentelemetry.io/docs/) |  ",
+                "content": "# \ud83d\udcf1 Android & iOS Mobile Observability \u2014 OpenTelemetry RUM  \n\nReal User Monitoring for Android and iOS apps instrumented with the [OpenTelemetry Android SDK](https://github.com/open-telemetry/opentelemetry-android) and [OpenTelemetry Swift](https://github.com/open-telemetry/opentelemetry-swift).  \n\n---  \n\n## \ud83d\uddc2\ufe0f Tabs  \n\n**Overview** \u2014 Session volume, errors, crashes, ANRs, device breakdown. Daily health check. ANRs are Android-only and always 0 for iOS.  \n\n**Session Explorer** \u2014 Lists all sessions. Click a row to set the Session ID filter and drill into a single user session across all other tabs.  \n\n**Traces / Logs / Events / Errors / Crashes / ANRs** \u2014 Per-signal views, filtered to the selected session when a Session ID is set.  \n\n---  \n\n## \u2699\ufe0f Setup  \n\n**Mobile service names** \u2014 This dashboard filters on the OpenTelemetry resource attribute `service.name`.\n\nEdit the `Mobile service names` dashboard variable and add the `service.name` values for your Android and iOS apps, for example `my-app-android, my-app-ios`. You can also type a service name directly into the dropdown because custom values are enabled.\n\nThis list is intentionally configured manually. Grafana Cloud stacks often contain backend services in the same Loki/Tempo data sources, so an automatic `service_name` dropdown would include unrelated services.  \n\n**Session ID** \u2014 Set automatically when clicking a session row. Paste a known ID to jump directly to a session.  \n\n**OTLP endpoint** \u2014 Both SDKs send data via OTLP. Configure `OTLP_ENDPOINT` and `OTLP_AUTH_HEADER` in your app. See [Send data via OTLP](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/).  \n\n---  \n\n## \ud83d\udcda Further Reading  \n\n| Topic | Link |  \n|---|---|  \n| OpenTelemetry Android SDK | [open-telemetry/opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android) |  \n| OpenTelemetry Swift SDK | [open-telemetry/opentelemetry-swift](https://github.com/open-telemetry/opentelemetry-swift) |  \n| OTel concepts | [opentelemetry.io/docs](https://opentelemetry.io/docs/) |  ",
                 "mode": "markdown"
               }
             },
@@ -2741,7 +2741,7 @@
           "description": "Last 10 errors, crashes, and ANRs across selected services. Click a row to expand details.",
           "id": 87,
           "links": [],
-          "title": "🔴 Most Recent Errors",
+          "title": "\ud83d\udd34 Most Recent Errors",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -3216,7 +3216,7 @@
                   ]
                 }
               },
-              "title": "ℹ️ About"
+              "title": "\u2139\ufe0f About"
             }
           }
         ]
@@ -3281,8 +3281,7 @@
           "name": "service_name",
           "options": [],
           "query": "quickpizza-android, quickpizza-ios",
-          "skipUrlSync": false,
-          "valuesFormat": "csv"
+          "skipUrlSync": false
         }
       },
       {

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -81,7 +81,7 @@ Common feature set:
 | --- | --- |
 | Flutter | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
 | React Native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
-| iOS native | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) (and an iOS-specific dashboard) on your Grafana Cloud stack |
+| iOS native | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) on your Grafana Cloud stack |
 | Android native | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) on your Grafana Cloud stack |
 
 Underlying datasources on whichever Grafana Cloud stack you target:
@@ -94,7 +94,7 @@ Underlying datasources on whichever Grafana Cloud stack you target:
   for log records, both labeled with `service_name` / `service_namespace`.
 
 The Frontend Observability plugin queries Loki for Faro-shaped data; the
-"Android & iOS OTel RUM" dashboard queries Tempo + Loki for OTel-shaped data.
+Mobile OTel RUM dashboard queries Tempo + Loki for OTel-shaped data.
 To import and configure the reusable dashboard, see
 [`MOBILE_OTEL_RUM_DASHBOARD.md`](./MOBILE_OTEL_RUM_DASHBOARD.md).
 
@@ -255,7 +255,7 @@ events.
 | Auto perf metrics | `app_memory`, `app_cpu_usage`, `app_frames_rate`, `app_frozen_frame`, `app_startup` (both) | _None on iOS_; `app.jank` events on Android |
 | Crashes | Native crash → `kind=exception, type=crash` (FaroCrashKit) | iOS: MetricKit (delayed); Android: `device.crash` event (next launch) |
 | Where to query | Frontend Observability plugin (Loki under the hood) | Tempo + Loki via Explore + custom dashboards |
-| Where to view | Frontend Observability plugin (per-app drilldown UI) | "Android & iOS OTel RUM" dashboard |
+| Where to view | Frontend Observability plugin (per-app drilldown UI) | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) |
 | User context | `user_id` / `user_username` (Faro auto when set via SDK) | Not yet attached on every signal — `enduser.id` is the OTel attribute to use; tracked in [#48](https://github.com/grafana/mobile-o11y-demo/issues/48) / [`OTEL_MOBILE_MATURITY.md` § M-001](./OTEL_MOBILE_MATURITY.md#m-001--no-first-class-user-context-enduserid-on-mobile-sdks) |
 
 ---

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -81,8 +81,8 @@ Common feature set:
 | --- | --- |
 | Flutter | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
 | React Native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
-| iOS native | "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard) on your Grafana Cloud stack |
-| Android native | "Android & iOS OTel RUM" dashboard on your Grafana Cloud stack |
+| iOS native | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) (and an iOS-specific dashboard) on your Grafana Cloud stack |
+| Android native | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) on your Grafana Cloud stack |
 
 Underlying datasources on whichever Grafana Cloud stack you target:
 
@@ -95,6 +95,8 @@ Underlying datasources on whichever Grafana Cloud stack you target:
 
 The Frontend Observability plugin queries Loki for Faro-shaped data; the
 "Android & iOS OTel RUM" dashboard queries Tempo + Loki for OTel-shaped data.
+To import and configure the reusable dashboard, see
+[`MOBILE_OTEL_RUM_DASHBOARD.md`](./MOBILE_OTEL_RUM_DASHBOARD.md).
 
 ---
 

--- a/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
+++ b/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
@@ -25,11 +25,11 @@ Grafana 13 or later.
 - Grafana 13 or later.
 - A Grafana Cloud stack with OTLP ingest enabled for logs and traces.
 - Native Android or iOS telemetry collected with the [OpenTelemetry Android SDK](https://github.com/open-telemetry/opentelemetry-android) or [OpenTelemetry Swift](https://github.com/open-telemetry/opentelemetry-swift), shaped like the QuickPizza demo apps.
-- A Loki data source with UID `grafanacloud-logs`.
-- A Tempo data source with UID `grafanacloud-traces`.
+- A Loki data source named `grafanacloud-logs`.
+- A Tempo data source named `grafanacloud-traces`.
 
-Grafana Cloud stacks commonly use these data source UIDs. If your stack or OSS
-Grafana instance uses different UIDs, update the data source references after
+Grafana Cloud stacks commonly use these data source names. If your stack or OSS
+Grafana instance uses different names, update the data source references after
 import.
 
 ## Import the Dashboard
@@ -115,7 +115,7 @@ If the dashboard is empty:
   endpoint.
 - Confirm that the OTLP credentials allow `logs:write` and `traces:write`.
 - Confirm that the dashboard points at the correct Loki and Tempo data source
-  UIDs.
+  names.
 
 For Android, use the Debug tab to emit a debug log, handled exception, ANR, or
 crash event. For iOS, use the Debug tab to emit logs and handled exceptions.

--- a/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
+++ b/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
@@ -55,6 +55,10 @@ Edit that variable and replace the demo values with the OpenTelemetry
 my-app-android, my-app-ios
 ```
 
+The default values (`quickpizza-android`, `quickpizza-ios`) are from the
+QuickPizza demo apps. Replace them after import unless you are viewing the demo
+stack.
+
 The list is intentionally manual. Grafana Cloud stacks often contain backend
 services in the same Loki and Tempo data sources, so automatic service
 discovery would include unrelated services.

--- a/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
+++ b/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
@@ -1,0 +1,122 @@
+# Mobile OTel RUM Dashboard
+
+This guide explains how to import and configure the reusable Mobile OTel RUM
+dashboard for native Android and iOS apps that send OpenTelemetry logs and
+traces to Grafana Cloud.
+
+The dashboard is a lightweight RUM-style view for mobile telemetry while
+Frontend Observability does not ingest native OTLP mobile data directly. It
+queries the stack's Loki and Tempo data sources, which are populated through
+Grafana Cloud OTLP ingest.
+
+## Dashboard Artifact
+
+The dashboard JSON lives at:
+
+```text
+Mobiles/dashboards/mobile-otel-rum-dashboard.json
+```
+
+It uses Grafana's dashboard resource format and a tabbed layout, so it requires
+Grafana 13 or later.
+
+## Requirements
+
+- Grafana 13 or later.
+- A Grafana Cloud stack with OTLP ingest enabled for logs and traces.
+- Native Android or iOS telemetry shaped like the QuickPizza demo apps.
+- A Loki data source with UID `grafanacloud-logs`.
+- A Tempo data source with UID `grafanacloud-traces`.
+
+Grafana Cloud stacks commonly use these data source UIDs. If your stack or OSS
+Grafana instance uses different UIDs, update the data source references after
+import.
+
+## Import the Dashboard
+
+1. Open your Grafana stack.
+2. Go to **Dashboards**.
+3. Select **New** and then **Import dashboard**.
+4. Upload or paste `Mobiles/dashboards/mobile-otel-rum-dashboard.json`.
+5. Save the dashboard.
+
+If you manage Grafana resources as code, you can also push the JSON resource
+with `gcx` or Git Sync.
+
+## Configure Mobile Service Names
+
+The dashboard uses a custom multi-value variable named `service_name`, labeled
+**Mobile service names**.
+
+Edit that variable and replace the demo values with the OpenTelemetry
+`service.name` values for your apps. For example:
+
+```text
+my-app-android, my-app-ios
+```
+
+The list is intentionally manual. Grafana Cloud stacks often contain backend
+services in the same Loki and Tempo data sources, so automatic service
+discovery would include unrelated services.
+
+You can also type a service name directly into the dropdown because custom
+values are enabled.
+
+## Expected Telemetry Shape
+
+The dashboard expects the same broad telemetry contract used by the native
+QuickPizza demo apps.
+
+Every signal should include these OpenTelemetry resource attributes:
+
+```text
+service.name
+service.namespace
+service.version
+deployment.environment
+```
+
+Session-aware views expect session attributes to be present. In Grafana Cloud
+Loki queries, `session.id` is available as `session_id`.
+
+Android signals from `opentelemetry-android` include events such as:
+
+- `screen.view`
+- `app.jank`
+- `session.start`
+- `rum.sdk.init.*`
+- `exception`
+- `device.crash`
+- `device.anr`
+
+iOS signals from OpenTelemetry Swift plus the QuickPizza app instrumentation
+include:
+
+- `app.screen.view`
+- `session.start`
+- `exception`
+- MetricKit crash, hang, CPU, disk-write, and app-launch diagnostics
+- URLSession spans
+- manual business spans such as `pizza.get_recommendation`, `auth.login`, and
+  `pizza.rate`
+
+For platform-specific setup details, see:
+
+- [Android Native Setup Guide](./ANDROID_NATIVE_SETUP.md)
+- [iOS OpenTelemetry Instrumentation Guide](./IOS_OBSERVABILITY_OTEL_GUIDE.md)
+
+## Troubleshooting
+
+If the dashboard is empty:
+
+- Confirm that the selected time range contains recent telemetry.
+- Confirm that **Mobile service names** matches your app's `service.name`.
+- Confirm that the app is exporting OTLP over HTTP to the correct Grafana Cloud
+  endpoint.
+- Confirm that the OTLP credentials allow `logs:write` and `traces:write`.
+- Confirm that the dashboard points at the correct Loki and Tempo data source
+  UIDs.
+
+For Android, use the Debug tab to emit a debug log, handled exception, ANR, or
+crash event. For iOS, use the Debug tab to emit logs and handled exceptions.
+MetricKit crash and hang diagnostics are delayed by Apple and may arrive later.

--- a/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
+++ b/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
@@ -24,7 +24,7 @@ Grafana 13 or later.
 
 - Grafana 13 or later.
 - A Grafana Cloud stack with OTLP ingest enabled for logs and traces.
-- Native Android or iOS telemetry shaped like the QuickPizza demo apps.
+- Native Android or iOS telemetry collected with the [OpenTelemetry Android SDK](https://github.com/open-telemetry/opentelemetry-android) or [OpenTelemetry Swift](https://github.com/open-telemetry/opentelemetry-swift), shaped like the QuickPizza demo apps.
 - A Loki data source with UID `grafanacloud-logs`.
 - A Tempo data source with UID `grafanacloud-traces`.
 

--- a/Mobiles/ios/README.md
+++ b/Mobiles/ios/README.md
@@ -148,6 +148,8 @@ bash Scripts/sim-run.sh
 ```
 
 Traces will appear in **Explore → Tempo** in your Grafana Cloud stack within seconds.
+To view native iOS telemetry in a RUM-style dashboard, import and configure the
+shared [Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `Mobiles/dashboards/mobile-otel-rum-dashboard.json` — a reusable
  Grafana 13+ dashboard for native Android and iOS apps sending OTLP logs
  and traces to Grafana Cloud. Requires Grafana 13+ (uses TabsLayout).
- Adds `Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md` — import and
  configuration guide, including expected telemetry shape and troubleshooting
  steps.
- Links the new guide from `Mobiles/android/README.md`,
  `Mobiles/ios/README.md`, and `Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`.

Closes https://github.com/grafana/app-o11y-kwl/issues/3019

Made with [Cursor](https://cursor.com)