### PR TITLE
feat(mobile): wire Android R8 symbols and Faro Gradle plugin in demo apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 ### React Native (`Mobiles/react-native/`)
 
-- **Stack:** React Native 0.84.x, `@grafana/faro-react-native` 1.0.0-alpha.1, `faro-react-native` 2.3.1.
+- **Stack:** React Native 0.84.x, `@grafana/faro-react-native` 1.3.0, `@grafana/faro-react-native-tracing` 1.3.0.
 - **Observability:** Faro signals as above, plus dual fetch + XMLHttpRequest auto tracing (`faro.tracing.fetch` + `faro.tracing.xml-http-request`), custom business measurements (`pizza.recommendation`, `pizza.rating`), native crash capture via Faro CrashKit (`type=crash`).
 - **Where it lands:** Frontend Observability plugin (Faro app `QuickPizza_ReactNative`, id `123`).
 - **Config:** `config.json` at `Mobiles/react-native/` — `BASE_URL`, `FARO_COLLECTOR_URL`.

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -1,7 +1,7 @@
 # QuickPizza Android Demo App
 
 A native Kotlin / Jetpack Compose app that demonstrates mobile observability
-using the `[opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android)`
+using the [opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android)
 RUM agent. It connects to the QuickPizza backend and exports traces and
 logs over OTLP/HTTP to Grafana Cloud.
 
@@ -10,14 +10,14 @@ logs over OTLP/HTTP to Grafana Cloud.
 > native Android app specifically.
 
 For setup details (Android Studio, SDK, emulator, physical devices) see
-`[../docs/ANDROID_NATIVE_SETUP.md](../docs/ANDROID_NATIVE_SETUP.md)`.
+[../docs/ANDROID_NATIVE_SETUP.md](../docs/ANDROID_NATIVE_SETUP.md).
 
 For the cross-platform observability overview (Faro vs OTel, what each
 platform emits, dashboards) see
-`[../docs/MOBILE_OBSERVABILITY_OVERVIEW.md](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md)`.
+[../docs/MOBILE_OBSERVABILITY_OVERVIEW.md](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md).
 
 > **Not the same as the Flutter Android app.** The Flutter implementation
-> lives at `[../flutter/](../flutter/)`. This directory is the **native**
+> lives at [../flutter/](../flutter/). This directory is the **native**
 > Kotlin/Compose app.
 
 ---
@@ -54,9 +54,9 @@ persist to `SharedPreferences` and apply on the next launch.
 ## Release build and Android symbols
 
 Release builds enable R8 (`isMinifyEnabled = true`) and emit native debug
-symbols (`ndk.debugSymbolLevel = FULL`). The `**com.grafana.faro`** Gradle plugin
+symbols (`ndk.debugSymbolLevel = FULL`). The **`com.grafana.faro`** Gradle plugin
 (`app/build.gradle.kts`) uploads symbolication artifacts automatically after
-`assembleRelease`, `bundleRelease`, or `**installRelease**` — no manual
+`assembleRelease`, `bundleRelease`, or **`installRelease`** — no manual
 `faro-cli` step is required.
 
 
@@ -70,7 +70,7 @@ symbols (`ndk.debugSymbolLevel = FULL`). The `**com.grafana.faro`** Gradle plugi
 
 Each shipped Android release gets a **release id** — a short label that
 combines the app package name, build number, and version string. For this
-demo that id is `**com.grafana.quickpizza@1@1.0`**.
+demo that id is **`com.grafana.quickpizza@1@1.0`**.
 
 Think of it in three steps:
 
@@ -89,13 +89,13 @@ build tooling and uploads stay in sync. Engineers: the app emits this id as
 `faro.app.bundleId` at runtime; `service.version` remains the human-readable
 version (`1.0`) for dashboards.
 
-> **Also in this repo — the React Native demo** (`[../react-native/](../react-native/)`):
+> **Also in this repo — the React Native demo** ([../react-native/](../react-native/)):
 > same three-step flow and the same release id per build. The difference is
 > *what* gets uploaded at build time. The React Native app is written in
 > JavaScript *and* native Android code, so its release pipeline uploads debug
 > files for **both** layers under one id. **This app** is native Kotlin only,
 > so it uploads debug files for the **Android/native** layer alone. Details:
-> `[../react-native/README.md](../react-native/README.md)`.
+> [../react-native/README.md](../react-native/README.md).
 
 ### Configure upload credentials
 
@@ -152,7 +152,7 @@ ls -l app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
 Manual retry outside Gradle (optional): `faro-cli android upload` with the same
 `FARO_SOURCEMAP_*` env vars and `--application-id` / `--version-code` /
 `--version-name` matching `bundle-id-release.txt` (see
-`[faro-cli` `android upload](https://github.com/grafana/faro-javascript-bundler-plugins/tree/main/packages/faro-cli)`).
+[faro-cli android upload](https://github.com/grafana/faro-javascript-bundler-plugins/tree/main/packages/faro-cli)).
 
 **Verify in Grafana:** install the release build (`./gradlew installRelease`),
 open the app, trigger **Debug → Crash (RuntimeException)**, relaunch, and check
@@ -165,30 +165,30 @@ scrambled labels like `a5.r0`.
 
 The user-facing screens (Home, Login, Profile, About, Debug) are aligned
 with the other QuickPizza mobile apps. See
-`[../FEATURES.md](../FEATURES.md)` for the shared feature spec.
+[../FEATURES.md](../FEATURES.md) for the shared feature spec.
 
 The **Debug** tab exposes:
 
 - Runtime config overrides (backend URL, OTLP endpoint, instance ID, API key).
 - Backend error/latency injection toggles
-(`x-error-record-recommendation`, `x-delay-record-recommendation`,
-`x-error-get-ingredients`, `x-delay-get-ingredients`).
+  (`x-error-record-recommendation`, `x-delay-record-recommendation`,
+  `x-error-get-ingredients`, `x-delay-get-ingredients`).
 - Client-side fault simulation (`useV2PizzaSchema`,
-`skipAuthDepInTools`).
+  `skipAuthDepInTools`).
 - An **OTel SDK section** with a `Disable disk buffering` toggle —
-default-on disk buffering means ~30–45 s end-to-end latency at the
-cost of offline resilience; turning it off gives ~1–6 s latency for
-live demos at the cost of dropping signals if the network is down.
+  default-on disk buffering means ~30–45 s end-to-end latency at the
+  cost of offline resilience; turning it off gives ~1–6 s latency for
+  live demos at the cost of dropping signals if the network is down.
 - **Quick signals** — buttons to send a debug log, an error log, and a
 custom event (`debug.test_event`).
 - **Handled exception** — emits an OTel exception log via
 `logger.exception(...)`.
 - **ANR card** — blocks the main thread for 10 s (same as RN). Android's 5 s ANR
-threshold trips and `event_name=device.anr` is captured by the OTel
-agent; ~5 s of system Wait/Close dialog after that.
+  threshold trips and `event_name=device.anr` is captured by the OTel
+  agent; ~5 s of system Wait/Close dialog after that.
 - **Crash card** — `RuntimeException` and simulated `NullPointerException`
-variants. The OTel-Android `CrashReporter` persists the crash to disk
-and the exporter delivers it on the next app launch.
+  variants. The OTel-Android `CrashReporter` persists the crash to disk
+  and the exporter delivers it on the next app launch.
 
 ---
 

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -1,7 +1,7 @@
 # QuickPizza Android Demo App
 
 A native Kotlin / Jetpack Compose app that demonstrates mobile observability
