### PR TITLE
chore: add QuickPizza diagnostics telemetry flow

### DIFF
--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -630,18 +630,16 @@ jobs:
             adb install -r apk/android-native/app-debug.apk
             bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android
 
-            if [ "$RUN_DIAGNOSTICS" = "true" ]; then
-              echo "==> Flutter APK: diagnostics E2E"
-              bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=android --flow=diagnostics
-
-              echo "==> React Native APK: diagnostics E2E"
-              bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=android --flow=diagnostics
-
-              echo "==> Android Native APK: diagnostics E2E"
-              bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android --flow=diagnostics
-            else
-              echo "Skipping diagnostics flow. Set workflow_dispatch input run_diagnostics=true to run it manually."
-            fi
+            # android-emulator-runner executes script lines individually, so
+            # keep diagnostics gating as one-line commands instead of a
+            # multi-line shell if block.
+            [ "$RUN_DIAGNOSTICS" = "true" ] || echo "Skipping diagnostics flow. Set workflow_dispatch input run_diagnostics=true to run it manually."
+            [ "$RUN_DIAGNOSTICS" != "true" ] || echo "==> Flutter APK: diagnostics E2E"
+            [ "$RUN_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=android --flow=diagnostics
+            [ "$RUN_DIAGNOSTICS" != "true" ] || echo "==> React Native APK: diagnostics E2E"
+            [ "$RUN_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=android --flow=diagnostics
+            [ "$RUN_DIAGNOSTICS" != "true" ] || echo "==> Android Native APK: diagnostics E2E"
+            [ "$RUN_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android --flow=diagnostics
 
             echo "E2E tests completed (Flutter, React Native, Android Native on same emulator)."
 

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -12,7 +12,13 @@ on:
       - "Mobiles/ios/**"
       - "compose.grafana-cloud.microservices.yaml"
   # Manual trigger for ad hoc testing
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      run_diagnostics:
+        description: "Also run Debug-tab diagnostics that emit handled exceptions and intentional crashes"
+        required: false
+        default: false
+        type: boolean
   # Scheduled run every hour for continuous telemetry
   schedule:
     - cron: "0 * * * *"
@@ -595,6 +601,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
         env:
           OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+          RUN_DIAGNOSTICS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_diagnostics == true }}
         with:
           api-level: 34
           arch: x86_64
@@ -622,6 +629,19 @@ jobs:
             echo "==> Android Native APK: install and E2E"
             adb install -r apk/android-native/app-debug.apk
             bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android
+
+            if [ "$RUN_DIAGNOSTICS" = "true" ]; then
+              echo "==> Flutter APK: diagnostics E2E"
+              bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=android --flow=diagnostics
+
+              echo "==> React Native APK: diagnostics E2E"
+              bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=android --flow=diagnostics
+
+              echo "==> Android Native APK: diagnostics E2E"
+              bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android --flow=diagnostics
+            else
+              echo "Skipping diagnostics flow. Set workflow_dispatch input run_diagnostics=true to run it manually."
+            fi
 
             echo "E2E tests completed (Flutter, React Native, Android Native on same emulator)."
 
@@ -796,8 +816,14 @@ jobs:
       - name: Run iOS e2e
         env:
           OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+          RUN_DIAGNOSTICS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_diagnostics == true }}
         run: |
           bash Mobiles/e2e/run_e2e_tests.sh --app=ios-native --platform=ios
+          if [ "$RUN_DIAGNOSTICS" = "true" ]; then
+            bash Mobiles/e2e/run_e2e_tests.sh --app=ios-native --platform=ios --flow=diagnostics
+          else
+            echo "Skipping diagnostics flow. Set workflow_dispatch input run_diagnostics=true to run it manually."
+          fi
 
       - name: Upload e2e test results
         if: always()

