### PR TITLE
Ignore CLAUDE.local.md at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ logs.txt
 # macOS
 .DS_Store
 /.claude/CLAUDE.md
+/CLAUDE.local.md
 /tmp_dev/
 /Mobiles/android/.gradle
 /Mobiles/android/app/src/main/res/raw/config.json


### PR DESCRIPTION
## Summary

- Add `/CLAUDE.local.md` to `.gitignore` alongside the existing `/.claude/CLAUDE.md` entry so per-developer Claude Code notes kept at the repo root stay untracked.

_PR description authored by Claude on Domas's behalf._