### PR TITLE
Update mobile observability SDKs

### DIFF
--- a/Mobiles/android/gradle/libs.versions.toml
+++ b/Mobiles/android/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ coreKtx = "1.15.0"
 lifecycle = "2.8.7"
 desugar = "2.1.4"
 datastore = "1.2.1"
-opentelemetryAndroid = "1.2.0-alpha"
-opentelemetryAndroidInstrumentation = "0.11.0-alpha"
+opentelemetryAndroid = "1.4.0-alpha"
+opentelemetryAndroidInstrumentation = "1.4.0-alpha"
 byteBuddy = "1.18.5"
 
 [libraries]

--- a/Mobiles/flutter/pubspec.lock
+++ b/Mobiles/flutter/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: "direct main"
     description:
       name: faro
-      sha256: cfd7dc9f1d0343d8929205b4e60b26d4dbe1e46de790bab00de4913c993ae014
+      sha256: c47ed45c810b3cf541c7163ec3abc541918287280e02a8f22a1199c928e52bb7
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.0"
+    version: "0.16.0"
   ffi:
     dependency: transitive
     description:

--- a/Mobiles/flutter/pubspec.yaml
+++ b/Mobiles/flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  faro: ^0.14.0
+  faro: ^0.16.0
   flutter_riverpod: ^3.1.0
   http: ^1.1.0
   shared_preferences: ^2.2.2

--- a/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
+++ b/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.3.0;
+				minimumVersion = 2.4.1;
 			};
 		};
 		62EFEF4C2F360BAE00E72D9F /* XCRemoteSwiftPackageReference "opentelemetry-swift-core" */ = {
@@ -440,7 +440,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift-core.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.3.0;
+				minimumVersion = 2.4.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Mobiles/ios/QuickPizzaIos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mobiles/ios/QuickPizzaIos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "f857994e146f5146d702e9c31ac6f3c27d55d18a",
-        "version" : "1.27.0"
+        "revision" : "6a8927df5a91710b414caba4f8a088dead4633db",
+        "version" : "1.27.5"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
       "state" : {
-        "revision" : "df57cc4fd0b4cf4f9d715253c6aaba4b6912f7e0",
-        "version" : "2.3.0"
+        "revision" : "21374ac2439aee4e206721ef91a7e8bf4c0579d6",
+        "version" : "2.4.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift-core.git",
       "state" : {
-        "revision" : "240c8d5e36c3c7b774ed961325369f0b1f2c965f",
-        "version" : "2.3.0"
+        "revision" : "84b9e341cbb7b4dd62cd1b89cd9e008995084132",
+        "version" : "2.4.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "2778fd4e5a12a8aaa30a3ee8285f4ce54c5f3181",
-        "version" : "1.9.1"
+        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
+        "version" : "1.12.1"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "0743a9364382629da3bf5677b46a2c4b1ce5d2a6",
-        "version" : "2.7.1"
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "5e72fc102906ebe75a3487595a653e6f43725552",
-        "version" : "2.94.0"
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "c5ab62237f21cad094812719a1bbe29443407c5f",
-        "version" : "1.34.1"
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
       }
     },
     {

--- a/Mobiles/react-native/ios/Podfile.lock
+++ b/Mobiles/react-native/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FaroReactNative (1.0.0):
+  - FaroReactNative (1.1.0):
     - PLCrashReporter (~> 1.11)
     - React-Core
   - FBLazyVector (0.84.1)
@@ -2180,9 +2180,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  FaroReactNative: cae60e655fcc5b43afbff967b345ccf3d0a0023f
+  FaroReactNative: dded3d24aef51de696059f34124eb47fdbaa0ad8
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: af26a2fc195f459f1524c41bc6da855e0eafa8ae
+  hermes-engine: e9e14608a793b9b4b1c7998481f7462e3cb96f99
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
@@ -2192,7 +2192,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: 8d637a909b2f1ea893ccd5f60707c5db195e57e9
+  React-Core-prebuilt: 6cc8687ba515963c0c1397bf43e6ed197cfa85d6
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2255,7 +2255,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: c380a964bdefa6cb8a75c47f1d645646b947eb74
+  ReactNativeDependencies: b5d7a80f91f92832aa12d4e7ec1d0e90a92722cd
   RNCAsyncStorage: 7a5a6094f9f6b9158e72f1855cd86e769413d851
   RNDeviceInfo: 900bd20e1fd3bfd894e7384cc4a83880c0341bd3
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707

--- a/Mobiles/react-native/package.json
+++ b/Mobiles/react-native/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@grafana/faro-react-native": "1.0.0",
-    "@grafana/faro-react-native-tracing": "1.0.0",
+    "@grafana/faro-react-native": "1.1.0",
+    "@grafana/faro-react-native-tracing": "1.1.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "@react-native-vector-icons/material-icons": "^13.1.1",
     "@react-navigation/bottom-tabs": "^6.5.20",
@@ -49,7 +49,7 @@
     "node": ">= 22.11.0"
   },
   "resolutions": {
-    "@grafana/faro-react-native": "1.0.0",
-    "@grafana/faro-react-native-tracing": "1.0.0"
+    "@grafana/faro-react-native": "1.1.0",
+    "@grafana/faro-react-native-tracing": "1.1.0"
   }
 }

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1046,13 +1046,13 @@
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/otlp-transformer" "^0.213.0"
 
