### PR TITLE
chore (security): add branch cleanup dry-run audit

### DIFF
--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -14,7 +14,7 @@ on:
       min_merged_age_days:
         description: Minimum age in days before merged branches are cleanup candidates
         required: true
-        default: "7"
+        default: "14"
       include_automation:
         description: Include renovate/dependabot/release-please branches as candidates
         required: true
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: ">=24.5.0"
 
       - name: Generate dry-run branch cleanup report
         env:

--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -1,0 +1,69 @@
+name: Branch Cleanup Dry Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: GitHub owner or organization to audit
+        required: true
+        default: grafana
+      repo:
+        description: Repository to audit
+        required: true
+        default: mobile-o11y-demo
+      min_merged_age_days:
+        description: Minimum age in days before merged branches are cleanup candidates
+        required: true
+        default: "7"
+      include_automation:
+        description: Include renovate/dependabot/release-please branches as candidates
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit:
+    name: Audit stale branches
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Generate dry-run branch cleanup report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_OWNER: ${{ inputs.owner }}
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_MIN_MERGED_AGE_DAYS: ${{ inputs.min_merged_age_days }}
+          INPUT_INCLUDE_AUTOMATION: ${{ inputs.include_automation }}
+        run: |
+          node scripts/audit-stale-branches.mjs \
+            --owner "$INPUT_OWNER" \
+            --repo "$INPUT_REPO" \
+            --min-merged-age-days "$INPUT_MIN_MERGED_AGE_DAYS" \
+            --include-automation "$INPUT_INCLUDE_AUTOMATION" \
+            > branch-cleanup-dry-run.md
+
+      - name: Print report summary
+        run: sed -n '1,80p' branch-cleanup-dry-run.md
+
+      - name: Publish report to job summary
+        run: cat branch-cleanup-dry-run.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: branch-cleanup-dry-run
+          path: branch-cleanup-dry-run.md
+          retention-days: 14