--- a/Mobiles/e2e/arbigent-e2e_diagnostics.android.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_diagnostics.android.yaml.template
@@ -1,0 +1,115 @@
+# Shared Arbigent diagnostics project for QuickPizza Android (Flutter + React Native + Android Native).
+# run_e2e_tests.sh replaces __ANDROID_PACKAGE__ with the app under test:
+#   - Flutter default:        com.example.flutter_mobile_o11y_demo
+#   - React Native default:   com.quickpizza
+#   - Android Native default: com.grafana.quickpizza
+#
+# This flow intentionally exercises the Debug tab instead of the normal pizza
+# happy path. It emits a handled exception, triggers a native crash, and
+# relaunches the app so persisted crash telemetry can flush on next startup.
+
+scenarios:
+  - id: "start_app"
+    goal: |
+      You should see the QuickPizza home screen.
+
+      SUCCESS CRITERIA:
+      - You see the QuickPizza home screen with a "Pizza, Please!" button.
+
+      __RECOVERY_BLOCK__
+
+    initializationMethods:
+      - type: "Back"
+        times: 3
+      - type: "CleanupData"
+        packageName: "__ANDROID_PACKAGE__"
+      - type: "LaunchApp"
+        packageName: "__ANDROID_PACKAGE__"
+    maxRetry: 2
+    maxStep: 5
+
+  - id: "open_debug_tab"
+    dependency: "start_app"
+    goal: |
+      You should open the QuickPizza Debug tab.
+
+      STEPS:
+      - Tap the bottom navigation tab labeled "Debug".
+      - If the bottom navigation is not visible, press Back once or scroll to recover, then tap "Debug".
+
+      SUCCESS CRITERIA:
+      - You see a Debug screen with controls such as "Send Debug Log", "Send Handled Exception", "Handled exception", or crash buttons.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8
+
+  - id: "send_handled_exception"
+    dependency: "open_debug_tab"
+    goal: |
+      You should emit one handled exception from the Debug tab.
+
+      STEPS:
+      - Tap exactly one handled-exception control.
+      - The button may be labeled "Send Handled Exception" or "Handled exception" depending on the app.
+      - Do not tap any crash, ANR, unhandled exception, or error-log button in this scenario.
+      - After tapping the handled exception button once, wait 1-2 seconds, then OUTPUT "Goal achieved" and STOP.
+
+      SUCCESS CRITERIA:
+      - The handled exception action was tapped once.
+      - The app is still running on the Debug screen.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8
+
+  - id: "trigger_native_crash"
+    dependency: "send_handled_exception"
+    goal: |
+      You should trigger one intentional native crash from the Debug tab.
+
+      STEPS:
+      - Tap exactly one crash control. Acceptable labels include:
+        - "Crash (RuntimeException)"
+        - "Crash (NPE)"
+        - "Crash (custom message)"
+        - "Crash (simulated NPE)"
+        - "RuntimeException / fatalError"
+        - "Null pointer / force unwrap"
+      - If a confirmation dialog appears, tap "Crash now" or "Crash".
+      - After confirming the crash, the app may terminate, disappear, show the Android launcher, or show an Android crash dialog. That is expected.
+
+      SUCCESS CRITERIA:
+      - You tapped one crash control and confirmed the crash if prompted.
+      - The app terminated or left the foreground, or an Android crash dialog appeared.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 1
+    maxStep: 12
+
+  - id: "relaunch_after_crash"
+    dependency: "trigger_native_crash"
+    initializationMethods:
+      - type: "LaunchApp"
+        packageName: "__ANDROID_PACKAGE__"
+    goal: |
+      QuickPizza should be relaunched after the intentional crash.
+
+      WHY:
+      - Android crash reporters often persist the crash and export it on the next app launch.
+
+      STEPS:
+      - If an Android crash dialog is visible, dismiss it.
+      - Launch QuickPizza again if it is not already visible.
+
+      SUCCESS CRITERIA:
+      - You see the QuickPizza app UI again, preferably the home screen or Debug screen.
+      - The app is running after the crash.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8

--- a/Mobiles/e2e/arbigent-e2e_diagnostics.android.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_diagnostics.android.yaml.template
@@ -54,7 +54,8 @@ scenarios:
       - Tap exactly one handled-exception control.
       - The button may be labeled "Send Handled Exception" or "Handled exception" depending on the app.
       - Do not tap any crash, ANR, unhandled exception, or error-log button in this scenario.
-      - After tapping the handled exception button once, wait 1-2 seconds, then OUTPUT "Goal achieved" and STOP.
+      - The UI may not visually change after this tap. That is expected.
+      - After tapping the handled exception button once, OUTPUT "Goal achieved" and STOP. Do not retry the same button just because the screen looks unchanged.
 
       SUCCESS CRITERIA:
       - The handled exception action was tapped once.