-using the [`opentelemetry-android`](https://github.com/open-telemetry/opentelemetry-android)
+using the `[opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android)`
 RUM agent. It connects to the QuickPizza backend and exports traces and
 logs over OTLP/HTTP to Grafana Cloud.
 
@@ -10,14 +10,14 @@ logs over OTLP/HTTP to Grafana Cloud.
 > native Android app specifically.
 
 For setup details (Android Studio, SDK, emulator, physical devices) see
-[`../docs/ANDROID_NATIVE_SETUP.md`](../docs/ANDROID_NATIVE_SETUP.md).
+`[../docs/ANDROID_NATIVE_SETUP.md](../docs/ANDROID_NATIVE_SETUP.md)`.
 
 For the cross-platform observability overview (Faro vs OTel, what each
 platform emits, dashboards) see
-[`../docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md).
+`[../docs/MOBILE_OBSERVABILITY_OVERVIEW.md](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md)`.
 
 > **Not the same as the Flutter Android app.** The Flutter implementation
-> lives at [`../flutter/`](../flutter/). This directory is the **native**
+> lives at `[../flutter/](../flutter/)`. This directory is the **native**
 > Kotlin/Compose app.
 
 ---
@@ -51,34 +51,144 @@ persist to `SharedPreferences` and apply on the next launch.
 
 ---
 
+## Release build and Android symbols
+
+Release builds enable R8 (`isMinifyEnabled = true`) and emit native debug
+symbols (`ndk.debugSymbolLevel = FULL`). The `**com.grafana.faro`** Gradle plugin
+(`app/build.gradle.kts`) uploads symbolication artifacts automatically after
+`assembleRelease`, `bundleRelease`, or `**installRelease**` — no manual
+`faro-cli` step is required.
+
+
+| Artifact       | Path (under `app/build/outputs/`)                       |
+| -------------- | ------------------------------------------------------- |
+| R8 mapping     | `mapping/release/mapping.txt`                           |
+| Native symbols | `native-debug-symbols/release/native-debug-symbols.zip` |
+
+
+### How release builds link to readable crash reports
+
+Each shipped Android release gets a **release id** — a short label that
+combines the app package name, build number, and version string. For this
+demo that id is `**com.grafana.quickpizza@1@1.0`**.
+
+Think of it in three steps:
+
+1. **At build time** (your CI or laptop, not on users’ phones), the Gradle
+  plugin uploads debug files for that release to Grafana — the files that
+   turn obfuscated crash output back into real class and file names.
+2. **At runtime**, the installed app only sends lightweight error reports.
+  Each report includes the same release id so Grafana knows *which* build
+   produced the crash.
+3. **In Grafana**, Frontend Observability uses that id to find the files
+  uploaded in step 1 and show a **readable stack trace** instead of
+   scrambled names like `a5.r0`.
+
+The release id is saved locally as `app/build/faro/bundle-id-release.txt` so
+build tooling and uploads stay in sync. Engineers: the app emits this id as
+`faro.app.bundleId` at runtime; `service.version` remains the human-readable
+version (`1.0`) for dashboards.
+
+> **Also in this repo — the React Native demo** (`[../react-native/](../react-native/)`):
+> same three-step flow and the same release id per build. The difference is
+> *what* gets uploaded at build time. The React Native app is written in
+> JavaScript *and* native Android code, so its release pipeline uploads debug
+> files for **both** layers under one id. **This app** is native Kotlin only,
+> so it uploads debug files for the **Android/native** layer alone. Details:
+> `[../react-native/README.md](../react-native/README.md)`.
+
+### Configure upload credentials
+
+Set these in the shell or CI (never hardcode the API key in Gradle):
+
+
+| Variable                  | Source in Grafana                                                             |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| `FARO_SOURCEMAP_ENDPOINT` | Frontend Observability → your app → **Settings → Source maps** (API base URL) |
+| `FARO_SOURCEMAP_APP_ID`   | App id                                                                        |
+| `FARO_SOURCEMAP_STACK_ID` | Stack id                                                                      |
+| `FARO_SOURCEMAP_API_KEY`  | Upload token                                                                  |
+
+
+```kotlin
+// app/build.gradle.kts (already wired)
+faro {
+    endpoint.set(System.getenv("FARO_SOURCEMAP_ENDPOINT"))
+    appId.set(System.getenv("FARO_SOURCEMAP_APP_ID"))
+    stackId.set(System.getenv("FARO_SOURCEMAP_STACK_ID"))
+    apiKey.set(System.getenv("FARO_SOURCEMAP_API_KEY"))
+}
+```
+
+If any variable is missing, `faroUploadSymbolsRelease` **warns and skips** — the
+build still succeeds (useful for local debug builds without upload access). Set
+`faro { enabled = false }` to disable uploads entirely.
+
+### Build and upload
+
+```bash
+cd Mobiles/android
+export FARO_SOURCEMAP_ENDPOINT="https://<your-stack>.grafana.net/api/v1"
+export FARO_SOURCEMAP_APP_ID="<app-id>"
+export FARO_SOURCEMAP_STACK_ID="<stack-id>"
+export FARO_SOURCEMAP_API_KEY="<token>"
+
+./gradlew assembleRelease   # or installRelease to push to a device
+```
+
+**What runs on release:** `faroWriteBundleIdRelease` → build →
+`faroUploadSymbolsRelease` (in-JVM upload to
+`POST …/app/{appId}/symbols/android/{bundleId}`). Look for `[Faro]` lines in
+Gradle output.
+
+Confirm artifacts from the **same** build:
+
+```bash
+ls -l app/build/faro/bundle-id-release.txt
+ls -l app/build/outputs/mapping/release/mapping.txt
+ls -l app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
+```
+
+Manual retry outside Gradle (optional): `faro-cli android upload` with the same
+`FARO_SOURCEMAP_*` env vars and `--application-id` / `--version-code` /
+`--version-name` matching `bundle-id-release.txt` (see
+`[faro-cli` `android upload](https://github.com/grafana/faro-javascript-bundler-plugins/tree/main/packages/faro-cli)`).
+
+**Verify in Grafana:** install the release build (`./gradlew installRelease`),
+open the app, trigger **Debug → Crash (RuntimeException)**, relaunch, and check
+Frontend Observability — the crash should show real Kotlin file names, not
+scrambled labels like `a5.r0`.
+
+---
+
 ## Features
 
 The user-facing screens (Home, Login, Profile, About, Debug) are aligned
 with the other QuickPizza mobile apps. See
-[`../FEATURES.md`](../FEATURES.md) for the shared feature spec.
+`[../FEATURES.md](../FEATURES.md)` for the shared feature spec.
 
 The **Debug** tab exposes:
 
 - Runtime config overrides (backend URL, OTLP endpoint, instance ID, API key).
 - Backend error/latency injection toggles
-  (`x-error-record-recommendation`, `x-delay-record-recommendation`,
-  `x-error-get-ingredients`, `x-delay-get-ingredients`).
+(`x-error-record-recommendation`, `x-delay-record-recommendation`,
+`x-error-get-ingredients`, `x-delay-get-ingredients`).
 - Client-side fault simulation (`useV2PizzaSchema`,
-  `skipAuthDepInTools`).
+`skipAuthDepInTools`).
 - An **OTel SDK section** with a `Disable disk buffering` toggle —
-  default-on disk buffering means ~30–45 s end-to-end latency at the
-  cost of offline resilience; turning it off gives ~1–6 s latency for
-  live demos at the cost of dropping signals if the network is down.
+default-on disk buffering means ~30–45 s end-to-end latency at the
+cost of offline resilience; turning it off gives ~1–6 s latency for
+live demos at the cost of dropping signals if the network is down.
 - **Quick signals** — buttons to send a debug log, an error log, and a
-  custom event (`debug.test_event`).
+custom event (`debug.test_event`).
 - **Handled exception** — emits an OTel exception log via
-  `logger.exception(...)`.
+`logger.exception(...)`.
 - **ANR card** — blocks the main thread for 6 s. Android's 5 s ANR
-  threshold trips and `event_name=device.anr` is captured by the OTel
-  agent.
+threshold trips and `event_name=device.anr` is captured by the OTel
+agent.
 - **Crash card** — `RuntimeException` and simulated `NullPointerException`
-  variants. The OTel-Android `CrashReporter` persists the crash to disk
-  and the exporter delivers it on the next app launch.
+variants. The OTel-Android `CrashReporter` persists the crash to disk
+and the exporter delivers it on the next app launch.
 
 ---
 
@@ -88,10 +198,12 @@ The app uses [`opentelemetry-android`](https://github.com/open-telemetry/opentel
 1.4.0-alpha and exports via OTLP/HTTP. Init lives in
 `app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt`.
 
-| Signal | Examples |
-| --- | --- |
-| **Spans** | `GET` (auto OkHttp), `AppStart` / `Paused` / `Stopped` (auto lifecycle), `pizza.get_recommendation` / `auth.login` / `pizza.rate` (manual) |
-| **Logs** | `screen.view` (auto), `app.jank` (auto, slow rendering), `session.start` (auto), `rum.sdk.init.*` (auto SDK self-telemetry), `exception` (manual `logger.exception`), `device.crash` (auto, next launch), `device.anr` (auto, runtime), `debug.test_event` (manual) |
+
+| Signal    | Examples                                                                                                                                                                                                                                                            |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Spans** | `GET` (auto OkHttp), `AppStart` / `Paused` / `Stopped` (auto lifecycle), `pizza.get_recommendation` / `auth.login` / `pizza.rate` (manual)                                                                                                                          |
+| **Logs**  | `screen.view` (auto), `app.jank` (auto, slow rendering), `session.start` (auto), `rum.sdk.init.`* (auto SDK self-telemetry), `exception` (manual `logger.exception`), `device.crash` (auto, next launch), `device.anr` (auto, runtime), `debug.test_event` (manual) |
+
 
 Core resource attributes: `service.name=quickpizza-android`,
 `service.namespace=quickpizza`, `service.version`,
@@ -105,12 +217,12 @@ session attributes) is inventoried in
 - Lifecycle / `AppStart` / activity-state spans.
 - Slow-rendering / jank detection (`event_name=app.jank`).
 - Crash reporting (`CrashReporter`) — persists unhandled exceptions to
-  disk and emits `event_name=device.crash` on next launch.
+disk and emits `event_name=device.crash` on next launch.
 - ANR detection — emits `event_name=device.anr`.
 - Sessions — 15-minute inactivity timeout, `session.id` stamped on
-  every signal.
+every signal.
 - Disk buffering of OTLP exports for offline resilience (toggle off via
-  the Debug screen).
+the Debug screen).
 
 Where to view the data on the demo stack:
 
@@ -150,22 +262,27 @@ without a rebuild — overrides apply on the next launch.
 ## Troubleshooting
 
 **No telemetry in Grafana**
+
 - Confirm `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY` (or their
-  Debug-screen overrides) are set.
+Debug-screen overrides) are set.
 - Verify the endpoint accepts OTLP/HTTP (not gRPC).
 - Use the Debug tab to send a debug log + handled exception and
-  confirm they arrive.
+confirm they arrive.
 
 **Disk buffering hides recent signals**
+
 - The default ~30–45 s buffering window is intentional for offline
-  resilience. Toggle `Disable disk buffering` from the Debug screen for
-  live demos.
+resilience. Toggle `Disable disk buffering` from the Debug screen for
+live demos.
 
 **App can't reach the backend**
+
 - Emulator: leave `BASE_URL` empty (uses `10.0.2.2:3333`).
 - Physical device: set `BASE_URL` to your machine's LAN IP.
 
 **Build fails with `ClassNotFoundException` / dex errors**
+
 - Ensure `gradle.properties` has
-  `android.useFullClasspathForDexingTransform=true` (required by
-  `opentelemetry-android` with AGP 8.3+).
+`android.useFullClasspathForDexingTransform=true` (required by
+`opentelemetry-android` with AGP 8.3+).
+

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -54,7 +54,7 @@ persist to `SharedPreferences` and apply on the next launch.
 ## Release build and Android symbols
 
 Release builds enable R8 (`isMinifyEnabled = true`) and emit native debug
-symbols (`ndk.debugSymbolLevel = FULL`). The **`com.grafana.faro`** Gradle plugin
+symbols (`ndk.debugSymbolLevel = FULL`). The **`com.grafana.faro.android-symbols`** Gradle plugin
 (`app/build.gradle.kts`) uploads symbolication artifacts automatically after
 `assembleRelease`, `bundleRelease`, or **`installRelease`** — no manual
 `faro-cli` step is required.

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -183,9 +183,9 @@ live demos at the cost of dropping signals if the network is down.
 custom event (`debug.test_event`).
 - **Handled exception** — emits an OTel exception log via
 `logger.exception(...)`.
-- **ANR card** — blocks the main thread for 6 s. Android's 5 s ANR
+- **ANR card** — blocks the main thread for 10 s (same as RN). Android's 5 s ANR
 threshold trips and `event_name=device.anr` is captured by the OTel
-agent.
+agent; ~5 s of system Wait/Close dialog after that.
 - **Crash card** — `RuntimeException` and simulated `NullPointerException`
 variants. The OTel-Android `CrashReporter` persists the crash to disk
 and the exporter delivers it on the next app launch.

--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.bytebuddy)
+    // Auto-uploads R8 mapping.txt + native-debug-symbols.zip after assembleRelease/bundleRelease/installRelease.
+    // NOTE: this module locks the buildscript classpath; after adding this plugin run
+    // `./gradlew --write-locks` (or `dependencies --write-locks`) to refresh the lockfiles.
+    id("com.grafana.faro") version "0.1.0"
 }
 
 // Remove config.json.example from res/raw before the resource merger runs.
@@ -40,7 +44,10 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
@@ -68,6 +75,14 @@ android {
             path = file("src/main/cpp/CMakeLists.txt")
         }
     }
