### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+QuickPizza is a Go backend + SvelteKit frontend demo app. No external services are required — it uses in-memory SQLite by default and all microservices run in a single process.
+
+### Running the dev environment
+
+- **Dev mode (live-reload):** `make dev` — starts Vite dev server on `:5173` and Go backend on `:3333` (backend proxies frontend assets from Vite).
+- **Production build:** `make build` then `./bin/quickpizza` — embeds built frontend into the Go binary and serves on `:3333`.
+- Standard commands are documented in `docs/development.md` and the `Makefile`.
+
+### Lint / format
+
+- **Frontend:** `cd pkg/web && npm run biome-check` (lint) / `npm run biome-format` (auto-fix).
+- **Go:** `make format-check` (requires `goimports` on `PATH`; installed to `$(go env GOPATH)/bin`).
+
+### Gotchas
+
+- `goimports` is not a system package — install with `go install golang.org/x/tools/cmd/goimports@latest`. Ensure `$(go env GOPATH)/bin` is on `PATH` (added to `~/.bashrc`).
+- The Go backend uses vendored dependencies (`vendor/`), so `go build` works offline without `go mod download`.
+- The frontend has no automated test suite — validation is via `biome-check` and `svelte-check` (`npm run check`).
+- `make dev` uses `trap 'kill 0' EXIT` — when terminated, it kills both the Vite and Go processes together.
+- Authentication for API calls: create a user via `POST /api/users`, log in via `POST /api/users/token/login` to get a bearer token, then pass `Authorization: Bearer <token>` header. The `X-Is-Internal` header bypasses auth only for internal recommendation endpoints, not for `/api/pizza`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,18 @@ QuickPizza is a Go backend + SvelteKit frontend demo app. No external services a
 
 ### Mobile apps — build environment
 
-This VM has the toolchains to build all three **Android** APKs. iOS apps cannot be built (requires macOS + Xcode). Android emulators are not available (no KVM in this VM); use **BrowserStack** to run APKs on real devices.
+This VM has the toolchains to build all three **Android** APKs. iOS apps cannot be built (requires macOS + Xcode).
+
+**Android emulator (software rendering, no KVM):**
+An AVD named `quickpizza-test` (Android 14, x86_64, google_apis) is pre-created. KVM is not available, so the emulator runs with software rendering (`-no-accel -gpu swiftshader_indirect`). Key characteristics:
+- **Boot time:** ~7–8 minutes.
+- **Performance:** Very slow. Jetpack Compose apps (Android native) trigger frequent ANR ("app isn't responding") dialogs. Flutter apps are somewhat more responsive.
+- **Disable animations** to reduce ANRs: `adb shell settings put global window_animation_scale 0 && adb shell settings put global transition_animation_scale 0 && adb shell settings put global animator_duration_scale 0`
+- **Backend connectivity:** The emulator reaches the host at `10.0.2.2`, so apps with empty `BASE_URL` default to `http://10.0.2.2:3333`, which maps to the local QuickPizza backend.
+- **Launch command:** `emulator -avd quickpizza-test -no-window -no-audio -no-accel -gpu swiftshader_indirect -memory 2048 -no-snapshot -no-boot-anim &`
+- **Wait for boot:** `adb wait-for-device && while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do sleep 10; done`
+- **Best for:** Smoke-testing that APKs install and launch. Not practical for full UI automation due to extreme slowness.
+- **Recommended for real automation:** BrowserStack (see below).
 
 **Installed toolchains:**
 - **Android SDK** at `/opt/android-sdk` — platform 36, build-tools 36.0.0, NDK 27.1.12297006 + 28.2.13676358. Env vars `ANDROID_HOME`/`ANDROID_SDK_ROOT` set in `~/.bashrc`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,41 @@ QuickPizza is a Go backend + SvelteKit frontend demo app. No external services a
 - The frontend has no automated test suite — validation is via `biome-check` and `svelte-check` (`npm run check`).
 - `make dev` uses `trap 'kill 0' EXIT` — when terminated, it kills both the Vite and Go processes together.
 - Authentication for API calls: create a user via `POST /api/users`, log in via `POST /api/users/token/login` to get a bearer token, then pass `Authorization: Bearer <token>` header. The `X-Is-Internal` header bypasses auth only for internal recommendation endpoints, not for `/api/pizza`.