--- a/Mobiles/e2e/arbigent-e2e_diagnostics.ios.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_diagnostics.ios.yaml.template
@@ -1,0 +1,115 @@
+# Shared Arbigent diagnostics project for QuickPizza iOS (native iOS + Flutter/RN on iOS).
+# run_e2e_tests.sh replaces __IOS_BUNDLE_ID__ with the app under test:
+#   - iOS Native default:       com.grafana.QuickPizzaIos
+#   - Flutter iOS default:      com.example.flutterMobileO11yDemo
+#   - React Native iOS default: com.quickpizza
+#
+# This flow intentionally exercises the Debug tab instead of the normal pizza
+# happy path. It emits a handled exception, triggers a native crash, and
+# relaunches the app. iOS MetricKit crash diagnostics are OS-managed and may be
+# delivered later, so the immediate verification is that the flow triggered the
+# crash and relaunched the app.
+
+scenarios:
+  - id: "start_app"
+    goal: |
+      You should see the QuickPizza home screen.
+
+      SUCCESS CRITERIA:
+      - You see the QuickPizza home screen with a "Pizza, Please!" button.
+
+      __RECOVERY_BLOCK__
+
+    initializationMethods:
+      - type: "CleanupData"
+        packageName: "__IOS_BUNDLE_ID__"
+      - type: "LaunchApp"
+        packageName: "__IOS_BUNDLE_ID__"
+    maxRetry: 2
+    maxStep: 5
+
+  - id: "open_debug_tab"
+    dependency: "start_app"
+    goal: |
+      You should open the QuickPizza Debug tab.
+
+      STEPS:
+      - Tap the bottom tab labeled "Debug".
+      - If the bottom tab bar is not visible, press Back once or scroll to recover, then tap "Debug".
+
+      SUCCESS CRITERIA:
+      - You see a Debug screen with controls such as "Send Debug Log", "Send Handled Exception", "Handled exception", or crash buttons.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8
+
+  - id: "send_handled_exception"
+    dependency: "open_debug_tab"
+    goal: |
+      You should emit one handled exception from the Debug tab.
+
+      STEPS:
+      - Tap exactly one handled-exception control.
+      - The button may be labeled "Send Handled Exception" or "Handled exception" depending on the app.
+      - Do not tap any crash, unhandled exception, or error-log button in this scenario.
+      - After tapping the handled exception button once, wait 1-2 seconds, then OUTPUT "Goal achieved" and STOP.
+
+      SUCCESS CRITERIA:
+      - The handled exception action was tapped once.
+      - The app is still running on the Debug screen.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8
+
+  - id: "trigger_native_crash"
+    dependency: "send_handled_exception"
+    goal: |
+      You should trigger one intentional native crash from the Debug tab.
+
+      STEPS:
+      - Tap exactly one crash control. Acceptable labels include:
+        - "Crash (fatalError)"
+        - "Crash (force-unwrap nil)"
+        - "Crash (custom message)"
+        - "Crash (simulated NPE)"
+        - "RuntimeException / fatalError"
+        - "Null pointer / force unwrap"
+      - If a confirmation dialog appears, tap "Crash now" or "Crash".
+      - After confirming the crash, the app may terminate, disappear, or return to the iOS Springboard. That is expected.
+
+      SUCCESS CRITERIA:
+      - You tapped one crash control and confirmed the crash if prompted.
+      - The app terminated or left the foreground.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 1
+    maxStep: 12
+
+  - id: "relaunch_after_crash"
+    dependency: "trigger_native_crash"
+    initializationMethods:
+      - type: "LaunchApp"
+        packageName: "__IOS_BUNDLE_ID__"
+    goal: |
+      QuickPizza should be relaunched after the intentional crash.
+
+      WHY:
+      - Flutter and React Native crash reporters may flush persisted crash telemetry on the next launch.
+      - Native iOS MetricKit crash diagnostics can be delayed by the OS, so immediate Grafana crash visibility is not guaranteed.
+
+      STEPS:
+      - Launch QuickPizza again if it is not already visible.
+
+      SUCCESS CRITERIA:
+      - You see the QuickPizza app UI again, preferably the home screen or Debug screen.
+      - The app is running after the crash.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8

--- a/Mobiles/e2e/arbigent-e2e_diagnostics.ios.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_diagnostics.ios.yaml.template
@@ -54,7 +54,8 @@ scenarios:
       - Tap exactly one handled-exception control.
       - The button may be labeled "Send Handled Exception" or "Handled exception" depending on the app.
       - Do not tap any crash, unhandled exception, or error-log button in this scenario.
-      - After tapping the handled exception button once, wait 1-2 seconds, then OUTPUT "Goal achieved" and STOP.
+      - The UI may not visually change after this tap. That is expected.
+      - After tapping the handled exception button once, OUTPUT "Goal achieved" and STOP. Do not retry the same button just because the screen looks unchanged.
 
       SUCCESS CRITERIA:
       - The handled exception action was tapped once.