+}
+
+// Grafana Faro symbol upload. Secrets come from the environment / CI — never hardcode the key.
+faro {
+    endpoint.set(System.getenv("FARO_SOURCEMAP_ENDPOINT"))
+    appId.set(System.getenv("FARO_SOURCEMAP_APP_ID"))
+    stackId.set(System.getenv("FARO_SOURCEMAP_STACK_ID"))
+    apiKey.set(System.getenv("FARO_SOURCEMAP_API_KEY"))
 }
 
 dependencies {
@@ -115,6 +130,8 @@ dependencies {
     implementation("com.google.protobuf:protobuf-javalite:3.25.1")
 
     // Testing
+    testImplementation(libs.junit4)
+    testImplementation(libs.proguard.retrace)
     androidTestImplementation(libs.test.runner)
     androidTestImplementation(libs.test.espresso.core)
     androidTestImplementation(libs.test.junit.ext)

--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -44,6 +44,8 @@ android {
 
     buildTypes {
         release {
+            // Demo / local release installs (installRelease requires a signing config).
+            signingConfig = signingConfigs.getByName("debug")
             isMinifyEnabled = true
             ndk {
                 debugSymbolLevel = "FULL"

--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     // Auto-uploads R8 mapping.txt + native-debug-symbols.zip after assembleRelease/bundleRelease/installRelease.
     // NOTE: this module locks the buildscript classpath; after adding this plugin run
     // `./gradlew --write-locks` (or `dependencies --write-locks`) to refresh the lockfiles.
-    id("com.grafana.faro") version "0.1.0"
+    id("com.grafana.faro.android-symbols") version "0.1.0"
 }
 
 // Remove config.json.example from res/raw before the resource merger runs.

--- a/Mobiles/android/app/buildscript-gradle.lockfile
+++ b/Mobiles/android/app/buildscript-gradle.lockfile
@@ -1,4 +1,14 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-empty=classpath
+com.grafana.faro:com.grafana.faro.gradle.plugin:0.1.0=classpath
+com.grafana.faro:faro-android-gradle-plugin:0.1.0=classpath
+com.squareup.okhttp3:okhttp:4.12.0=classpath
+com.squareup.okio:okio-jvm:3.6.0=classpath
+com.squareup.okio:okio:3.6.0=classpath
+org.jetbrains.kotlin:kotlin-stdlib-common:2.2.0=classpath
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10=classpath
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10=classpath
+org.jetbrains.kotlin:kotlin-stdlib:2.2.0=classpath
+org.jetbrains:annotations:13.0=classpath
+empty=

--- a/Mobiles/android/app/buildscript-gradle.lockfile
+++ b/Mobiles/android/app/buildscript-gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.grafana.faro:com.grafana.faro.gradle.plugin:0.1.0=classpath
+com.grafana.faro:com.grafana.faro.android-symbols.gradle.plugin:0.1.0=classpath
 com.grafana.faro:faro-android-gradle-plugin:0.1.0=classpath
 com.squareup.okhttp3:okhttp:4.12.0=classpath
 com.squareup.okio:okio-jvm:3.6.0=classpath

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AndroidPackageInfo.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AndroidPackageInfo.kt
@@ -1,0 +1,26 @@
+package com.grafana.quickpizza.core.config
+
+import android.content.Context
+
+/**
+ * Helper utilities for reading Android package metadata.
+ *
+ * Isolates API level compatibility logic from application config.
+ */
+object AndroidPackageInfo {
+    /**
+     * Returns the app's version code (build number).
+     *
+     * This is Android's incremental build identifier (like iOS CFBundleVersion),
+     * not to be confused with the user-facing version string (versionName).
+     */
+    fun getVersionCode(context: Context): Long = runCatching {
+        val info = context.packageManager.getPackageInfo(context.packageName, 0)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    }.getOrDefault(0L)
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AppConfig.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AppConfig.kt
@@ -24,6 +24,26 @@ class AppConfig @Inject constructor(
     val otlpInstanceId: String get() = config.otlpInstanceId.trim()
     val otlpApiKey: String get() = config.otlpApiKey.trim()
 
+    /** Matches `defaultConfig.applicationId` in `app/build.gradle.kts`. */
+    val applicationId: String get() = context.packageName
+
+    val versionCode: Long
+        get() = runCatching {
+            val info = context.packageManager.getPackageInfo(context.packageName, 0)
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                info.longVersionCode
+            } else {
+                @Suppress("DEPRECATION")
+                info.versionCode.toLong()
+            }
+        }.getOrDefault(0L)
+
+    val versionName: String get() = appVersion
+
+    /** Encoded Android symbols bundle id: `{applicationId}@{versionCode}@{versionName}`. */
+    val symbolsBundleId: String get() =
+        SymbolsBundleId.format(applicationId, versionCode, versionName)
+
     val appVersion: String get() = runCatching {
         context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "unknown"
     }.getOrDefault("unknown")

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AppConfig.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/AppConfig.kt
@@ -28,21 +28,11 @@ class AppConfig @Inject constructor(
     val applicationId: String get() = context.packageName
 
     val versionCode: Long
-        get() = runCatching {
-            val info = context.packageManager.getPackageInfo(context.packageName, 0)
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
-                info.longVersionCode
-            } else {
-                @Suppress("DEPRECATION")
-                info.versionCode.toLong()
-            }
-        }.getOrDefault(0L)
-
-    val versionName: String get() = appVersion
+        get() = AndroidPackageInfo.getVersionCode(context)
 
     /** Encoded Android symbols bundle id: `{applicationId}@{versionCode}@{versionName}`. */
     val symbolsBundleId: String get() =
-        SymbolsBundleId.format(applicationId, versionCode, versionName)
+        SymbolsBundleId.format(applicationId, versionCode, appVersion)
 
     val appVersion: String get() = runCatching {
         context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "unknown"

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/SymbolsBundleId.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/SymbolsBundleId.kt
@@ -1,0 +1,19 @@
+package com.grafana.quickpizza.core.config
+
+/**
+ * Canonical Android symbols bundle id for upload and OTLP resource `faro.app.bundleId`.
+ * Format: `{applicationId}@{versionCode}@{versionName}` (matches `com.grafana.faro` Gradle plugin).
+ */
+object SymbolsBundleId {
+    private const val SEPARATOR = "@"
+
+    fun format(applicationId: String, versionCode: Long, versionName: String): String =
+        "$applicationId$SEPARATOR$versionCode$SEPARATOR$versionName"
+
+    fun validate(bundleId: String): Boolean {
+        val parts = bundleId.split(SEPARATOR)
+        if (parts.size != 3) return false
+        if (parts[0].isBlank() || parts[1].isBlank() || parts[2].isBlank()) return false
+        return parts[1].all { it.isDigit() }
+    }
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/SymbolsBundleId.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/config/SymbolsBundleId.kt
@@ -2,7 +2,7 @@ package com.grafana.quickpizza.core.config
 
 /**
  * Canonical Android symbols bundle id for upload and OTLP resource `faro.app.bundleId`.
- * Format: `{applicationId}@{versionCode}@{versionName}` (matches `com.grafana.faro` Gradle plugin).
+ * Format: `{applicationId}@{versionCode}@{versionName}` (matches `com.grafana.faro.android-symbols` Gradle plugin).
  */
 object SymbolsBundleId {
     private const val SEPARATOR = "@"

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
@@ -119,6 +119,7 @@ class OTelService @Inject constructor(
                 if (osHandler != null) {
                     osHandler.uncaughtException(thread, throwable)
                 } else {
+                    // No prior handler registered; terminate the process to ensure the app crashes for real.
                     android.os.Process.killProcess(android.os.Process.myPid())
                     kotlin.system.exitProcess(10)
                 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
@@ -54,10 +54,13 @@ class OTelService @Inject constructor(
                     enabled(diskBufferingEnabled)
                 }
                 resource {
-                    // Logical OTel service (dashboards, Tempo filters) — not the Android package name.
+                    // Logical service name for traces/dashboards (not the package name).
+                    // This groups all Android app telemetry together, similar to how
+                    // the app name appears in Frontend Observability.
                     put(AttributeKey.stringKey("service.name"), SERVICE_NAME)
                     put(AttributeKey.stringKey("service.namespace"), "quickpizza")
-                    put(AttributeKey.stringKey("service.version"), appConfig.versionName)
+                    // App version - matches the version displayed to users.
+                    put(AttributeKey.stringKey("service.version"), appConfig.appVersion)
                     // Encoded build identity — maps to meta.app.bundleId for Android symbol retrace.
                     put(AttributeKey.stringKey("faro.app.bundleId"), appConfig.symbolsBundleId)
                 }

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
@@ -54,9 +54,12 @@ class OTelService @Inject constructor(
                     enabled(diskBufferingEnabled)
                 }
                 resource {
-                    put(AttributeKey.stringKey("service.name"), "quickpizza-android")
+                    // Logical OTel service (dashboards, Tempo filters) — not the Android package name.
+                    put(AttributeKey.stringKey("service.name"), SERVICE_NAME)
                     put(AttributeKey.stringKey("service.namespace"), "quickpizza")
-                    put(AttributeKey.stringKey("service.version"), appConfig.appVersion)
+                    put(AttributeKey.stringKey("service.version"), appConfig.versionName)
+                    // Encoded build identity — maps to meta.app.bundleId for Android symbol retrace.
+                    put(AttributeKey.stringKey("faro.app.bundleId"), appConfig.symbolsBundleId)
                 }
             }
         }.onFailure { Log.e(TAG, "OTelService initialization failed", it) }.getOrNull()
@@ -140,6 +143,7 @@ class OTelService @Inject constructor(
 
     companion object {
         private const val TAG = "OTelService"
+        const val SERVICE_NAME = "quickpizza-android"
         const val INSTRUMENTATION_SCOPE = "com.grafana.quickpizza"
         private const val CRASH_INSTRUMENTATION_SCOPE = "io.opentelemetry.crash"
         private const val DEVICE_CRASH_EVENT_NAME = "device.crash"

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt
@@ -94,6 +94,10 @@ class OTelService @Inject constructor(
      * *after* that delegation — i.e. after the process is already dead. The queued crash log is
      * dropped, so crashes never appear in the backend (handled exceptions are unaffected because
      * the process stays alive long enough for the normal batch flush).
+     *
+     * We install the outermost handler ourselves: emit `device.crash`, force-flush synchronously,
+     * then hand off to the original OS handler so the app still crashes for real. Because this
+     * replaces the SDK chain as the default handler, the crash is emitted exactly once.
      */
     private fun installCrashFlushHandler(osHandler: Thread.UncaughtExceptionHandler?) {
         val sdk = rum?.openTelemetry as? OpenTelemetrySdk ?: run {
@@ -119,6 +123,7 @@ class OTelService @Inject constructor(
         }
     }
 
+    /** Mirrors the OTel-Android CrashReporter payload so the collector classifies it as a crash. */
     private fun emitDeviceCrash(sdk: OpenTelemetrySdk, thread: Thread, throwable: Throwable) {
         sdk.logsBridge.get(CRASH_INSTRUMENTATION_SCOPE)
             .logRecordBuilder()

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/domain/AuthRepository.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/auth/domain/AuthRepository.kt
@@ -50,8 +50,8 @@ class AuthRepository @Inject constructor(
     }
 
     private data class LoginRequest(
-        val username: String,
-        val password: String,
+        @SerializedName("username") val username: String,
+        @SerializedName("password") val password: String,
     )
 
     private data class LoginResponse(

--- a/Mobiles/android/app/src/test/java/com/grafana/quickpizza/core/config/SymbolsBundleIdTest.kt
+++ b/Mobiles/android/app/src/test/java/com/grafana/quickpizza/core/config/SymbolsBundleIdTest.kt
@@ -1,0 +1,27 @@
+package com.grafana.quickpizza.core.config
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SymbolsBundleIdTest {
+
+    @Test
+    fun formatUsesVersionCodeBeforeVersionName() {
+        assertEquals(
+            "com.grafana.quickpizza@1@1.0",
+            SymbolsBundleId.format("com.grafana.quickpizza", 1L, "1.0"),
+        )
+    }
+
+    @Test
+    fun validateAcceptsEncodedTriple() {
+        assertTrue(SymbolsBundleId.validate("com.grafana.quickpizza@1@1.0"))
+    }
+
+    @Test
+    fun validateRejectsNonNumericVersionCode() {
+        assertFalse(SymbolsBundleId.validate("com.app@beta@1.0"))
+    }
+}

--- a/Mobiles/android/app/src/test/java/com/grafana/quickpizza/core/o11y/R8RetraceTest.kt
+++ b/Mobiles/android/app/src/test/java/com/grafana/quickpizza/core/o11y/R8RetraceTest.kt
@@ -1,0 +1,55 @@
+package com.grafana.quickpizza.core.o11y
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import proguard.retrace.ReTrace
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.LineNumberReader
+import java.io.PrintWriter
+import java.io.StringReader
+import java.nio.charset.StandardCharsets
+
+/**
+ * Verifies that a fixed obfuscated stack + mapping fixture deobfuscate with ProGuard ReTrace
+ * (same tool chain as Android SDK `retrace` / server-side R8 retrace).
+ */
+class R8RetraceTest {
+
+    @Test
+    fun sampleObfuscatedStackDeobfuscatesToDebugViewModel() {
+        val mappingFile = File.createTempFile("quickpizza-mapping", ".txt")
+        mappingFile.deleteOnExit()
+        mappingFile.writeText(SAMPLE_MAPPING)
+
+        val output = ByteArrayOutputStream()
+        val reTrace = ReTrace(mappingFile)
+        reTrace.retrace(
+            LineNumberReader(StringReader(SAMPLE_OBFUSCATED_STACK)),
+            PrintWriter(output, true, StandardCharsets.UTF_8),
+        )
+
+        val retraced = output.toString(StandardCharsets.UTF_8)
+        assertFalse("Expected obfuscated class name to disappear", retraced.contains("a5.r0"))
+        assertTrue(
+            "Expected deobfuscated DebugViewModel frame, got:\n$retraced",
+            retraced.contains("com.grafana.quickpizza.features.debug.DebugViewModel.triggerRuntimeCrash") &&
+                retraced.contains(":163"),
+        )
+    }
+
+    private companion object {
+        const val SAMPLE_MAPPING = """
+            com.grafana.quickpizza.features.debug.DebugViewModel -> a5.r0:
+                163:163:void triggerRuntimeCrash():163:163 -> invoke
+        """
+
+        const val SAMPLE_OBFUSCATED_STACK = """
+            java.lang.RuntimeException: Deliberate crash from QuickPizza debug tab
+                at a5.r0.invoke(DebugViewModel.kt:163)
+                at a5.r0.invoke(Unknown Source)
+                at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:375)
+        """
+    }
+}

--- a/Mobiles/android/app/src/test/java/com/grafana/quickpizza/core/o11y/R8RetraceTest.kt
+++ b/Mobiles/android/app/src/test/java/com/grafana/quickpizza/core/o11y/R8RetraceTest.kt
@@ -40,16 +40,16 @@ class R8RetraceTest {
     }
 
     private companion object {
-        const val SAMPLE_MAPPING = """
+        val SAMPLE_MAPPING = """
             com.grafana.quickpizza.features.debug.DebugViewModel -> a5.r0:
                 163:163:void triggerRuntimeCrash():163:163 -> invoke
-        """
+        """.trimIndent()
 
-        const val SAMPLE_OBFUSCATED_STACK = """
+        val SAMPLE_OBFUSCATED_STACK = """
             java.lang.RuntimeException: Deliberate crash from QuickPizza debug tab
                 at a5.r0.invoke(DebugViewModel.kt:163)
                 at a5.r0.invoke(Unknown Source)
                 at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:375)
-        """
+        """.trimIndent()
     }
 }

--- a/Mobiles/android/gradle/libs.versions.toml
+++ b/Mobiles/android/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ datastore = "1.2.1"
 opentelemetryAndroid = "1.4.0-alpha"
 opentelemetryAndroidInstrumentation = "1.4.0-alpha"
 byteBuddy = "1.18.5"
+junit4 = "4.13.2"
+proguardRetrace = "7.4.2"
 
 [libraries]
 # AndroidX Core
@@ -67,6 +69,8 @@ test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.
 test-junit-ext = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+proguard-retrace = { module = "com.guardsquare:proguard-retrace", version.ref = "proguardRetrace" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/Mobiles/android/settings.gradle.kts
+++ b/Mobiles/android/settings.gradle.kts
@@ -1,5 +1,8 @@
 pluginManagement {
     repositories {
+        // Resolve a locally published `com.grafana.faro` build first (gradle publishToMavenLocal).
+        // Once the plugin is on the Gradle Plugin Portal, gradlePluginPortal() below is enough.
+        mavenLocal()
         google {
             content {
                 includeGroupByRegex("com\\.android.*")

--- a/Mobiles/android/settings.gradle.kts
+++ b/Mobiles/android/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        // Resolve a locally published `com.grafana.faro` build first (gradle publishToMavenLocal).
+        // Resolve a locally published `com.grafana.faro.android-symbols` build first (gradle publishToMavenLocal).
         // Once the plugin is on the Gradle Plugin Portal, gradlePluginPortal() below is enough.
         mavenLocal()
         google {

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -136,8 +136,7 @@ which exercises Faro's `crash` exception path on the next launch.
 
 ### React Native (Faro)
 
-- **SDK:** `faro-react-native` 2.3.1, integration
-  `@grafana/faro-react-native:1.0.0` (alpha — see RN README)
+- **SDK:** `@grafana/faro-react-native` 1.3.0, `@grafana/faro-react-native-tracing` 1.3.0 (see RN README)
 - **Init:** `Mobiles/react-native/src/bootstrap.ts` →
   `core/o11y/faroSdk.ts`
 - **Faro app:** registry name `QuickPizza_ReactNative`, id `123`

--- a/Mobiles/react-native/README.md
+++ b/Mobiles/react-native/README.md
@@ -95,7 +95,7 @@ Edit **`sourcemaps.config.json`** (gitignored, like `config.json`):
 | `apiKey` | Bearer token for the source map API (optional if you use env only). |
 | `bundleId` | Optional default id for **iOS** / dev; **Android release** uses Gradle (`applicationId@versionCode@versionName`) via `@grafana/faro-metro-plugin` — do not set `FARO_BUNDLE_ID` in CI. |
 
-For **Android** release, configure **`com.grafana.faro`** in `android/app/build.gradle` and run **`yarn android --mode=release`** (or `./gradlew :app:assembleRelease` from `android/`). Metro reads the same bundle id from Gradle; R8 symbols upload with the plugin.
+For **Android** release, configure **`com.grafana.faro.android-symbols`** in `android/app/build.gradle` and run **`yarn android --mode=release`** (or `./gradlew :app:assembleRelease` from `android/`). Metro reads the same bundle id from Gradle; R8 symbols upload with the plugin.
 
 For **iOS** release, export source map API vars in the same shell where you run **`yarn ios -- --mode Release`** (or inject them into CI **`xcodebuild`**) so the autolinked upload step can run **`faro-upload-source-map`**. Set **`FARO_BUNDLE_ID`** (or `bundleId` in config) to a stable id per shipped IPA build.
 

--- a/Mobiles/react-native/README.md
+++ b/Mobiles/react-native/README.md
@@ -93,13 +93,13 @@ Edit **`sourcemaps.config.json`** (gitignored, like `config.json`):
 | `appName` | Must match `app.name` in `initializeFaro` (`src/bootstrap.ts`). |
 | `endpoint`, `appId`, `stackId` | **Frontend Observability → your app → Settings → Source maps** (not the Faro collector URL). |
 | `apiKey` | Bearer token for the source map API (optional if you use env only). |
-| `bundleId` | Optional default id; release builds usually set `FARO_BUNDLE_ID` in the shell so it matches the uploaded map. |
+| `bundleId` | Optional default id for **iOS** / dev; **Android release** uses Gradle (`applicationId@versionCode@versionName`) via `@grafana/faro-metro-plugin` — do not set `FARO_BUNDLE_ID` in CI. |
 
-For **Android** release, export these in the same shell where you run **`yarn android --mode=release`**. 
+For **Android** release, configure **`com.grafana.faro`** in `android/app/build.gradle` and run **`yarn android --mode=release`** (or `./gradlew :app:assembleRelease` from `android/`). Metro reads the same bundle id from Gradle; R8 symbols upload with the plugin.
 
-For **iOS** release, export them in the same shell where you run **`yarn ios -- --mode Release`** (or inject them into CI **`xcodebuild`**) so the autolinked upload step can run **`faro-upload-source-map`**.
+For **iOS** release, export source map API vars in the same shell where you run **`yarn ios -- --mode Release`** (or inject them into CI **`xcodebuild`**) so the autolinked upload step can run **`faro-upload-source-map`**. Set **`FARO_BUNDLE_ID`** (or `bundleId` in config) to a stable id per shipped IPA build.
 
-`FARO_BUNDLE_ID`, `FARO_SOURCEMAP_ENDPOINT`, `FARO_SOURCEMAP_APP_ID`, `FARO_SOURCEMAP_STACK_ID`, `FARO_SOURCEMAP_API_KEY`.
+`FARO_SOURCEMAP_ENDPOINT`, `FARO_SOURCEMAP_APP_ID`, `FARO_SOURCEMAP_STACK_ID`, `FARO_SOURCEMAP_API_KEY` (and on iOS, `FARO_BUNDLE_ID` when not using an explicit `bundleId` in `metro.config.js`).
 
 They override the JSON values when set. Use **one** bundle id per build you ship; changing the id means uploading a new map.
 
@@ -107,21 +107,20 @@ They override the JSON values when set. Use **one** bundle id per build you ship
 
 Run everything from **`Mobiles/react-native/`**.
 
-1. **Produce a release install and upload the map** — Metro, Hermes, compose, then the upload step injected by autolinking:
+1. **Produce a release install** — Gradle runs Metro with the Faro plugin; bundle id is `applicationId@versionCode@versionName` (see `android/app/build/faro/bundle-id-release.txt` after build):
 
    ```bash
-   export FARO_BUNDLE_ID="$(git rev-parse --short HEAD)-$(date +%s)"
    export FARO_SOURCEMAP_ENDPOINT="https://<your-stack>.grafana.net/api/v1"
    export FARO_SOURCEMAP_APP_ID="<app-id>"
    export FARO_SOURCEMAP_STACK_ID="<stack-id>"
    export FARO_SOURCEMAP_API_KEY="<token>"
    export ENABLE_FARO_PAYLOAD_DIAGNOSTICS=true
 
-   yarn install   # after changing faro-metro-plugin / faro-cli deps
+   yarn install   # after changing faro-metro-plugin / faro-android-gradle-plugin deps
    yarn android --mode=release
    ```
 
-   **What you should see:** the build finishes without `[Faro] Skipping composed source map upload` unless a required env var is missing. The composed map path is `android/app/build/generated/sourcemaps/react/release/index.android.bundle.map`.
+   **What you should see:** release build completes; R8/native symbols upload via the Faro Gradle plugin when configured. JS source maps use the same bundle id as `meta.app.bundleId`. Composed map path: `android/app/build/generated/sourcemaps/react/release/index.android.bundle.map`.
 
 2. **Check the device payload (optional but fast)** — confirms the bundle id and frame filenames are usable for symbolication:
 
@@ -129,7 +128,7 @@ Run everything from **`Mobiles/react-native/`**.
    adb logcat -d | rg '\[Faro diagnostics\]'
    ```
 
-   **What to look for:** `[Faro diagnostics][init]` includes your `meta.app.bundleId` matching `FARO_BUNDLE_ID`; `[Faro diagnostics][exception]` lists frames with `index.android.bundle`, not only raw `address at …` lines.
+   **What to look for:** `[Faro diagnostics][init]` shows `meta.app.bundleId` like `com.example@42@1.0.0`; `[Faro diagnostics][exception]` lists frames with `index.android.bundle`, not only raw `address at …` lines.
 
 3. **Trigger an error in the app** — open **Debug** → under **Exceptions** tap **Handled exception** (or provoke another JS error you care about).
 
@@ -138,16 +137,17 @@ Run everything from **`Mobiles/react-native/`**.
 **Useful toggles**
 
 - Skip upload while iterating: `FARO_SKIP_SOURCEMAP_UPLOAD=1 yarn android --mode=release`.
-- Re-upload the same composed map manually (same env vars):
+- Re-upload the same composed map manually (read bundle id from Gradle output):
 
   ```bash
+  BUNDLE_ID="$(cat android/app/build/faro/bundle-id-release.txt)"
   npx faro-cli metro upload \
     --map android/app/build/generated/sourcemaps/react/release/index.android.bundle.map \
     --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
     --app-id "$FARO_SOURCEMAP_APP_ID" \
     --stack-id "$FARO_SOURCEMAP_STACK_ID" \
     --api-key "$FARO_SOURCEMAP_API_KEY" \
-    --bundle-id "$FARO_BUNDLE_ID"
+    --bundle-id "$BUNDLE_ID"
   ```
 
 #### iOS — release build, upload, verify

--- a/Mobiles/react-native/android/app/build.gradle
+++ b/Mobiles/react-native/android/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    // Auto-uploads R8 mapping.txt + native-debug-symbols.zip after assembleRelease/bundleRelease.
-    id "com.grafana.faro" version "0.1.0"
+    // Auto-uploads R8 mapping.txt + native .so symbols (AGP zip and/or CMake obj/) after release builds.
+    id "com.grafana.faro.android-symbols" version "0.1.0"
 }
 
 apply plugin: "com.android.application"

--- a/Mobiles/react-native/android/app/build.gradle
+++ b/Mobiles/react-native/android/app/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    // Auto-uploads R8 mapping.txt + native-debug-symbols.zip after assembleRelease/bundleRelease.
+    id "com.grafana.faro" version "0.1.0"
+}
+
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
@@ -57,7 +62,7 @@ react {
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)
@@ -112,9 +117,41 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
+            ndk {
+                debugSymbolLevel 'FULL'
+            }
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+}
+
+def loadSourcemapsConfig = {
+    def configFile = file("${rootProject.projectDir.parentFile}/sourcemaps.config.json")
+    if (!configFile.exists()) {
+        return [:]
+    }
+    try {
+        return new groovy.json.JsonSlurper().parse(configFile)
+    } catch (Exception ignored) {
+        return [:]
+    }
+}()
+
+def faroEnvOrConfig = { String envName, String configKey ->
+    def fromEnv = System.getenv(envName)
+    if (fromEnv != null && !fromEnv.trim().isEmpty()) {
+        return fromEnv.trim()
+    }
+    def fromConfig = loadSourcemapsConfig[configKey]
+    return fromConfig != null ? fromConfig.toString().trim() : null
+}
+
+// Grafana Faro symbol upload. Env vars override sourcemaps.config.json (gitignored).
+faro {
+    endpoint = faroEnvOrConfig("FARO_SOURCEMAP_ENDPOINT", "endpoint")
+    appId = faroEnvOrConfig("FARO_SOURCEMAP_APP_ID", "appId")
+    stackId = faroEnvOrConfig("FARO_SOURCEMAP_STACK_ID", "stackId")
+    apiKey = faroEnvOrConfig("FARO_SOURCEMAP_API_KEY", "apiKey")
 }
 
 dependencies {

--- a/Mobiles/react-native/android/settings.gradle
+++ b/Mobiles/react-native/android/settings.gradle
@@ -1,4 +1,14 @@
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
+pluginManagement {
+    includeBuild("../node_modules/@react-native/gradle-plugin")
+    repositories {
+        // Resolve a locally published `com.grafana.faro` build first (gradle publishToMavenLocal);
+        // gradlePluginPortal() covers it once the plugin is published.
+        mavenLocal()
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'QuickPizza'

--- a/Mobiles/react-native/android/settings.gradle
+++ b/Mobiles/react-native/android/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     includeBuild("../node_modules/@react-native/gradle-plugin")
     repositories {
-        // Resolve a locally published `com.grafana.faro` build first (gradle publishToMavenLocal);
+        // Resolve a locally published `com.grafana.faro.android-symbols` build first (gradle publishToMavenLocal);
         // gradlePluginPortal() covers it once the plugin is published.
         mavenLocal()
         gradlePluginPortal()

--- a/Mobiles/react-native/ios/Podfile.lock
+++ b/Mobiles/react-native/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FaroReactNative (1.2.1):
+  - FaroReactNative (1.3.0):
     - PLCrashReporter (~> 1.11)
     - React-Core
   - FBLazyVector (0.84.1)
@@ -2180,9 +2180,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  FaroReactNative: 8129c56d724e57c6e375b675b92e0d66d12d88d8
+  FaroReactNative: e0f10da721e47afdb405fad89ccedd9e209ddbf1
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: 40d9c07f06e5cfb14add9a995c44cd9260eb8403
+  hermes-engine: 528bfb259b01020633a544e63e8be5e6b6953bb6
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
@@ -2192,7 +2192,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: af87338af8fe3fdf3058328c8001eb9a6c35f2ac
+  React-Core-prebuilt: 9771b8998ebe5dc3e0fb6e37b67c68273428d244
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2255,7 +2255,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: 378c47f88c1f15c3e7af23cf2a6ba1b142da8cef
+  ReactNativeDependencies: a986374004d502715f3265942d16c3ebbdebb1eb
   RNCAsyncStorage: 7a5a6094f9f6b9158e72f1855cd86e769413d851
   RNDeviceInfo: 900bd20e1fd3bfd894e7384cc4a83880c0341bd3
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707

--- a/Mobiles/react-native/metro.config.js
+++ b/Mobiles/react-native/metro.config.js
@@ -1,26 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const withFaroConfig = require('@grafana/faro-metro-plugin').default;
+const { default: withFaroConfig, isIosBundleContext } = require('@grafana/faro-metro-plugin');
 
 /**
  * Basename (no path) for the source map top-level `file` field and upload temp map name.
  * Must match `releaseBundleFilename` in `initializeFaro` for symbolication.
- * There is no `npx react-native bundle` flag for this — set it here (or via FARO_SOURCEMAP_FILE for per-platform CI).
- * Android release bundles often use `index.android.bundle`; iOS often uses `main.jsbundle`.
- *
- * Xcode sets PLATFORM_NAME (e.g. iphoneos, iphonesimulator) during the Bundle React Native
- * script; it does not set FARO_PLATFORM. Without detecting iOS here, Metro would label maps as
- * `index.android.bundle` while devices report `main.jsbundle`, breaking Hermes compose + FE O11y symbolication for iOS.
+ * Xcode sets PLATFORM_NAME during the Bundle React Native script; use FARO_PLATFORM=ios when bundling for iOS outside Xcode.
  */
-const xcPlatform = (process.env.PLATFORM_NAME || '').toLowerCase();
-const isIosBundlePlatform =
-  process.env.FARO_PLATFORM === 'ios' ||
-  xcPlatform.includes('iphone') ||
-  xcPlatform.includes('ipad');
 const defaultSourceMapFile =
   process.env.FARO_SOURCEMAP_FILE ||
-  (isIosBundlePlatform ? 'main.jsbundle' : 'index.android.bundle');
+  (isIosBundleContext() ? 'main.jsbundle' : 'index.android.bundle');
 
 /** Must match `FARO_APP_NAME` in `src/bootstrap.ts` and `initializeFaro` `app.name`. */
 const DEFAULT_FARO_APP_NAME = 'QuickPizza_ReactNative';
@@ -35,7 +25,6 @@ function loadSourcemapsConfig() {
       appId: '',
       stackId: '',
       apiKey: '',
-      bundleId: undefined,
     };
   }
   const raw = fs.readFileSync(configPath, 'utf8');
@@ -45,52 +34,22 @@ function loadSourcemapsConfig() {
       ? parsed.appName.trim()
       : DEFAULT_FARO_APP_NAME;
   const apiKey = typeof parsed.apiKey === 'string' ? parsed.apiKey : '';
-  const bundleId =
-    typeof parsed.bundleId === 'string' && String(parsed.bundleId).trim() !== ''
-      ? String(parsed.bundleId).trim()
-      : undefined;
   return {
     appName,
     endpoint: typeof parsed.endpoint === 'string' ? parsed.endpoint : '',
     appId: typeof parsed.appId === 'string' ? parsed.appId : '',
     stackId: typeof parsed.stackId === 'string' ? parsed.stackId : '',
     apiKey,
-    bundleId,
   };
 }
 
 const sourcemapsStatic = loadSourcemapsConfig();
 
-/** Same rule as `@grafana/faro-bundlers-shared` `cleanAppName` / `exportBundleIdToFile`. */
-function cleanAppNameForFaro(appName) {
-  return appName.toUpperCase().replace(/[^A-Z0-9]/g, '_');
-}
-
 /**
- * Matches the web bundler pattern: `FARO_BUNDLE_ID` first, then per-app
- * `FARO_BUNDLE_ID_${cleanAppName(appName)}` (the latter is what lands in `.env.QUICKPIZZA_REACTNATIVE`
- * when using `skipUpload` + `exportBundleIdToFile` on Webpack/Rollup).
- */
-function resolveFaroBundleId(appName, bundleIdFromFile) {
-  const generic = process.env.FARO_BUNDLE_ID;
-  if (generic != null && String(generic).trim() !== '') {
-    return String(generic).trim();
-  }
-  const perAppKey = `FARO_BUNDLE_ID_${cleanAppNameForFaro(appName)}`;
-  const perApp = process.env[perAppKey];
-  if (perApp != null && String(perApp).trim() !== '') {
-    return String(perApp).trim();
-  }
-  if (bundleIdFromFile != null && String(bundleIdFromFile).trim() !== '') {
-    return String(bundleIdFromFile).trim();
-  }
-  return undefined;
-}
-
-/**
- * Metro + Faro source maps (Hermes release). Static ids live in `sourcemaps.config.json` (see example file).
- * Optional file fields: `apiKey`, `bundleId`. Env wins: FARO_SOURCEMAP_API_KEY, FARO_BUNDLE_ID, FARO_BUNDLE_ID_<CLEAN_APP_NAME>.
- * Env FARO_SOURCEMAP_ENDPOINT | _APP_ID | _STACK_ID override JSON when set (e.g. CI).
+ * Metro + Faro source maps (Hermes release).
+ * Android release bundleId is resolved inside @grafana/faro-metro-plugin from the Faro Gradle
+ * plugin file (applicationId@versionCode@versionName) — omit bundleId here.
+ * Env overrides for upload API only: FARO_SOURCEMAP_*.
  */
 const faroMetroOpts = {
   appName: sourcemapsStatic.appName,
@@ -98,10 +57,8 @@ const faroMetroOpts = {
   appId: process.env.FARO_SOURCEMAP_APP_ID || sourcemapsStatic.appId,
   stackId: process.env.FARO_SOURCEMAP_STACK_ID || sourcemapsStatic.stackId,
   apiKey: process.env.FARO_SOURCEMAP_API_KEY || sourcemapsStatic.apiKey || '',
-  bundleId: resolveFaroBundleId(sourcemapsStatic.appName, sourcemapsStatic.bundleId),
   verbose: process.env.FARO_METRO_VERBOSE === '1',
   gzipContents: true,
-  /** Align with `--bundle-output …/index.android.bundle` (Android) or set FARO_SOURCEMAP_FILE / FARO_PLATFORM=ios. */
   sourceMapFile: defaultSourceMapFile,
 };
 

--- a/Mobiles/react-native/package.json
+++ b/Mobiles/react-native/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@grafana/faro-react-native": "1.2.1",
+    "@grafana/faro-react-native": "file:../../../faro-react-native-sdk/packages/react-native",
     "@grafana/faro-react-native-tracing": "1.2.1",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "@react-native-vector-icons/material-icons": "^13.1.1",
@@ -28,7 +28,8 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@grafana/faro-metro-plugin": "0.2.0",
+    "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli",
+    "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin",
     "@react-native-community/cli": "20.1.0",
     "@react-native-community/cli-platform-android": "20.1.0",
     "@react-native-community/cli-platform-ios": "20.1.0",
@@ -53,7 +54,9 @@
     "node": ">=24.5.0"
   },
   "resolutions": {
-    "@grafana/faro-react-native": "1.2.1",
+    "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli",
+    "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin",
+    "@grafana/faro-react-native": "file:../../../faro-react-native-sdk/packages/react-native",
     "@grafana/faro-react-native-tracing": "1.2.1"
   }
 }

--- a/Mobiles/react-native/package.json
+++ b/Mobiles/react-native/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@grafana/faro-react-native": "file:../../../faro-react-native-sdk/packages/react-native",
-    "@grafana/faro-react-native-tracing": "1.2.1",
+    "@grafana/faro-react-native": "1.3.0",
+    "@grafana/faro-react-native-tracing": "1.3.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "@react-native-vector-icons/material-icons": "^13.1.1",
     "@react-navigation/bottom-tabs": "^6.5.20",
@@ -56,7 +56,7 @@
   "resolutions": {
     "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli",
     "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin",
-    "@grafana/faro-react-native": "file:../../../faro-react-native-sdk/packages/react-native",
-    "@grafana/faro-react-native-tracing": "1.2.1"
+    "@grafana/faro-react-native": "1.3.0",
+    "@grafana/faro-react-native-tracing": "1.3.0"
   }
 }

--- a/Mobiles/react-native/package.json
+++ b/Mobiles/react-native/package.json
@@ -28,8 +28,8 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli",
-    "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin",
+    "@grafana/faro-cli": "0.11.0",
+    "@grafana/faro-metro-plugin": "0.3.0",
     "@react-native-community/cli": "20.1.0",
     "@react-native-community/cli-platform-android": "20.1.0",
     "@react-native-community/cli-platform-ios": "20.1.0",
@@ -54,8 +54,6 @@
     "node": ">=24.5.0"
   },
   "resolutions": {
-    "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli",
-    "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin",
     "@grafana/faro-react-native": "1.3.0",
     "@grafana/faro-react-native-tracing": "1.3.0"
   }

--- a/Mobiles/react-native/sourcemaps.config.example.json
+++ b/Mobiles/react-native/sourcemaps.config.example.json
@@ -1,8 +1,7 @@
 {
   "appName": "QuickPizza_ReactNative",
-  "endpoint": "https://your-stack.grafana.net/api/v1",
-  "appId": "your-frontend-observability-app-id",
-  "stackId": "your-grafana-cloud-stack-id",
-  "apiKey": "",
-  "bundleId": ""
+  "endpoint": "http://localhost:8000/faro/api/v1",
+  "appId": "1",
+  "stackId": "1",
+  "apiKey": "auth_token_value"
 }

--- a/Mobiles/react-native/sourcemaps.config.example.json
+++ b/Mobiles/react-native/sourcemaps.config.example.json
@@ -1,7 +1,7 @@
 {
   "appName": "QuickPizza_ReactNative",
-  "endpoint": "http://localhost:8000/faro/api/v1",
-  "appId": "1",
-  "stackId": "1",
-  "apiKey": "auth_token_value"
+  "endpoint": "https://your-stack.grafana.net/api/v1",
+  "appId": "your-frontend-observability-app-id",
+  "stackId": "your-grafana-cloud-stack-id",
+  "apiKey": ""
 }

--- a/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
+++ b/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
@@ -183,6 +183,21 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
     );
   };
 
+  const confirmNativeAnr = () => {
+    Alert.alert(
+      'Trigger native ANR?',
+      'The UI will freeze for ~10s while the main thread is blocked. Faro reports it as an ANR.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Freeze',
+          style: 'destructive',
+          onPress: () => triggerNativeCrash('anr'),
+        },
+      ],
+    );
+  };
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <ScrollView

--- a/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
+++ b/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
@@ -183,21 +183,6 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
     );
   };
 
-  const confirmNativeAnr = () => {
-    Alert.alert(
-      'Trigger native ANR?',
-      'The UI will freeze for ~10s while the main thread is blocked. Faro reports it as an ANR.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Freeze',
-          style: 'destructive',
-          onPress: () => triggerNativeCrash('anr'),
-        },
-      ],
-    );
-  };
-
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <ScrollView

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1484,17 +1484,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-bundlers-shared@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "@grafana/faro-bundlers-shared@npm:0.10.1"
-  dependencies:
-    ansis: "npm:^4.0.0"
-    tar: "npm:^7.1.0"
-    undici: "npm:^8.1.0"
-  checksum: 10c0/865ff10c8e794e0a4128b5a4c01e64f815c7dbcb7a0dad44ff1242880360f02ae15d409181029c72647019271073b1d5a77faf6c9f78a6846ac5a04c74e49b9f
-  languageName: node
-  linkType: hard
-
 "@grafana/faro-bundlers-shared@npm:^0.11.0":
   version: 0.11.0
   resolution: "@grafana/faro-bundlers-shared@npm:0.11.0"
@@ -1506,20 +1495,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-cli@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "@grafana/faro-cli@npm:0.10.0"
+"@grafana/faro-cli@portal:../../../faro-javascript-bundler-plugins/packages/faro-cli::locator=QuickPizza%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@grafana/faro-cli@portal:../../../faro-javascript-bundler-plugins/packages/faro-cli::locator=QuickPizza%40workspace%3A."
   dependencies:
-    "@grafana/faro-bundlers-shared": "npm:^0.10.1"
+    "@grafana/faro-bundlers-shared": "npm:^0.11.0"
     commander: "npm:^14.0.0"
     dotenv: "npm:^17.0.1"
     glob: "npm:^13.0.0"
     tar: "npm:^7.1.0"
   bin:
     faro-cli: dist/cjs/cli.js
-  checksum: 10c0/c6628803874226d8bb4ac3f3c46e7b4ed3fb431c41c21b40b7301a15841ad9619b3cb512ade351cf160e9d760130c50a891cd80fe84fab65f3c20ce82814fd05
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@grafana/faro-core@npm:^2.2.3":
   version: 2.3.1
@@ -1531,9 +1519,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-metro-plugin@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@grafana/faro-metro-plugin@npm:0.2.0"
+"@grafana/faro-metro-plugin@portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin::locator=QuickPizza%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@grafana/faro-metro-plugin@portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin::locator=QuickPizza%40workspace%3A."
   dependencies:
     "@grafana/faro-bundlers-shared": "npm:^0.11.0"
     "@grafana/faro-cli": "npm:^0.10.0"
@@ -1543,9 +1531,8 @@ __metadata:
     metro: ">=0.81.0"
   bin:
     faro-upload-source-map: bin/faro-upload-source-map.js
-  checksum: 10c0/668c66b908a14dc23115f9a265149b5f0faa83abc313c789043cf984f7e3f04b5f99ca423a74068cf5d2ae0f6569a92fa1babedcde064e9f5b7b39562b66f2f4
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@grafana/faro-react-native-tracing@npm:1.2.1":
   version: 1.2.1
@@ -1569,9 +1556,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-react-native@npm:1.2.1":
+"@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native::locator=QuickPizza%40workspace%3A.":
   version: 1.2.1
-  resolution: "@grafana/faro-react-native@npm:1.2.1"
+  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=224f6a&locator=QuickPizza%40workspace%3A."
   dependencies:
     "@grafana/faro-core": "npm:^2.2.3"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
@@ -1586,7 +1573,7 @@ __metadata:
       optional: true
     react-native-mmkv:
       optional: true
-  checksum: 10c0/07a3844f4f304e8a028afca366efedb7b3bc794bec64d411d224690a2ccd4ae8df5ed666277ffb109d0f0109436026cb6c2978de1981035a905e040fc179d725
+  checksum: 10c0/28f773afb9a30e08f138894c2ba018a3bb63a49fc1d091ecee663a188497121d5c01b78d9fcc41a18ca357a224091da962050292af3d23f8d4566cf979748f12
   languageName: node
   linkType: hard
 
@@ -3302,8 +3289,9 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/runtime": "npm:^7.25.0"
-    "@grafana/faro-metro-plugin": "npm:0.2.0"
-    "@grafana/faro-react-native": "npm:1.2.1"
+    "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli"
+    "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin"
+    "@grafana/faro-react-native": "file:../../../faro-react-native-sdk/packages/react-native"
     "@grafana/faro-react-native-tracing": "npm:1.2.1"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
     "@react-native-community/cli": "npm:20.1.0"

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1495,9 +1495,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-cli@portal:../../../faro-javascript-bundler-plugins/packages/faro-cli::locator=QuickPizza%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@grafana/faro-cli@portal:../../../faro-javascript-bundler-plugins/packages/faro-cli::locator=QuickPizza%40workspace%3A."
+"@grafana/faro-cli@npm:0.11.0, @grafana/faro-cli@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@grafana/faro-cli@npm:0.11.0"
   dependencies:
     "@grafana/faro-bundlers-shared": "npm:^0.11.0"
     commander: "npm:^15.0.0"
@@ -1506,8 +1506,9 @@ __metadata:
     tar: "npm:^7.1.0"
   bin:
     faro-cli: dist/cjs/cli.js
+  checksum: 10c0/707513ef7f1e351f0a774e4b0b729d3a0fd2ebf3036aefa830996ad717e64f53ea9c4e7d9ed03fbfafadb8a0f02eb764a3ce4e98ac82947c6f88320466cf1d0b
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@grafana/faro-core@npm:^2.7.0":
   version: 2.7.1
@@ -1519,9 +1520,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-metro-plugin@portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin::locator=QuickPizza%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@grafana/faro-metro-plugin@portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin::locator=QuickPizza%40workspace%3A."
+"@grafana/faro-metro-plugin@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@grafana/faro-metro-plugin@npm:0.3.0"
   dependencies:
     "@grafana/faro-bundlers-shared": "npm:^0.11.0"
     "@grafana/faro-cli": "npm:^0.11.0"
@@ -1531,8 +1532,9 @@ __metadata:
     metro: ">=0.81.0"
   bin:
     faro-upload-source-map: bin/faro-upload-source-map.js
+  checksum: 10c0/e310d59c7383649b89c0cd393513f4eab9446e512baae6b64798e7cf71eeefb100fc55d6bd41ed85dfeaa9824f0dbda42213f1162274e85aa9ab62e6857e4520
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@grafana/faro-react-native-tracing@npm:1.3.0":
   version: 1.3.0
@@ -3252,8 +3254,8 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/runtime": "npm:^7.25.0"
-    "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli"
-    "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin"
+    "@grafana/faro-cli": "npm:0.11.0"
+    "@grafana/faro-metro-plugin": "npm:0.3.0"
     "@grafana/faro-react-native": "npm:1.3.0"
     "@grafana/faro-react-native-tracing": "npm:1.3.0"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1500,7 +1500,7 @@ __metadata:
   resolution: "@grafana/faro-cli@portal:../../../faro-javascript-bundler-plugins/packages/faro-cli::locator=QuickPizza%40workspace%3A."
   dependencies:
     "@grafana/faro-bundlers-shared": "npm:^0.11.0"
-    commander: "npm:^14.0.0"
+    commander: "npm:^15.0.0"
     dotenv: "npm:^17.0.1"
     glob: "npm:^13.0.0"
     tar: "npm:^7.1.0"
@@ -1508,16 +1508,6 @@ __metadata:
     faro-cli: dist/cjs/cli.js
   languageName: node
   linkType: soft
-
-"@grafana/faro-core@npm:^2.2.3":
-  version: 2.3.1
-  resolution: "@grafana/faro-core@npm:2.3.1"
-  dependencies:
-    "@opentelemetry/api": "npm:^1.9.0"
-    "@opentelemetry/otlp-transformer": "npm:^0.213.0"
-  checksum: 10c0/db8ad2650c8ca4bbb7c62d740fdb0b72633a352eda172b7e0f00ab9cc3bdde49ebab16e6cf4114114c8a7169449f03d5b21085befaa08b4e51229c5825d98616
-  languageName: node
-  linkType: hard
 
 "@grafana/faro-core@npm:^2.7.0":
   version: 2.7.1
@@ -1534,7 +1524,7 @@ __metadata:
   resolution: "@grafana/faro-metro-plugin@portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin::locator=QuickPizza%40workspace%3A."
   dependencies:
     "@grafana/faro-bundlers-shared": "npm:^0.11.0"
-    "@grafana/faro-cli": "npm:^0.10.0"
+    "@grafana/faro-cli": "npm:^0.11.0"
     cross-fetch: "npm:^4.0.0"
     source-map: "npm:^0.7.4"
   peerDependencies:
@@ -1544,12 +1534,12 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@grafana/faro-react-native-tracing@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@grafana/faro-react-native-tracing@npm:1.2.1"
+"@grafana/faro-react-native-tracing@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@grafana/faro-react-native-tracing@npm:1.3.0"
   dependencies:
-    "@grafana/faro-core": "npm:^2.2.3"
-    "@grafana/faro-react-native": "npm:^1.2.1"
+    "@grafana/faro-core": "npm:^2.7.0"
+    "@grafana/faro-react-native": "npm:^1.3.0"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/core": "npm:^2.0.0"
     "@opentelemetry/instrumentation": "npm:^0.208.0"
@@ -1562,13 +1552,13 @@ __metadata:
     "@opentelemetry/semantic-conventions": "npm:^1.32.0"
   peerDependencies:
     react-native: ">=0.70.0"
-  checksum: 10c0/86e5e0ac8d71b330244fe2b63f83eb0caad09e0538431ce42b45c01c1f53c3a500c522e1ec46a475dc70ea55c3684af9a6de2e048d3bf42a400ee55e95773ee7
+  checksum: 10c0/57706e48c84dc8756092ba128238809fae854a628578f8070ab219a94949cb88a9a574fb79cdd622d6328b2baeb47f5962cb58b4f7e9f5715b993046f086e4c6
   languageName: node
   linkType: hard
 
-"@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native::locator=QuickPizza%40workspace%3A.":
-  version: 1.2.1
-  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=f53f59&locator=QuickPizza%40workspace%3A."
+"@grafana/faro-react-native@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@grafana/faro-react-native@npm:1.3.0"
   dependencies:
     "@grafana/faro-core": "npm:^2.7.0"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
@@ -1583,7 +1573,7 @@ __metadata:
       optional: true
     react-native-mmkv:
       optional: true
-  checksum: 10c0/579fd7b37134ec0f9ebb4b8bafb01b0d40f42551e33af3be74e61dae4eb0c66933f9c87c7880b5e26161a1110feea724c64e1f94541f4dfb736844fbf324a789
+  checksum: 10c0/1a67b04efd3aaaf47597ae7e0ad94ac78270194cfd6e2233bcff1d56294075fd0e7e2927b284f7f0fba6a3455ab56869bfcdd378d7656a6d7ba3c3f4f272b76f
   languageName: node
   linkType: hard
 
@@ -2002,15 +1992,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api-logs@npm:0.213.0":
-  version: 0.213.0
-  resolution: "@opentelemetry/api-logs@npm:0.213.0"
-  dependencies:
-    "@opentelemetry/api": "npm:^1.3.0"
-  checksum: 10c0/74421639d518b6d060aae8b0693feb6e7bcf2674951dfadc5ad111fc7285b1ba403010fbf2c5cd82b84267c31faef0bb72e4d61c008c5ec572471a0100e5c493
-  languageName: node
-  linkType: hard
-
 "@opentelemetry/api-logs@npm:0.218.0":
   version: 0.218.0
   resolution: "@opentelemetry/api-logs@npm:0.218.0"
@@ -2035,17 +2016,6 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   checksum: 10c0/f618b63f2f560d052791d2406b1411722aa4b0585031242e6906f869f0a707ffe725c4b29bf18aed1f202e1ab5dfc3a9f769c517ac8521338b33ac8c4265fba9
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/core@npm:2.6.0":
-  version: 2.6.0
-  resolution: "@opentelemetry/core@npm:2.6.0"
-  dependencies:
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10c0/526854a3d8917c82b41bfea6ed48f2e9ae38705d1758710b86f879e5c4910b9dbe7fa03d36205e98ebebe4854ae781116d8f298a10cd0fe2e51138e75926ec3a
   languageName: node
   linkType: hard
 
@@ -2129,23 +2099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-transformer@npm:^0.213.0":
-  version: 0.213.0
-  resolution: "@opentelemetry/otlp-transformer@npm:0.213.0"
-  dependencies:
-    "@opentelemetry/api-logs": "npm:0.213.0"
-    "@opentelemetry/core": "npm:2.6.0"
-    "@opentelemetry/resources": "npm:2.6.0"
-    "@opentelemetry/sdk-logs": "npm:0.213.0"
-    "@opentelemetry/sdk-metrics": "npm:2.6.0"
-    "@opentelemetry/sdk-trace-base": "npm:2.6.0"
-    protobufjs: "npm:^7.0.0"
-  peerDependencies:
-    "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/38ff685e4d3e88354d4995e71e69efd9cde83bec9922fc408f9ac9babc3a5b2dd9f713267b7b02ec80e8181234f2ffb6f91334e3bae3f95e18ce92c73c308b10
-  languageName: node
-  linkType: hard
-
 "@opentelemetry/otlp-transformer@npm:^0.218.0":
   version: 0.218.0
   resolution: "@opentelemetry/otlp-transformer@npm:0.218.0"
@@ -2171,18 +2124,6 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   checksum: 10c0/f08fa69ccccb6d14b6932fabe6f8e097c0dfc41ae8f4c0f6c54fb04bc3d9c04e742da3e22d7240d74b585287101126d97a0da192b493a9724dc07a56ca1b77e0
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/resources@npm:2.6.0":
-  version: 2.6.0
-  resolution: "@opentelemetry/resources@npm:2.6.0"
-  dependencies:
-    "@opentelemetry/core": "npm:2.6.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.3.0 <1.10.0"
-  checksum: 10c0/9c75654690c0917be948ed18453f3085a54541f0db8c8b728515f5a26b67c5fc1f6acd2644462e17368045e3c3fd65f728e8bd0a19c31fe12cc443fa0f0f058c
   languageName: node
   linkType: hard
 
@@ -2223,20 +2164,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-logs@npm:0.213.0":
-  version: 0.213.0
-  resolution: "@opentelemetry/sdk-logs@npm:0.213.0"
-  dependencies:
-    "@opentelemetry/api-logs": "npm:0.213.0"
-    "@opentelemetry/core": "npm:2.6.0"
-    "@opentelemetry/resources": "npm:2.6.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.4.0 <1.10.0"
-  checksum: 10c0/b0916f49061bb92bd8c6133207640fd2dcba8b639299b0673f55c976f1d4452c2434e6d55526787781a9f1b736ea192d8608e3b1daafdb85480967029e491442
-  languageName: node
-  linkType: hard
-
 "@opentelemetry/sdk-logs@npm:0.218.0":
   version: 0.218.0
   resolution: "@opentelemetry/sdk-logs@npm:0.218.0"
@@ -2263,18 +2190,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-metrics@npm:2.6.0":
-  version: 2.6.0
-  resolution: "@opentelemetry/sdk-metrics@npm:2.6.0"
-  dependencies:
-    "@opentelemetry/core": "npm:2.6.0"
-    "@opentelemetry/resources": "npm:2.6.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.9.0 <1.10.0"
-  checksum: 10c0/b174199aa1ef6086a15281eb4f7abac434e5d937e488dfe0929ce7fd7119d829da26997913c55cde56d5350983451678f3157e8bc0cf134a6186cee812307f31
-  languageName: node
-  linkType: hard
-
 "@opentelemetry/sdk-metrics@npm:2.7.1":
   version: 2.7.1
   resolution: "@opentelemetry/sdk-metrics@npm:2.7.1"
@@ -2297,19 +2212,6 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   checksum: 10c0/a67715b71d7253cd61ea79954f56491796ac7a660d03d5381fd81defd4546042bb465b27e1b6eee4b1ed32c00305a5349a16d04fd44314c9a1d371a0a638107a
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/sdk-trace-base@npm:2.6.0":
-  version: 2.6.0
-  resolution: "@opentelemetry/sdk-trace-base@npm:2.6.0"
-  dependencies:
-    "@opentelemetry/core": "npm:2.6.0"
-    "@opentelemetry/resources": "npm:2.6.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.3.0 <1.10.0"
-  checksum: 10c0/92363197f17d37adf206299da95f683fc039a77f9477caad4bbd6599561cab699c29a1a72830cb1271d7ffc50cd2ed061e85e92f69d06e3fa1946bb742a41ce2
   languageName: node
   linkType: hard
 
@@ -3352,8 +3254,8 @@ __metadata:
     "@babel/runtime": "npm:^7.25.0"
     "@grafana/faro-cli": "portal:../../../faro-javascript-bundler-plugins/packages/faro-cli"
     "@grafana/faro-metro-plugin": "portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin"
-    "@grafana/faro-react-native": "file:../../../faro-react-native-sdk/packages/react-native"
-    "@grafana/faro-react-native-tracing": "npm:1.2.1"
+    "@grafana/faro-react-native": "npm:1.3.0"
+    "@grafana/faro-react-native-tracing": "npm:1.3.0"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
     "@react-native-community/cli": "npm:20.1.0"
     "@react-native-community/cli-platform-android": "npm:20.1.0"
@@ -4264,10 +4166,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^14.0.0":
-  version: 14.0.3
-  resolution: "commander@npm:14.0.3"
-  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
+"commander@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "commander@npm:15.0.0"
+  checksum: 10c0/539229c171914ea1ccd45ee5f10d924289a12a684ea3a7a44147abe54003c35ed6de9ae4ad198d88c29fdf403dca0428451a388234e6dc01b6faa978fb207206
   languageName: node
   linkType: hard
 
@@ -8047,7 +7949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.0.0, protobufjs@npm:^7.3.0":
+"protobufjs@npm:^7.3.0":
   version: 7.5.5
   resolution: "protobufjs@npm:7.5.5"
   dependencies:

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1519,6 +1519,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/faro-core@npm:^2.7.0":
+  version: 2.7.1
+  resolution: "@grafana/faro-core@npm:2.7.1"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/otlp-transformer": "npm:^0.218.0"
+  checksum: 10c0/30cfe6644c57cf8c515198eb058600537646568103549cc065f5a6362b8c5a56342d9f5c6dd51dcb6a8849bfc67b0a4268a2dcbeb8dc56c52067fa358d0f5379
+  languageName: node
+  linkType: hard
+
 "@grafana/faro-metro-plugin@portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin::locator=QuickPizza%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-metro-plugin@portal:../../../faro-javascript-bundler-plugins/packages/faro-metro-plugin::locator=QuickPizza%40workspace%3A."
@@ -1558,9 +1568,9 @@ __metadata:
 
 "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native::locator=QuickPizza%40workspace%3A.":
   version: 1.2.1
-  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=44bcad&locator=QuickPizza%40workspace%3A."
+  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=f53f59&locator=QuickPizza%40workspace%3A."
   dependencies:
-    "@grafana/faro-core": "npm:^2.2.3"
+    "@grafana/faro-core": "npm:^2.7.0"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
     react-native-device-info: "npm:^11.1.0"
   peerDependencies:
@@ -1573,7 +1583,7 @@ __metadata:
       optional: true
     react-native-mmkv:
       optional: true
-  checksum: 10c0/f25fbb986925ae042483559f9a358dd3701eecc83d549fa8f92330a5c107c0dab161343ff95846ba7e662edeb7cf7ff15ec9a7339468c6a64423fb50d5c2a0b7
+  checksum: 10c0/579fd7b37134ec0f9ebb4b8bafb01b0d40f42551e33af3be74e61dae4eb0c66933f9c87c7880b5e26161a1110feea724c64e1f94541f4dfb736844fbf324a789
   languageName: node
   linkType: hard
 
@@ -2001,6 +2011,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.218.0":
+  version: 0.218.0
+  resolution: "@opentelemetry/api-logs@npm:0.218.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.3.0"
+  checksum: 10c0/39ed739f6c9ef4b4a1d4c8afb18c388a0b4ee9527d4afcf16c2e7beacebcc256ff6407ae27042a4a39509fc78d87ecf991c3efbcbf7f339ea9e65a8fa39468cd
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.9.0":
   version: 1.9.1
   resolution: "@opentelemetry/api@npm:1.9.1"
@@ -2127,6 +2146,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/otlp-transformer@npm:^0.218.0":
+  version: 0.218.0
+  resolution: "@opentelemetry/otlp-transformer@npm:0.218.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.218.0"
+    "@opentelemetry/core": "npm:2.7.1"
+    "@opentelemetry/resources": "npm:2.7.1"
+    "@opentelemetry/sdk-logs": "npm:0.218.0"
+    "@opentelemetry/sdk-metrics": "npm:2.7.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.7.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/0be6d38912945d7f44a141af08b27d3a20a117e5e732d06304dcb1b2b781c1a4096207a8855dadddf45c7d51db4938bd5bf764c9c55e71335bd1d3464e0d308f
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/resources@npm:2.2.0":
   version: 2.2.0
   resolution: "@opentelemetry/resources@npm:2.2.0"
@@ -2202,6 +2237,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-logs@npm:0.218.0":
+  version: 0.218.0
+  resolution: "@opentelemetry/sdk-logs@npm:0.218.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.218.0"
+    "@opentelemetry/core": "npm:2.7.1"
+    "@opentelemetry/resources": "npm:2.7.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.4.0 <1.10.0"
+  checksum: 10c0/2b65f32d59df0fdd712042029e459e544666a1848b8ef2b5bed25d68404e25dc46a67aec587b501e0e4d72f2967e355ffea162f6cbcf2a89c64e6e2971650392
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-metrics@npm:2.2.0":
   version: 2.2.0
   resolution: "@opentelemetry/sdk-metrics@npm:2.2.0"
@@ -2223,6 +2272,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.9.0 <1.10.0"
   checksum: 10c0/b174199aa1ef6086a15281eb4f7abac434e5d937e488dfe0929ce7fd7119d829da26997913c55cde56d5350983451678f3157e8bc0cf134a6186cee812307f31
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:2.7.1":
+  version: 2.7.1
+  resolution: "@opentelemetry/sdk-metrics@npm:2.7.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.7.1"
+    "@opentelemetry/resources": "npm:2.7.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.9.0 <1.10.0"
+  checksum: 10c0/31e21e5b4357cb33a29ab180e0e1ad0bd7516ebeca4712285809c1b89f3069b94d7dbdd6b1877ac813c172eca1a1c87727f9c4bcbf1c4580b3dffb3559f671c2
   languageName: node
   linkType: hard
 

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1558,7 +1558,7 @@ __metadata:
 
 "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native::locator=QuickPizza%40workspace%3A.":
   version: 1.2.1
-  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=934822&locator=QuickPizza%40workspace%3A."
+  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=42f224&locator=QuickPizza%40workspace%3A."
   dependencies:
     "@grafana/faro-core": "npm:^2.2.3"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
@@ -1573,7 +1573,7 @@ __metadata:
       optional: true
     react-native-mmkv:
       optional: true
-  checksum: 10c0/5d60741afebf1a897df3c956b402a1e978911bb909bb80310f90b756c3a384245901a73559f89dd2258cb693fccfa760d76f7053f9eea6da705f9c237ed551c9
+  checksum: 10c0/c037809c8492821779bd779244e604f521568a172923a3aad7092c45c366709061f7374981c7d214e0a067f3d9bb78ec1a8f42f28d0ccf4e7212d96bba2af346
   languageName: node
   linkType: hard
 

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1558,7 +1558,7 @@ __metadata:
 
 "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native::locator=QuickPizza%40workspace%3A.":
   version: 1.2.1
-  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=224f6a&locator=QuickPizza%40workspace%3A."
+  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=934822&locator=QuickPizza%40workspace%3A."
   dependencies:
     "@grafana/faro-core": "npm:^2.2.3"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
@@ -1573,7 +1573,7 @@ __metadata:
       optional: true
     react-native-mmkv:
       optional: true
-  checksum: 10c0/28f773afb9a30e08f138894c2ba018a3bb63a49fc1d091ecee663a188497121d5c01b78d9fcc41a18ca357a224091da962050292af3d23f8d4566cf979748f12
+  checksum: 10c0/5d60741afebf1a897df3c956b402a1e978911bb909bb80310f90b756c3a384245901a73559f89dd2258cb693fccfa760d76f7053f9eea6da705f9c237ed551c9
   languageName: node
   linkType: hard
 

--- a/Mobiles/react-native/yarn.lock
+++ b/Mobiles/react-native/yarn.lock
@@ -1558,7 +1558,7 @@ __metadata:
 
 "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native::locator=QuickPizza%40workspace%3A.":
   version: 1.2.1
-  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=42f224&locator=QuickPizza%40workspace%3A."
+  resolution: "@grafana/faro-react-native@file:../../../faro-react-native-sdk/packages/react-native#../../../faro-react-native-sdk/packages/react-native::hash=44bcad&locator=QuickPizza%40workspace%3A."
   dependencies:
     "@grafana/faro-core": "npm:^2.2.3"
     "@react-native-async-storage/async-storage": "npm:^1.21.0"
@@ -1573,7 +1573,7 @@ __metadata:
       optional: true
     react-native-mmkv:
       optional: true
-  checksum: 10c0/c037809c8492821779bd779244e604f521568a172923a3aad7092c45c366709061f7374981c7d214e0a067f3d9bb78ec1a8f42f28d0ccf4e7212d96bba2af346
+  checksum: 10c0/f25fbb986925ae042483559f9a358dd3701eecc83d549fa8f92330a5c107c0dab161343ff95846ba7e662edeb7cf7ff15ec9a7339468c6a64423fb50d5c2a0b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Wire the QuickPizza mobile demo apps for **Android native symbolication**:

- **Native Android (`Mobiles/android`)** — enable R8 in release (`isMinifyEnabled = true`, `ndk.debugSymbolLevel = FULL`), add the `com.grafana.faro` Gradle plugin for R8 mapping + native symbol upload, and emit `faro.app.bundleId` (`{applicationId}@{versionCode}@{versionName}`) from `OTelService` for collector-side retrace lookup.
- **React Native (`Mobiles/react-native`)** — same Faro Gradle plugin + release ProGuard/R8 setup; Metro no longer sets `bundleId` manually — it is resolved from Gradle via `@grafana/faro-metro-plugin`.
- **Debug / validation** — refactor `QuickPizzaCrashModule` with obfuscatable private crash helpers; add an **ANR (block main thread ~10s)** button on the Debug screen. Add `Mobiles/android/scripts/retrace-release-stack.sh` and README steps to validate R8 retrace locally before backend upload exists.
- **Docs** — expand Android and RN READMEs with release build, symbol upload, and retrace smoke-test instructions.

## Crash telemetry reliability (OTel-Android workaround)

Native Android unhandled crashes were never reaching the collector, so the symbolication demo had nothing to retrace. Root cause is an ordering bug in `opentelemetry-android`'s crash instrumentation: the auto-installed `CrashReporter` emits the `device.crash` log and then immediately delegates to the OS process-killer, while the SDK's own `FlushOnCrashExceptionHandler` only force-flushes **after** that delegation — i.e. after the process is already dead. The queued crash log is dropped. Handled exceptions are unaffected because the process stays alive long enough for the normal batch flush.

Workaround in `OTelService`: install our own outermost `Thread.setDefaultUncaughtExceptionHandler` that emits `device.crash` (mirroring the `CrashReporter` payload), force-flushes the logger and tracer providers **synchronously** with a short timeout, then hands off to the original OS handler so the app still crashes for real. Because this replaces the SDK chain as the default handler, the crash is emitted exactly once.

This is a demo-side mitigation until the SDK guarantees flush-before-termination. Related upstream tracking:
- open-telemetry/opentelemetry-android#1398 — process terminates unexpectedly from a crash/force close
- open-telemetry/opentelemetry-android#815 — flushing events on app start and finish

### Other demo ergonomics in the same change

- `build.gradle.kts`: release builds use the debug signing config so `installRelease` works locally without a release keystore.
- `AuthRepository`: annotate `LoginRequest` fields with `@SerializedName` so R8 minification keeps the wire-format field names.
- Debug ANR raised from 6s to 10s (matching the RN demo) so the system ANR dialog stays open long enough to interact with.
- `run-android.sh`: auto-start an emulator when none is connected; add `--emulator-only` / `--avd` flags for E2E/CI use.

### Dependency note

This branch temporarily links `@grafana/faro-react-native`, `@grafana/faro-metro-plugin`, and `@grafana/faro-cli` to local workbench repos for cross-repo development. **Before merge**, pin to published npm/Gradle versions once the Faro Android Gradle plugin and related SDK changes are released.

## Verification

### React Native — release + symbols

From `Mobiles/react-native/`:

1. Copy `sourcemaps.config.example.json` → `sourcemaps.config.json` and set upload credentials.
2. Publish Faro Gradle plugin locally if needed: `publishToMavenLocal` in `faro-android-gradle-plugin`.
3. `yarn install && yarn android --mode=release`
4. Confirm `android/app/build/faro/bundle-id-release.txt` contains `com.quickpizza@1@1.0`.
5. Debug → **Crash (RuntimeException)** or **ANR** → verify payloads in Grafana / logcat diagnostics.

### Native Android — local retrace gate

From `Mobiles/android/`:

1. `./gradlew assembleRelease`
3. `./gradlew installRelease` → Debug → crash → `./scripts/retrace-release-stack.sh /tmp/quickpizza-crash.txt`

### Skip upload while iterating

- `FARO_SKIP_SOURCEMAP_UPLOAD=1 yarn android --mode=release`

**DEMO**:

https://github.com/user-attachments/assets/346dfab6-e498-40db-a308-3a1b7b51f9b6

<img width="3018" height="1038" alt="Android Logs - Sourcesmaps and Symbols uploaded" src="https://github.com/user-attachments/assets/592671a3-bef7-4fc8-b28d-359972478dff" />
