### PR TITLE
Reassign CODEOWNERS to mobile-o11y-engineers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @grafana/k6-cloud-provisioning
-
+* @grafana/mobile-o11y-engineers


### PR DESCRIPTION
## Summary

- Replace `@grafana/k6-cloud-provisioning` with `@grafana/mobile-o11y-engineers` in the root `CODEOWNERS` so reviews route to the team now maintaining this repo.

_PR description authored by Claude on Domas's behalf._