--- a/Mobiles/e2e/run_e2e_tests.sh
+++ b/Mobiles/e2e/run_e2e_tests.sh
@@ -10,6 +10,7 @@
 #   ./Mobiles/e2e/run_e2e_tests.sh --app=react-native    --platform=android
 #   ./Mobiles/e2e/run_e2e_tests.sh --app=android-native  --platform=android
 #   ./Mobiles/e2e/run_e2e_tests.sh --app=ios-native      --platform=ios
+#   ./Mobiles/e2e/run_e2e_tests.sh --app=flutter         --platform=android --flow=diagnostics
 #
 # Future phases will add:
 #   --app=flutter          --platform=ios
@@ -45,12 +46,12 @@ MOBILES_ROOT="$(cd "$SCRIPT_DIR/.." &> /dev/null && pwd)"
 REPO_ROOT="$(cd "$MOBILES_ROOT/.." &> /dev/null && pwd)"
 REPORT_DIR="$SCRIPT_DIR/report-generator"
 RESULTS_ROOT="$SCRIPT_DIR/results"
-# Platform-specific scenario templates live next to this script. The Android
-# template covers Flutter/RN/Native on Android; the iOS template covers
-# native iOS (and Flutter/RN on iOS once those phases land). The runner picks
-# the file based on --platform; see render_template().
-TEMPLATE_FILE_ANDROID="$SCRIPT_DIR/arbigent-e2e_basic_pizza_flow.android.yaml.template"
-TEMPLATE_FILE_IOS="$SCRIPT_DIR/arbigent-e2e_basic_pizza_flow.ios.yaml.template"
+# Flow/platform-specific scenario templates live next to this script. The
+# runner picks the file based on --flow and --platform; see render_template().
+TEMPLATE_FILE_ANDROID_BASIC="$SCRIPT_DIR/arbigent-e2e_basic_pizza_flow.android.yaml.template"
+TEMPLATE_FILE_IOS_BASIC="$SCRIPT_DIR/arbigent-e2e_basic_pizza_flow.ios.yaml.template"
+TEMPLATE_FILE_ANDROID_DIAGNOSTICS="$SCRIPT_DIR/arbigent-e2e_diagnostics.android.yaml.template"
+TEMPLATE_FILE_IOS_DIAGNOSTICS="$SCRIPT_DIR/arbigent-e2e_diagnostics.ios.yaml.template"
 RECOVERY_HINTS_FILE="$SCRIPT_DIR/arbigent-recovery-hints.txt"
 RENDER_HELPER="$SCRIPT_DIR/render-template.js"
 
@@ -113,6 +114,7 @@ trap cleanup_on_exit INT TERM QUIT
 
 APP=""
 PLATFORM=""
+FLOW="basic"
 
 show_help() {
     cat <<EOF
@@ -125,6 +127,7 @@ Required:
   --platform=<android|ios>                                 Target platform
 
 Other:
+  --flow=<basic|diagnostics>                               Scenario flow (default: basic)
   -h, --help                                               Show this help message
 
 Examples:
@@ -132,6 +135,7 @@ Examples:
   bash $0 --app=react-native --platform=android
   bash $0 --app=android-native --platform=android
   bash $0 --app=ios-native --platform=ios
+  bash $0 --app=flutter --platform=android --flow=diagnostics
 
 Required env vars:
   OPENAI_API_KEY                    OpenAI key used by Arbigent
@@ -150,6 +154,8 @@ while [[ $# -gt 0 ]]; do
         --app)        APP="$2"; shift 2 ;;
         --platform=*) PLATFORM="${1#--platform=}"; shift ;;
         --platform)   PLATFORM="$2"; shift 2 ;;
+        --flow=*)     FLOW="${1#--flow=}"; shift ;;
+        --flow)       FLOW="$2"; shift 2 ;;
         -h|--help)    show_help; exit 0 ;;
         *)            echo "Unknown option: $1" >&2; show_help; exit 1 ;;
     esac
@@ -157,6 +163,11 @@ done
 
 [ -n "$APP" ]      || { show_help; print_error "--app is required"; }
 [ -n "$PLATFORM" ] || { show_help; print_error "--platform is required"; }
+
+case "$FLOW" in
+    basic|diagnostics) ;;
+    *) print_error "Unsupported --flow=$FLOW (supported: basic, diagnostics)" ;;
+esac
 
 ### App configuration table ###################################################
 # Add new apps here as later phases bring them online (native android,
