### PR TITLE
chore: schedule branch cleanup report

### DIFF
--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -20,9 +20,19 @@ on:
         required: true
         type: boolean
         default: false
+      create_issue:
+        description: Create a GitHub issue with the report
+        required: true
+        type: boolean
+        default: false
+  schedule:
+    # GitHub cron does not support "every 14 days" directly. This runs weekly,
+    # then the cadence step below only lets the report continue every other week.
+    - cron: "0 14 * * 4"
 
 permissions:
   contents: read
+  issues: write
   pull-requests: read
 
 jobs:
@@ -30,23 +40,49 @@ jobs:
     name: Audit stale branches
     runs-on: ubuntu-24.04
     steps:
+      - name: Check 14-day report cadence
+        id: cadence
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPORT_ANCHOR_DATE: "2026-05-28"
+        run: |
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "run_report=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          today="$(date -u +%F)"
+          today_seconds="$(date -u -d "$today" +%s)"
+          anchor_seconds="$(date -u -d "$REPORT_ANCHOR_DATE" +%s)"
+          days_since_anchor="$(( (today_seconds - anchor_seconds) / 86400 ))"
+
+          if [ "$(( days_since_anchor % 14 ))" -eq 0 ]; then
+            echo "run_report=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_report=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping branch cleanup report. Next report runs on the 14-day cadence." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Checkout code
+        if: steps.cadence.outputs.run_report == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Node.js
+        if: steps.cadence.outputs.run_report == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ">=24.5.0"
 
       - name: Generate dry-run branch cleanup report
+        if: steps.cadence.outputs.run_report == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_OWNER: ${{ inputs.owner }}
-          INPUT_REPO: ${{ inputs.repo }}
-          INPUT_MIN_MERGED_AGE_DAYS: ${{ inputs.min_merged_age_days }}
-          INPUT_INCLUDE_AUTOMATION: ${{ inputs.include_automation }}
+          INPUT_OWNER: ${{ github.event_name == 'schedule' && 'grafana' || inputs.owner }}
+          INPUT_REPO: ${{ github.event_name == 'schedule' && 'mobile-o11y-demo' || inputs.repo }}
+          INPUT_MIN_MERGED_AGE_DAYS: ${{ github.event_name == 'schedule' && '14' || inputs.min_merged_age_days }}
+          INPUT_INCLUDE_AUTOMATION: ${{ github.event_name == 'schedule' && 'false' || inputs.include_automation }}
         run: |
           node scripts/audit-stale-branches.mjs \
             --owner "$INPUT_OWNER" \
@@ -56,12 +92,38 @@ jobs:
             > branch-cleanup-dry-run.md
 
       - name: Print report summary
+        if: steps.cadence.outputs.run_report == 'true'
         run: sed -n '1,80p' branch-cleanup-dry-run.md
 
       - name: Publish report to job summary
+        if: steps.cadence.outputs.run_report == 'true'
         run: cat branch-cleanup-dry-run.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Create GitHub issue report
+        if: steps.cadence.outputs.run_report == 'true' && (github.event_name == 'schedule' || inputs.create_issue)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          report_date="$(date -u +%F)"
+          issue_title="Branch cleanup dry-run report - $report_date"
+
+          {
+            echo "Automated read-only branch cleanup report."
+            echo
+            echo "Workflow run: $RUN_URL"
+            echo
+            cat branch-cleanup-dry-run.md
+          } > branch-cleanup-issue.md
+
+          gh issue create \
+            --repo "$ISSUE_REPO" \
+            --title "$issue_title" \
+            --body-file branch-cleanup-issue.md
+
       - name: Upload report
+        if: steps.cadence.outputs.run_report == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: branch-cleanup-dry-run

--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -32,13 +32,17 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: read
 
 jobs:
   audit:
     name: Audit stale branches
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      create_issue: ${{ steps.issue.outputs.create_issue }}
     steps:
       - name: Check 14-day report cadence
         id: cadence
@@ -130,8 +134,28 @@ jobs:
             echo "Skipping issue creation because there are no actionable branch cleanup items." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Upload report
+        if: steps.cadence.outputs.run_report == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: branch-cleanup-dry-run
+          path: branch-cleanup-dry-run.md
+          retention-days: 14
+
+  create-issue:
+    name: Create issue report
+    needs: audit
+    if: needs.audit.outputs.create_issue == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Download report
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: branch-cleanup-dry-run
+
       - name: Create GitHub issue report
