### PR TITLE
ci(build_and_test): read Go version from go.mod

### DIFF
--- a/.github/workflows/build_and_test_no_docker.yaml
+++ b/.github/workflows/build_and_test_no_docker.yaml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
 
       - name: Setup Goimports
         run: go install golang.org/x/tools/cmd/goimports@v0.42.0


### PR DESCRIPTION
## Why

The `build_and_test_no_docker` workflow has been failing on `main` since 4e9a85e (the otel-go bump). setup-go without `go-version-file` installs its default (Go 1.24.13) and sets `GOTOOLCHAIN=local`, so Go refuses to auto-fetch the 1.25 toolchain that go.mod now requires:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
make: *** [Makefile:18: build-go] Error 1
```

## What

- [.github/workflows/build_and_test_no_docker.yaml](.github/workflows/build_and_test_no_docker.yaml) — set `go-version-file: go.mod` on the `setup-go` step so CI tracks the directive in go.mod. The sibling `mobile_demo_telemetry` workflow already uses this pattern.

_PR description authored by Claude on Domas's behalf._