+
+### Mobile apps — build environment
+
+This VM has the toolchains to build all three **Android** APKs. iOS apps cannot be built (requires macOS + Xcode). Android emulators are not available (no KVM in this VM); use **BrowserStack** to run APKs on real devices.
+
+**Installed toolchains:**
+- **Android SDK** at `/opt/android-sdk` — platform 36, build-tools 36.0.0, NDK 27.1.12297006 + 28.2.13676358. Env vars `ANDROID_HOME`/`ANDROID_SDK_ROOT` set in `~/.bashrc`.
+- **Flutter** 3.41.9 (Dart 3.11.5) at `/opt/flutter`. On `PATH` via `~/.bashrc`.
+- **JDK 21** (system, `/usr/bin/java`). Works for all three Gradle builds.
+- **Yarn** 1.22.22 (via nvm) for React Native.
+
+**Build commands (from `/workspace`):**
+
+| App | Build command | APK output |
+|-----|--------------|------------|
+| Flutter | `cd Mobiles/flutter && flutter pub get && flutter build apk --debug --dart-define-from-file=config.json` | `Mobiles/flutter/build/app/outputs/flutter-apk/app-debug.apk` |
+| React Native | `cd Mobiles/react-native && yarn install && cd android && ./gradlew assembleDebug` | `Mobiles/react-native/android/app/build/outputs/apk/debug/app-debug.apk` |
+| Android native | `cd Mobiles/android && ./gradlew assembleDebug` | `Mobiles/android/app/build/outputs/apk/debug/app-debug.apk` |
+
+**Config files:** Each app needs a `config.json` copied from its `.example` template:
+- Flutter: `Mobiles/flutter/config.json` (from `config.json.example`) — `FARO_COLLECTOR_URL`, `BASE_URL`, `PORT`.
+- React Native: `Mobiles/react-native/config.json` (from `config.json.example`) — same fields.
+- Android native: `Mobiles/android/app/src/main/res/raw/config.json` (from root `config.json.example`) — `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`, `BASE_URL`.
+
+### BrowserStack integration
+
+**BrowserStack Local** binary is installed at `/usr/local/bin/BrowserStackLocal` (v8.9). It creates a tunnel from BrowserStack devices to the local QuickPizza backend.
+
+**Credentials:** `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` environment secrets.
+
+**Running apps on BrowserStack with local backend:**
+1. Start the QuickPizza backend: `make dev` or `./bin/quickpizza` (port 3333).
+2. Start BrowserStack Local tunnel: `BrowserStackLocal --key $BROWSERSTACK_ACCESS_KEY --local-identifier quickpizza-tunnel &`
+3. Upload APK: `curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" -X POST https://api-cloud.browserstack.com/app-automate/upload -F "file=@<path-to-apk>"`
+4. Use the returned `bs://` URL with `takeAppScreenshot` or `runAppTestsOnBrowserStack` MCP tools, setting `browserstack.local=true` and `browserstack.localIdentifier=quickpizza-tunnel` in capabilities.
+5. In the app's `config.json`, set `BASE_URL` to `http://localhost:3333` — BrowserStack Local routes `localhost` from the device through the tunnel to this VM.
+
+**Note:** The BrowserStack free trial may have expired. Check plan status: `curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" https://api-cloud.browserstack.com/app-automate/plan.json`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,27 @@ An AVD named `quickpizza-test` (Android 14, x86_64, google_apis) is pre-created.
 5. In the app's `config.json`, set `BASE_URL` to `http://localhost:3333` — BrowserStack Local routes `localhost` from the device through the tunnel to this VM.
 
 **Note:** The BrowserStack free trial may have expired. Check plan status: `curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" https://api-cloud.browserstack.com/app-automate/plan.json`