-        if: steps.cadence.outputs.run_report == 'true' && steps.issue.outputs.create_issue == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_REPO: ${{ github.repository }}
@@ -161,11 +185,3 @@ jobs:
             --title "$issue_title" \
             --label "$ISSUE_LABEL" \
             --body-file branch-cleanup-issue.md
-
-      - name: Upload report
-        if: steps.cadence.outputs.run_report == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: branch-cleanup-dry-run
-          path: branch-cleanup-dry-run.md
-          retention-days: 14

--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -135,10 +135,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_REPO: ${{ github.repository }}
+          ISSUE_LABEL: branch-cleanup
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           report_date="$(date -u +%F)"
           issue_title="Branch cleanup dry-run report - $report_date"
+
+          if ! gh label list --repo "$ISSUE_REPO" --search "$ISSUE_LABEL" --json name --jq '.[].name' | grep -Fxq "$ISSUE_LABEL"; then
+            gh label create "$ISSUE_LABEL" \
+              --repo "$ISSUE_REPO" \
+              --color "0e8a16" \
+              --description "Branch cleanup automation reports"
+          fi
 
           {
             echo "Automated read-only branch cleanup report."
@@ -151,6 +159,7 @@ jobs:
           gh issue create \
             --repo "$ISSUE_REPO" \
             --title "$issue_title" \
+            --label "$ISSUE_LABEL" \
             --body-file branch-cleanup-issue.md
 
       - name: Upload report

--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -99,8 +99,39 @@ jobs:
         if: steps.cadence.outputs.run_report == 'true'
         run: cat branch-cleanup-dry-run.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Check whether an issue is needed
+        id: issue
+        if: steps.cadence.outputs.run_report == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CREATE_ISSUE_INPUT: ${{ inputs.create_issue }}
+        run: |
+          merged_candidates="$(awk -F': ' '/^- Merged branch cleanup candidates:/ {print $2}' branch-cleanup-dry-run.md)"
+          closed_unmerged="$(awk -F': ' '/^- Closed-unmerged branches needing review:/ {print $2}' branch-cleanup-dry-run.md)"
+          no_pr="$(awk -F': ' '/^- No-PR branches needing review:/ {print $2}' branch-cleanup-dry-run.md)"
+          automation="$(awk -F': ' '/^- Automation branches skipped:/ {print $2}' branch-cleanup-dry-run.md)"
+
+          merged_candidates="${merged_candidates:-0}"
+          closed_unmerged="${closed_unmerged:-0}"
+          no_pr="${no_pr:-0}"
+          automation="${automation:-0}"
+          actionable_count="$((merged_candidates + closed_unmerged + no_pr + automation))"
+
+          echo "actionable_count=$actionable_count" >> "$GITHUB_OUTPUT"
+
+          if [ "$CREATE_ISSUE_INPUT" = "true" ]; then
+            echo "create_issue=true" >> "$GITHUB_OUTPUT"
+            echo "Creating an issue because create_issue=true was requested manually." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$EVENT_NAME" = "schedule" ] && [ "$actionable_count" -gt 0 ]; then
+            echo "create_issue=true" >> "$GITHUB_OUTPUT"
+            echo "Creating an issue because $actionable_count actionable branch cleanup items were found." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "create_issue=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping issue creation because there are no actionable branch cleanup items." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Create GitHub issue report
-        if: steps.cadence.outputs.run_report == 'true' && (github.event_name == 'schedule' || inputs.create_issue)
+        if: steps.cadence.outputs.run_report == 'true' && steps.issue.outputs.create_issue == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Follow-up to the branch cleanup dry-run workflow from #66.

This makes the report actually run on its own instead of relying on someone to remember to trigger it manually. It still stays read-only and does not delete any branches.

## What changed

- Added a scheduled run for the branch cleanup dry-run report
- Uses a 14-day cadence for scheduled reports
- Creates a GitHub issue with the report so the team gets normal GitHub visibility/notifications
- Keeps manual runs available through `workflow_dispatch`
- Adds an optional manual `create_issue` input for testing or one-off reports
- Keeps the existing Action summary and artifact upload

## Notes

GitHub cron does not support “every 14 days” directly, so this runs weekly and only continues on every other week based on a cadence check.

I went with GitHub issues instead of email/Gmail because it avoids extra credentials and keeps the report tied to the repo.

## Testing

- Triggered the workflow manually from this PR branch with `create_issue=true`: https://github.com/grafana/mobile-o11y-demo/actions/runs/26592497670
- Confirmed it created this test issue: https://github.com/grafana/mobile-o11y-demo/issues/68