### PR TITLE
k6: replace removed --no-summary with --summary-mode=disabled

### DIFF
--- a/k6/run-tests.sh
+++ b/k6/run-tests.sh
@@ -33,7 +33,7 @@ for test in $TESTS; do
 	# Disable thresholds because some threshold examples fail
     echo "Running: $test"
     rm -f $LOGS
-	$K6_PATH run --no-thresholds -e BASE_URL="$BASE_URL" --log-output=file=$LOGS --log-format=json -w --no-summary "$test"
+	$K6_PATH run --no-thresholds -e BASE_URL="$BASE_URL" --log-output=file=$LOGS --log-format=json -w --summary-mode=disabled "$test"
     k6_exit_code=$?
 
     # Only check error logs if logs file is not empty.


### PR DESCRIPTION
## Summary

- k6 v2.0.0 removed the `--no-summary` CLI flag. `setup-k6-action` in every workflow here pins no version, so CI now installs v2 and every run dies on the first foundations test with `unknown flag: --no-summary` (exit 255).
- Swap to the documented replacement: `--summary-mode=disabled` in `k6/run-tests.sh`.

Verified `--summary-mode {compact,full,disabled}` is the supported flag in `grafana/k6:latest` (`k6 v2.0.0`).

Last green run on `main` was 2026-05-07; the workflow has been broken on every PR since.

_PR description authored by Claude on Domas's behalf._