+
+### Grafana Cloud CLI (gcx)
+
+**gcx** (v0.2.14) is installed at `/usr/local/bin/gcx` with 19 agent skills in `~/.agents/skills/`. Use it to verify that mobile app telemetry lands correctly in Grafana Cloud.
+
+**Authentication:** Set these environment secrets (or use `gcx login`):
+- `GRAFANA_SERVER` — Grafana Cloud instance URL (e.g. `https://<stack>.grafana.net`)
+- `GRAFANA_TOKEN` — Grafana service account token (Editor/Admin role)
+- `GRAFANA_CLOUD_TOKEN` — Cloud Access Policy token (needed for `gcx frontend`, `gcx traces`, etc.)
+
+**Telemetry verification commands for mobile apps:**
+
+| What to check | Command |
+|---------------|---------|
+| Faro apps (Flutter, RN) | `gcx frontend apps list` |
+| Faro app details | `gcx frontend apps get <app-id>` |
+| OTel traces (iOS, Android native) | `gcx traces query '{resource.service.name="quickpizza-android"}' --since 1h` |
+| OTel logs (iOS, Android native) | `gcx logs query '{service_name="quickpizza-android"}' --since 1h` |
+| Explore available datasources | `gcx datasources list` |
+| Check connection | `gcx config check` |
+
+**Where each app's telemetry lands (from `CLAUDE.md`):**
+- Flutter + React Native → Grafana Cloud **Frontend Observability** (Faro)
+- iOS native + Android native → Grafana Cloud **Tempo + Loki** (OTLP/HTTP)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,22 +78,32 @@ An AVD named `quickpizza-test` (Android 14, x86_64, google_apis) is pre-created.
 
 **gcx** (v0.2.14) is installed at `/usr/local/bin/gcx` with 19 agent skills in `~/.agents/skills/`. Use it to verify that mobile app telemetry lands correctly in Grafana Cloud.
 
-**Authentication:** Set these environment secrets (or use `gcx login`):
-- `GRAFANA_SERVER` — Grafana Cloud instance URL (e.g. `https://<stack>.grafana.net`)
-- `GRAFANA_TOKEN` — Grafana service account token (Editor/Admin role)
-- `GRAFANA_CLOUD_TOKEN` — Cloud Access Policy token (needed for `gcx frontend`, `gcx traces`, etc.)
+**Authentication:** A persistent context `mobile-o11y` is configured via `gcx login`. It uses:
+- `GRAFANA_MOBILE_O11Y_URL` — Grafana Cloud instance URL
+- `GRAFANA_MOBILE_O11Y_API_KEY` — Service account token (`glsa_` format)
+
+To recreate the context (e.g. after token rotation):
+```
+gcx login mobile-o11y --server "$GRAFANA_MOBILE_O11Y_URL" --token "$GRAFANA_MOBILE_O11Y_API_KEY" --yes
+```
+
+Default datasources are configured: `grafanacloud-traces` (Tempo), `grafanacloud-logs` (Loki), `grafanacloud-prom` (Prometheus).
+
+`GRAFANA_CLOUD_TOKEN` (Cloud Access Policy token) is **not** needed for traces/logs/metrics queries. It's only needed for Cloud product APIs like `gcx frontend apps list` (Faro), `gcx slo`, etc.
 
 **Telemetry verification commands for mobile apps:**
 
 | What to check | Command |
 |---------------|---------|