@@ -188,9 +199,14 @@ case "$APP" in
 esac
 
 # All test artifacts (arbigent-result/, arbigent-cache/, archived runs)
-# are written under Mobiles/e2e/results/<app>/ to keep the per-app
-# directories clean and centralise e2e outputs in one place.
-RESULTS_DIR="$RESULTS_ROOT/$APP"
+# are written under Mobiles/e2e/results/<app>/ for the default happy path.
+# Non-default flows add a suffix so diagnostics failures/reports do not
+# overwrite the normal pizza flow for the same app.
+RESULTS_APP_DIR="$APP"
+if [ "$FLOW" != "basic" ]; then
+    RESULTS_APP_DIR="$APP-$FLOW"
+fi
+RESULTS_DIR="$RESULTS_ROOT/$RESULTS_APP_DIR"
 
 case "$PLATFORM" in
     android)
@@ -383,13 +399,15 @@ render_template() {
     fi
 
     local template_file
-    case "$PLATFORM" in
-        android) template_file="$TEMPLATE_FILE_ANDROID" ;;
-        ios)     template_file="$TEMPLATE_FILE_IOS" ;;
-        *)       print_error "render_template: unsupported platform '$PLATFORM'" ;;
+    case "$FLOW:$PLATFORM" in
+        basic:android)       template_file="$TEMPLATE_FILE_ANDROID_BASIC" ;;
+        basic:ios)           template_file="$TEMPLATE_FILE_IOS_BASIC" ;;
+        diagnostics:android) template_file="$TEMPLATE_FILE_ANDROID_DIAGNOSTICS" ;;
+        diagnostics:ios)     template_file="$TEMPLATE_FILE_IOS_DIAGNOSTICS" ;;
+        *)                   print_error "render_template: unsupported flow/platform '$FLOW/$PLATFORM'" ;;
     esac
     if [ ! -f "$template_file" ]; then
-        print_error "Missing Arbigent template for $PLATFORM: $template_file"
+        print_error "Missing Arbigent template for flow=$FLOW platform=$PLATFORM: $template_file"
     fi
 
     node "$RENDER_HELPER" \
@@ -407,7 +425,7 @@ run_tests() {
         ios)     identity="bundle=$IOS_BUNDLE_ID" ;;
         *)       identity="" ;;
     esac
-    print_step "Running E2E tests for app=$APP platform=$PLATFORM ($identity)..."
+    print_step "Running E2E tests for app=$APP platform=$PLATFORM flow=$FLOW ($identity)..."
 
     if [ -z "${OPENAI_API_KEY:-}" ]; then
         print_error "OPENAI_API_KEY environment variable is not set"
@@ -482,6 +500,7 @@ run_tests() {
 echo ""
 echo "╔═══════════════════════════════════════════════════════════════╗"
 printf "║   QuickPizza E2E   app=%-14s   platform=%-7s      ║\n" "$APP" "$PLATFORM"
+printf "║   flow=%-12s                                      ║\n" "$FLOW"
 echo "╚═══════════════════════════════════════════════════════════════╝"
 echo ""
 


### PR DESCRIPTION
## Summary

Added a separate QuickPizza diagnostics flow to the mobile demo telemetry workflow.

The normal hourly pizza flow stays unchanged. Diagnostics are opt-in through `workflow_dispatch` so we can generate handled exceptions and crash telemetry when needed without making every scheduled run look unhealthy.

## What changed

- Added Android and iOS diagnostics Arbigent templates.
- Added `--flow=basic|diagnostics` support to the shared e2e runner.
- Keeps diagnostics results separate under `*-diagnostics`.
- Wires diagnostics into the workflow behind a manual `run_diagnostics` input.
- Diagnostics flow:
  - launch app
  - open Debug tab
  - send handled exception
  - trigger crash
  - relaunch app so crash telemetry can flush

## Testing

Manually ran the workflow from this branch with `run_diagnostics=true`:
https://github.com/grafana/mobile-o11y-demo/actions/runs/26766054801

<img width="849" height="354" alt="Screenshot 2026-06-02 at 11 28 16 AM" src="https://github.com/user-attachments/assets/9d4bc824-fe17-49b8-b871-7a0c5713f4bd" />


Verified:
- workflow passed
- diagnostics artifacts were generated for Android native, Flutter Android, React Native Android, and iOS native
- diagnostics scenarios ran through handled exception, crash, and relaunch
- Grafana showed new handled exception/error data and crash data for the Faro Flutter and React Native demo apps

Task: grafana/app-o11y-kwl#3492