--- a/scripts/audit-stale-branches.mjs
+++ b/scripts/audit-stale-branches.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+const token = process.env.GITHUB_TOKEN;
+
+if (!token) {
+  console.error('GITHUB_TOKEN is required.');
+  process.exit(1);
+}
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  args.set(process.argv[index], process.argv[index + 1]);
+}
+
+const owner = args.get('--owner') ?? process.env.GITHUB_REPOSITORY_OWNER ?? 'grafana';
+const repo =
+  args.get('--repo') ??
+  process.env.GITHUB_REPOSITORY?.split('/')[1] ??
+  'mobile-o11y-demo';
+const minMergedAgeDays = Number(args.get('--min-merged-age-days') ?? '7');
+const includeAutomation = args.get('--include-automation') === 'true';
+
+if (!Number.isFinite(minMergedAgeDays) || minMergedAgeDays < 0) {
+  console.error('--min-merged-age-days must be a non-negative number.');
+  process.exit(1);
+}
+
+const graphqlUrl = 'https://api.github.com/graphql';
+const headers = {
+  authorization: `Bearer ${token}`,
+  'content-type': 'application/json',
+  'user-agent': 'mobile-o11y-branch-audit',
+};
+
+async function graphql(query, variables) {
+  const response = await fetch(graphqlUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL request failed: ${response.status} ${await response.text()}`);
+  }
+
+  const payload = await response.json();
+  if (payload.errors?.length) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(payload.errors)}`);
+  }
+
+  return payload.data;
+}
+
+async function getBranches() {
+  const branches = [];
+  let cursor = null;
+  let defaultBranchName = 'main';
+
+  do {
+    const data = await graphql(
+      `query($owner: String!, $repo: String!, $cursor: String) {
+        repository(owner: $owner, name: $repo) {
+          defaultBranchRef { name }
+          refs(
+            refPrefix: "refs/heads/"
+            first: 100
+            after: $cursor
+            orderBy: { field: TAG_COMMIT_DATE, direction: DESC }
+          ) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              name
+              target {
+                ... on Commit {
+                  oid
+                  committedDate
+                  messageHeadline
+                  author { user { login } name }
+                }
+              }
+              associatedPullRequests(first: 10) {
+                nodes {
+                  number
+                  title
+                  state
+                  merged
+                  mergedAt
+                  isDraft
+                  url
+                  author { login }
+                  headRefName
+                  headRepository { name owner { login } }
+                  baseRepository { name owner { login } }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, repo, cursor }
+    );
+
+    defaultBranchName = data.repository.defaultBranchRef?.name ?? defaultBranchName;
+    branches.push(...data.repository.refs.nodes);
+    cursor = data.repository.refs.pageInfo.hasNextPage
+      ? data.repository.refs.pageInfo.endCursor
+      : null;
+  } while (cursor);
+
+  return { branches, defaultBranchName };
+}
+
+function isAutomationBranch(branchName) {
+  return (
+    branchName.startsWith('dependabot/') ||
+    branchName.startsWith('renovate/') ||
+    branchName.startsWith('release-please--')
+  );
+}
+
+function mergedAgeDays(mergedAt) {
+  return (Date.now() - new Date(mergedAt).getTime()) / 86_400_000;
+}
+
+function classify(branch, defaultBranchName) {
+  const pullRequests = branch.associatedPullRequests.nodes.filter(
+    (candidate) =>
+      candidate.headRefName === branch.name &&
+      candidate.headRepository?.name === repo &&
+      candidate.headRepository?.owner?.login === owner &&
+      candidate.baseRepository?.name === repo &&
+      candidate.baseRepository?.owner?.login === owner
+  );
+  const pullRequest =
+    pullRequests.find((candidate) => candidate.merged) ??
+    pullRequests.find((candidate) => candidate.state === 'OPEN') ??
+    pullRequests[0];
+
+  if (branch.name === defaultBranchName) {
+    return { bucket: 'protected', branch, pullRequest, reason: 'default branch' };
+  }
+
+  const automation = isAutomationBranch(branch.name);
+  if (automation && !includeAutomation) {
+    return { bucket: 'automation', branch, pullRequest, reason: 'automation branch' };
+  }
+
+  if (!pullRequest) {
+    return { bucket: 'noPr', branch, pullRequest, reason: 'no linked PR found' };
+  }
+
+  if (pullRequest.state === 'OPEN') {
+    return { bucket: 'open', branch, pullRequest, reason: 'open PR' };
+  }
+
+  if (!pullRequest.merged) {
+    return { bucket: 'closedUnmerged', branch, pullRequest, reason: 'closed but not merged' };
+  }
+
+  if (mergedAgeDays(pullRequest.mergedAt) < minMergedAgeDays) {
+    return {
+      bucket: 'recentMerged',
+      branch,
+      pullRequest,
+      reason: `merged less than ${minMergedAgeDays} days ago`,
+    };
+  }
+
+  return { bucket: 'mergedCandidate', branch, pullRequest, reason: 'merged PR branch' };
+}
+
+function row(item) {
+  const pr = item.pullRequest;
+  const prText = pr ? `[#${pr.number}](${pr.url})` : '-';
+  const updated = item.branch.target?.committedDate ?? '-';
+  const author =
+    item.branch.target?.author?.user?.login ?? item.branch.target?.author?.name ?? '-';
+  const sha = item.branch.target?.oid ?? '-';
+  return `| \`${item.branch.name}\` | ${prText} | ${author} | ${updated} | \`${sha}\` | ${item.reason} |`;
+}
+
+function section(title, items) {
+  if (!items.length) {
+    return `## ${title}\n\nNone.\n`;
+  }
+
+  return [
+    `## ${title}`,
+    '',
+    '| Branch | PR | Last author | Last commit date | SHA | Reason |',
+    '| --- | --- | --- | --- | --- | --- |',
+    ...items.map(row),
+    '',
+  ].join('\n');
+}
+
+const { branches, defaultBranchName } = await getBranches();
+const groups = branches.reduce((accumulator, branch) => {
+  const item = classify(branch, defaultBranchName);
+  accumulator[item.bucket] ??= [];
+  accumulator[item.bucket].push(item);
+  return accumulator;
+}, {});
+
+const report = [
+  `# Branch Cleanup Dry Run: ${owner}/${repo}`,
+  '',
+  `Generated: ${new Date().toISOString()}`,
+  '',
+  `This is a dry-run report. It does not delete branches.`,
+  `Cross-repo audits require a token with read access to the target repository.`,
+  '',
+  `Minimum merged-branch age: ${minMergedAgeDays} days`,
+  `Automation branches included as delete candidates: ${includeAutomation}`,
+  '',
+  '## Summary',
+  '',
+  `- Total branches: ${branches.length}`,
+  `- Merged branch cleanup candidates: ${groups.mergedCandidate?.length ?? 0}`,
+  `- Recent merged branches skipped: ${groups.recentMerged?.length ?? 0}`,
+  `- Open PR branches skipped: ${groups.open?.length ?? 0}`,
+  `- Closed-unmerged branches needing review: ${groups.closedUnmerged?.length ?? 0}`,
+  `- No-PR branches needing review: ${groups.noPr?.length ?? 0}`,
+  `- Automation branches skipped: ${groups.automation?.length ?? 0}`,
+  '',
+  section('Merged Branch Cleanup Candidates', groups.mergedCandidate ?? []),
+  section('Recent Merged Branches Skipped', groups.recentMerged ?? []),
+  section('Open PR Branches Skipped', groups.open ?? []),
+  section('Closed-Unmerged Branches Needing Review', groups.closedUnmerged ?? []),
+  section('No-PR Branches Needing Review', groups.noPr ?? []),
+  section('Automation Branches Skipped', groups.automation ?? []),
+].join('\n');
+
+console.log(report);


### PR DESCRIPTION
## Summary

Added a read-only branch cleanup audit workflow for `mobile-o11y-demo`.

This is intentionally dry-run only. It does not delete branches. The goal is to report leftover branch categories that GitHub’s “Automatically delete head branches” setting does not cover, such as closed-unmerged branches, no-PR branches, automation branches, release/version branches, and other stale branch cases.

## What it does

- Adds a manual `workflow_dispatch` GitHub Action
- Generates a Markdown branch audit report
- Groups branches into:
  - merged cleanup candidates
  - recent merged branches
  - open PR branches
  - closed-unmerged branches
  - no-PR branches
  - automation branches
- Writes the report to the Action summary
- Uploads the report as an artifact
- Uses read-only permissions
- Does not delete anything

## Notes
`mobile-o11y-demo` already has GitHub’s “Automatically delete head branches” enabled, so this is not intended to replace that setting.

This is for visibility into branch leftovers/exceptions that auto-delete does not handle. Scheduling, Slack posting, or any deletion behavior can be considered separately after the team agrees on cleanup rules.

## Testing

- Ran `node --check scripts/audit-stale-branches.mjs`
- Ran the script locally against `grafana/mobile-o11y-demo` and confirmed it generated the expected Markdown dry-run report
- Verified invalid `--min-merged-age-days` input fails fast
- Simulated writing the generated report to `$GITHUB_STEP_SUMMARY`
- Tried to run the new `workflow_dispatch` workflow from the PR branch, but GitHub does not expose new manual workflows until the workflow file exists on the default branch