-| Faro apps (Flutter, RN) | `gcx frontend apps list` |
-| Faro app details | `gcx frontend apps get <app-id>` |
-| OTel traces (iOS, Android native) | `gcx traces query '{resource.service.name="quickpizza-android"}' --since 1h` |
-| OTel logs (iOS, Android native) | `gcx logs query '{service_name="quickpizza-android"}' --since 1h` |
-| Explore available datasources | `gcx datasources list` |
-| Check connection | `gcx config check` |
+| All recent traces | `gcx traces query '{}' --since 24h` |
+| Flutter traces | `gcx traces query '{resource.service.name="QuickPizza_Flutter"}' --since 1h` |
+| React Native traces | `gcx traces query '{resource.service.name="QuickPizza_ReactNative"}' --since 1h` |
+| Android native traces | `gcx traces query '{resource.service.name="quickpizza-android"}' --since 1h` |
+| iOS native traces | `gcx traces query '{resource.service.name="quickpizza-ios"}' --since 1h` |
+| Backend logs | `gcx logs query '{service_namespace=~"quickpizza.*"}' --since 1h` |
+| Datasources | `gcx datasources list` |
+| Connection check | `gcx config check` |
 
 **Where each app's telemetry lands (from `CLAUDE.md`):**
-- Flutter + React Native → Grafana Cloud **Frontend Observability** (Faro)
+- Flutter + React Native → Grafana Cloud **Tempo** (traces via Faro tracing) + **Frontend Observability** (Faro events/logs/measurements — requires `GRAFANA_CLOUD_TOKEN` for `gcx frontend` commands)
 - iOS native + Android native → Grafana Cloud **Tempo + Loki** (OTLP/HTTP)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud development instructions for the full stack: web backend/frontend, all three Android mobile apps, Android emulator, and BrowserStack integration.

### What was set up

**Web app (Go + SvelteKit):**
- Frontend lint, Go format checks, full build, dev mode all verified working
- Pizza recommendation generated via API and browser UI

**Mobile apps (Android APK builds):**
- Android SDK (API 36, build-tools 36.0.0, NDK 27.1.12297006)
- Flutter 3.41.9 (Dart 3.11.5)
- JDK 21 (system)
- Yarn 1.22.22 (for React Native)
- BrowserStack Local binary v8.9

**Built APKs:**
| App | APK Size | Status |
|-----|----------|--------|
| Flutter | 151 MB | Built |
| React Native | 124 MB | Built |
| Android native | 23 MB | Built |

**Android emulator (software rendering):**
- AVD `quickpizza-test` (Android 14, x86_64) created and booted
- No KVM — runs with `-no-accel -gpu swiftshader_indirect`
- Boot time ~7–8 min; frequent ANR dialogs due to slow rendering
- Apps install and launch; backend reachable at `10.0.2.2:3333`
- Flutter app renders cleanly; Compose-based native app struggles more

**BrowserStack:** Tools installed and credentials verified. App Automate testing time expired — needs plan renewal.

### Emulator evidence

[Android native app home screen on emulator](https://cursor.com/agents/bc-24336e1f-0a9c-4545-8205-785f4634bb90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fandroid_dismissed.png)
Android native app fully rendered on emulator — home screen with Pizza Please button.

[Flutter app responding to Pizza Please tap](https://cursor.com/agents/bc-24336e1f-0a9c-4545-8205-785f4634bb90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fflutter_pizza_result.png)
Flutter app on emulator — tapped Pizza Please, got auth error (backend is reachable, app correctly requires login).

### Web app demo

[quickpizza_demo.mp4](https://cursor.com/agents/bc-24336e1f-0a9c-4545-8205-785f4634bb90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquickpizza_demo.mp4)
QuickPizza web app generating a pizza recommendation end-to-end.

## Verification

- Frontend lint (`npm run biome-check`): passing
- Go format check (`make format-check`): passing
- Full build (`make build`): successful
- Dev mode (`make dev`): running on ports 5173/3333
- Flutter APK build: successful
- React Native APK build: successful
- Android native APK build: successful
- Android emulator boot: successful (software rendering, ~7.5 min)
- APK install on emulator: successful (both native and Flutter)
- App launch on emulator: successful (both render home screens)
- Backend connectivity from emulator: verified (10.0.2.2 ping OK)
- BrowserStack upload: blocked by expired trial

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24336e1f-0a9c-4545-8205-785f4634bb90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24336e1f-0a9c-4545-8205-785f4634bb90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

