### PR TITLE
fix(ci): unblock mobile telemetry runtime jobs

### DIFF
--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -9,6 +9,16 @@ on:
         required: false
         default: false
         type: boolean
+  # Temporary: run full telemetry on PR #74 to validate this workflow fix.
+  pull_request:
+    paths:
+      - ".github/workflows/mobile_demo_telemetry.yaml"
+      - "Mobiles/e2e/**"
+      - "Mobiles/flutter/**"
+      - "Mobiles/react-native/**"
+      - "Mobiles/android/**"
+      - "Mobiles/ios/**"
+      - "compose.grafana-cloud.microservices.yaml"
   # Scheduled run every hour for continuous telemetry
   schedule:
     - cron: "0 * * * *"
@@ -38,6 +48,7 @@ env:
 jobs:
   run-mobile-demo:
     name: Run Android Mobile Demo
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-mobile-telemetry-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: mobile-demo-telemetry
@@ -324,6 +335,7 @@ jobs:
 
   run-ios-mobile-demo:
     name: Run iOS Mobile Demo
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-mobile-telemetry-ci')
     # macOS-only: xcrun simctl + the booted iOS simulator only work on macOS.
     runs-on: macos-26
     timeout-minutes: 180

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -51,7 +51,7 @@ jobs:
     if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-mobile-telemetry-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: mobile-demo-telemetry
+    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
     permissions:
       id-token: write
       contents: read
@@ -339,7 +339,7 @@ jobs:
     # macOS-only: xcrun simctl + the booted iOS simulator only work on macOS.
     runs-on: macos-26
     timeout-minutes: 180
-    environment: mobile-demo-telemetry
+    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -9,16 +9,6 @@ on:
         required: false
         default: false
         type: boolean
-  # Temporary: run full telemetry on PR #74 to validate this workflow fix.
-  pull_request:
-    paths:
-      - ".github/workflows/mobile_demo_telemetry.yaml"
-      - "Mobiles/e2e/**"
-      - "Mobiles/flutter/**"
-      - "Mobiles/react-native/**"
-      - "Mobiles/android/**"
-      - "Mobiles/ios/**"
-      - "compose.grafana-cloud.microservices.yaml"
   # Scheduled run every hour for continuous telemetry
   schedule:
     - cron: "0 * * * *"
@@ -48,10 +38,9 @@ env:
 jobs:
   run-mobile-demo:
     name: Run Android Mobile Demo
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-mobile-telemetry-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
+    environment: mobile-demo-telemetry
     permissions:
       id-token: write
       contents: read
@@ -335,11 +324,10 @@ jobs:
 
   run-ios-mobile-demo:
     name: Run iOS Mobile Demo
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-mobile-telemetry-ci')
     # macOS-only: xcrun simctl + the booted iOS simulator only work on macOS.
     runs-on: macos-26
     timeout-minutes: 180
-    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
+    environment: mobile-demo-telemetry
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -79,6 +79,10 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
 
+      - name: Build QuickPizza backend image
+        run: |
+          docker build -t quickpizza-mobile-local:ci .
+
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -213,8 +217,7 @@ jobs:
           DEPLOYMENT_ENVIRONMENT: ci
           # Use dev Alloy config for grafana-dev.net stack
           ALLOY_FILE_NAME: cloud-dev.alloy
-          # Mobile fork image (k6 workflows keep upstream quickpizza-local).
-          QUICKPIZZA_IMAGE: ghcr.io/grafana/quickpizza-mobile-local:latest
+          QUICKPIZZA_IMAGE: quickpizza-mobile-local:ci
         run: |
           echo "Starting QuickPizza backend (Grafana Cloud microservices + dev Alloy override)..."
           docker compose -f compose.grafana-cloud.microservices.yaml -f compose.grafana-cloud.dev-override.yaml up -d
@@ -412,7 +415,7 @@ jobs:
             exit 1
           fi
           echo "Built app: $APP_PATH"
-          echo "app_path=$APP_PATH" >> "$GITHUB_OUTPUT"
+          echo "app_path=$(pwd)/$APP_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload iOS build log
         if: failure()

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   run-mobile-demo:
-    name: Run Mobile Demo
+    name: Run Android Mobile Demo
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: mobile-demo-telemetry


### PR DESCRIPTION
## What changed

- Build a local `quickpizza-mobile-local:ci` Docker image before the Android telemetry runtime starts.
- Point Docker Compose at that local image instead of `ghcr.io/grafana/quickpizza-mobile-local:latest`.
- Emit the native iOS simulator `.app` path as an absolute path, matching the Flutter and React Native iOS app outputs.

## Why

The manually approved scheduled run `27192828350` failed after all mobile builds completed:

- Android failed immediately in `Start QuickPizza backend (Docker Compose)`.
- iOS failed immediately in `Install iOS apps and run e2e tests`.

The Android workflow currently pulls `ghcr.io/grafana/quickpizza-mobile-local:latest`, but anonymous GHCR access for that package is denied. Building the image locally avoids package visibility/token drift and avoids mutable `latest` behavior.

The iOS native app build step ran from `Mobiles/ios` and wrote `app_path` as a relative `DerivedData/...` path. The later install step runs from the repository root, so that relative path points at the wrong directory. Writing an absolute path fixes the handoff.

## Verification

- Parsed `.github/workflows/mobile_demo_telemetry.yaml` with the Ruby YAML parser.
- Ran `git diff --check`.
- Could not fetch raw GitHub job logs/artifacts because the API requires repo admin/auth for this repository, but job step metadata and timings were available via the API.