-"@grafana/faro-react-native-tracing@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@grafana/faro-react-native-tracing/-/faro-react-native-tracing-1.0.0.tgz#2cc28c2443eee5a8f6da471e96d679607227243a"
-  integrity sha512-sRJBquH9TufNs8hw6AUpQvHq2+EtkqLnME7jzoqrZ/W54vOHf1iQht0mBMpD6qg/V/f3v6R+/3Asnh1rH+z4PA==
+"@grafana/faro-react-native-tracing@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/faro-react-native-tracing/-/faro-react-native-tracing-1.1.0.tgz#1a86bfedf5db7a249edb1ed2bc0536bf1928b3e6"
+  integrity sha512-PjP5FIjoWJH4q8ySVlDEHrUyxh1lrgwR7k1rR589Z8I6kd8TujTQuzCapxqMX/Y9WyxUO1yoj1j8MIUMokEmVQ==
   dependencies:
     "@grafana/faro-core" "^2.2.3"
-    "@grafana/faro-react-native" "^1.0.0"
+    "@grafana/faro-react-native" "^1.1.0"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/core" "^2.0.0"
     "@opentelemetry/instrumentation" "^0.208.0"
@@ -1061,12 +1061,13 @@
     "@opentelemetry/otlp-transformer" "^0.208.0"
     "@opentelemetry/resources" "^2.0.0"
     "@opentelemetry/sdk-trace-base" "^2.0.0"
+    "@opentelemetry/sdk-trace-web" "^2.0.0"
     "@opentelemetry/semantic-conventions" "^1.32.0"
 
-"@grafana/faro-react-native@1.0.0", "@grafana/faro-react-native@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@grafana/faro-react-native/-/faro-react-native-1.0.0.tgz#f09e420a144a77ff041e5eeed414d90615f10100"
-  integrity sha512-6KXtbKHJBtsquopTs9rEB9EBQTDigVn4C/jHtPrxe6/DbwaFePhCtih2JUcEwJIPYjGP4evrEO7A8WbCYEkuoA==
+"@grafana/faro-react-native@1.1.0", "@grafana/faro-react-native@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/faro-react-native/-/faro-react-native-1.1.0.tgz#76e24dacc6101937c4b92ea024cd5c86adf004ea"
+  integrity sha512-KRAZJFCk2ZVgdi1Z2SeVt9c7r119UO1lCc6q+GDeApQHFPQEbICNmgIFFPL6EGceVPQ32F5mj2xGr/q/p6abtA==
   dependencies:
     "@grafana/faro-core" "^2.2.3"
     "@react-native-async-storage/async-storage" "^1.21.0"
@@ -1433,6 +1434,13 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
+"@opentelemetry/core@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.7.1.tgz#162bfab46d6ff4da1bef240ea52e23a926b0fdbc"
+  integrity sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
 "@opentelemetry/instrumentation-fetch@^0.208.0":
   version "0.208.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.208.0.tgz#1bfa7593f0e4fac4933e287ce4dd030340281dd2"
@@ -1512,6 +1520,14 @@
     "@opentelemetry/core" "2.6.1"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
+"@opentelemetry/resources@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.7.1.tgz#3b2a9179f6119bb1f2cddefe41ba9b2855504a5d"
+  integrity sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
 "@opentelemetry/sdk-logs@0.208.0":
   version "0.208.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz#013494e23412c1594a694a358211cd150144c525"
@@ -1565,6 +1581,15 @@
     "@opentelemetry/resources" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
+"@opentelemetry/sdk-trace-base@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz#9160c3af9ef2219c26563abd136e22fb7d19b34f"
+  integrity sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
 "@opentelemetry/sdk-trace-base@^2.0.0":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz#ed353062be4c28a0649247ad369654020c29bfce"
@@ -1581,6 +1606,14 @@
   dependencies:
     "@opentelemetry/core" "2.2.0"
     "@opentelemetry/sdk-trace-base" "2.2.0"
+
+"@opentelemetry/sdk-trace-web@^2.0.0":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.7.1.tgz#4fbfd6147ec366ff87b46057aba7b35900f4cc2e"
+  integrity sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
 
 "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.32.0":
   version "1.40.0"
@@ -6935,7 +6968,7 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^2.2.1, yaml@^2.6.1, yaml@^2.7.0:
+yaml@^2.2.1, yaml@^2.6.1:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
   integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==


### PR DESCRIPTION
## Summary
- Update Flutter Faro from 0.14.0 to 0.16.0.
- Update Faro React Native packages from 1.0.0 to 1.1.0, which enables end-to-end trace propagation for the RN demo app.
- Update native Android OTel Android SDK/instrumentation to 1.4.0-alpha and native iOS OTel Swift/Core to 2.4.1.

## Notes
- Native Android distributed trace propagation still only shows mobile app spans; leaving that existing issue out of this SDK update PR.

## Test plan
- `flutter analyze`
- `yarn test --watchAll=false --watchman=false`
- `./gradlew testDebugUnitTest`
- `xcodebuild -quiet -project QuickPizzaIos.xcodeproj -scheme QuickPizzaIos -destination 'platform=iOS Simulator,name=iPhone 17' build`
- Manually verified all mobile demo apps launch and send telemetry.

Made with [Cursor](https://cursor.com)