### PR TITLE
fix(ci): export iOS backend telemetry

### DIFF
--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -343,6 +343,8 @@ jobs:
             OTLP_ENDPOINT=otlp_endpoint_android_native:value
             OTLP_INSTANCE_ID=otlp_instance_id_android_native:value
             OTLP_API_KEY=otlp_api_key_android_native:value
+            GRAFANA_CLOUD_STACK=grafana_cloud_stack:value
+            GRAFANA_CLOUD_TOKEN=grafana_cloud_token:value
             OPENAI_API_KEY=openai_api_key:value
 
       - name: Checkout code
@@ -572,6 +574,87 @@ jobs:
           set -e
           make build-go
 
+      - name: Start Alloy for iOS backend telemetry
+        env:
+          GRAFANA_CLOUD_STACK: ${{ env.GRAFANA_CLOUD_STACK }}
+          GRAFANA_CLOUD_TOKEN: ${{ env.GRAFANA_CLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          case "$(uname -m)" in
+            arm64) ALLOY_ARCH="arm64" ;;
+            x86_64) ALLOY_ARCH="amd64" ;;
+            *) echo "Unsupported macOS architecture: $(uname -m)" && exit 1 ;;
+          esac
+
+          ALLOY_ZIP="alloy-darwin-${ALLOY_ARCH}.zip"
+          curl -fsSL -o "$ALLOY_ZIP" "https://github.com/grafana/alloy/releases/download/v1.14.2/${ALLOY_ZIP}"
+          curl -fsSL -o alloy-SHA256SUMS "https://github.com/grafana/alloy/releases/download/v1.14.2/SHA256SUMS"
+          grep " ${ALLOY_ZIP}$" alloy-SHA256SUMS | shasum -a 256 -c -
+          unzip -q "$ALLOY_ZIP" -d alloy-bin
+          ALLOY_BIN="$(find alloy-bin -type f -name 'alloy*' | head -1)"
+          chmod +x "$ALLOY_BIN"
+
+          cat > alloy-ios-ci.alloy <<'EOF'
+          import.file "grafana_cloud" {
+            filename = "deployments/docker-compose/grafana-cloud/grafana_cloud_stack.alloy"
+          }
+
+          grafana_cloud.stack "receivers" {
+            stack_name = env("GRAFANA_CLOUD_STACK")
+            token = env("GRAFANA_CLOUD_TOKEN")
+            api_url = coalesce(env("GRAFANA_CLOUD_API_URL"), "https://grafana-dev.com/api/instances/")
+          }
+
+          otelcol.receiver.otlp "ios_backend" {
+            grpc {
+              endpoint = "127.0.0.1:4317"
+            }
+            http {
+              endpoint = "127.0.0.1:4318"
+            }
+            output {
+              metrics = [otelcol.processor.batch.default.input]
+              traces  = [otelcol.processor.batch.default.input]
+            }
+          }
+
+          otelcol.processor.batch "default" {
+            output {
+              metrics = [otelcol.exporter.otlphttp.grafana_cloud.input]
+              traces  = [otelcol.exporter.otlphttp.grafana_cloud.input]
+            }
+          }
+
+          otelcol.auth.basic "grafana_cloud" {
+            username = grafana_cloud.stack.receivers.info["id"]
+            password = env("GRAFANA_CLOUD_TOKEN")
+          }
+
+          otelcol.exporter.otlphttp "grafana_cloud" {
+            client {
+              endpoint = "https://otlp-gateway-" + grafana_cloud.stack.receivers.info["clusterSlug"] + ".grafana-dev.net/otlp"
+              auth     = otelcol.auth.basic.grafana_cloud.handler
+            }
+          }
+          EOF
+
+          "$ALLOY_BIN" run alloy-ios-ci.alloy --server.http.listen-addr=127.0.0.1:12345 --stability.level=public-preview > alloy-ios.log 2>&1 &
+          echo "$!" > alloy-ios.pid
+
+          for i in {1..20}; do
+            if curl -fsS "http://127.0.0.1:12345/-/ready" > /dev/null 2>&1; then
+              echo "Alloy is ready"
+              exit 0
+            fi
+            echo "Waiting for Alloy... attempt $i/20"
+            sleep 1
+          done
+
+          echo "Alloy did not become ready in time"
+          cat alloy-ios.log
+          exit 1
+
       - name: Start QuickPizza backend
         env:
           DEPLOYMENT_ENVIRONMENT: ci
@@ -583,6 +666,7 @@ jobs:
           QUICKPIZZA_ENABLE_ALL_SERVICES=1 \
           QUICKPIZZA_DB= \
           QUICKPIZZA_TIMEOUT=10s \
+          QUICKPIZZA_OTLP_ENDPOINT=http://127.0.0.1:4318 \
           QUICKPIZZA_OTEL_SERVICE_NAME=quickpizza-ios-ci-backend \
           OTEL_RESOURCE_ATTRIBUTES="deployment.environment=${DEPLOYMENT_ENVIRONMENT},service.version=quickpizza-local" \
           ./bin/quickpizza > backend-ios.log 2>&1 &
@@ -705,6 +789,9 @@ jobs:
           if [ -f backend-ios.log ]; then
             tail -200 backend-ios.log
           fi
+          if [ -f alloy-ios.log ]; then
+            tail -200 alloy-ios.log
+          fi
 
       - name: Stop backend
         if: always()
@@ -712,12 +799,17 @@ jobs:
           if [ -f backend-ios.pid ]; then
             kill "$(cat backend-ios.pid)" || true
           fi
+          if [ -f alloy-ios.pid ]; then
+            kill "$(cat alloy-ios.pid)" || true
+          fi
 
       - name: Upload backend logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-logs-ios
-          path: backend-ios.log
+          path: |
+            backend-ios.log
+            alloy-ios.log
           retention-days: 3
           if-no-files-found: ignore

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -9,6 +9,16 @@ on:
         required: false
         default: false
         type: boolean
+  # Temporary: run full telemetry on PR #75 to validate the iOS backend telemetry fix.
+  pull_request:
+    paths:
+      - ".github/workflows/mobile_demo_telemetry.yaml"
+      - "Mobiles/e2e/**"
+      - "Mobiles/flutter/**"
+      - "Mobiles/react-native/**"
+      - "Mobiles/android/**"
+      - "Mobiles/ios/**"
+      - "compose.grafana-cloud.microservices.yaml"
   # Scheduled run every hour for continuous telemetry
   schedule:
     - cron: "0 * * * *"
@@ -38,9 +48,10 @@ env:
 jobs:
   run-mobile-demo:
     name: Run Android Mobile Demo
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-ios-telemetry-backend')
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: mobile-demo-telemetry
+    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
     permissions:
       id-token: write
       contents: read
@@ -324,10 +335,11 @@ jobs:
 
   run-ios-mobile-demo:
     name: Run iOS Mobile Demo
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-ios-telemetry-backend')
     # macOS-only: xcrun simctl + the booted iOS simulator only work on macOS.
     runs-on: macos-26
     timeout-minutes: 180
-    environment: mobile-demo-telemetry
+    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -9,16 +9,6 @@ on:
         required: false
         default: false
         type: boolean
-  # Temporary: run full telemetry on PR #75 to validate the iOS backend telemetry fix.
-  pull_request:
-    paths:
-      - ".github/workflows/mobile_demo_telemetry.yaml"
-      - "Mobiles/e2e/**"
-      - "Mobiles/flutter/**"
-      - "Mobiles/react-native/**"
-      - "Mobiles/android/**"
-      - "Mobiles/ios/**"
-      - "compose.grafana-cloud.microservices.yaml"
   # Scheduled run every hour for continuous telemetry
   schedule:
     - cron: "0 * * * *"
@@ -48,10 +38,9 @@ env:
 jobs:
   run-mobile-demo:
     name: Run Android Mobile Demo
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-ios-telemetry-backend')
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
+    environment: mobile-demo-telemetry
     permissions:
       id-token: write
       contents: read
@@ -335,11 +324,10 @@ jobs:
 
   run-ios-mobile-demo:
     name: Run iOS Mobile Demo
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref == 'codex/fix-ios-telemetry-backend')
     # macOS-only: xcrun simctl + the booted iOS simulator only work on macOS.
     runs-on: macos-26
     timeout-minutes: 180
-    environment: ${{ github.event_name == 'pull_request' && 'mobile-demo-telemetry-pr' || 'mobile-demo-telemetry' }}
+    environment: mobile-demo-telemetry
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Why

The mobile telemetry workflow is green again, but the iOS demo traces in Grafana Cloud only show the mobile app span. They do not include the expected backend/e2e spans underneath the app request.

Android already shows the full trace shape because its workflow starts the QuickPizza backend through Docker Compose with Alloy. The backend containers export OTLP to Alloy (`QUICKPIZZA_OTLP_ENDPOINT=http://alloy:4318`), and Alloy forwards that data to Grafana Cloud using the backend telemetry credentials.

The iOS job is different: it builds and starts `./bin/quickpizza` natively on the macOS runner. Before this change that native backend did not set `QUICKPIZZA_OTLP_ENDPOINT`, so backend telemetry was not exported. The iOS apps still sent their own mobile spans, which is why traces existed but stopped at the app span.

## What changed

- Start a local Alloy process in the iOS telemetry job.
- Fetch the same backend Grafana Cloud secrets used by the Android backend path: `GRAFANA_CLOUD_STACK` and `GRAFANA_CLOUD_TOKEN`.
- Configure local Alloy with the same `grafana_cloud.stack` dev-stack endpoint style as the Android Docker Compose Alloy config.
- Point the native macOS QuickPizza backend at local Alloy via `QUICKPIZZA_OTLP_ENDPOINT=http://127.0.0.1:4318`.
- Upload `alloy-ios.log` together with `backend-ios.log` for easier diagnosis.
- Verify the downloaded Alloy release asset against `SHA256SUMS` before running it.

## Verification

- Parsed `.github/workflows/mobile_demo_telemetry.yaml` with Ruby YAML.
- Ran `git diff --check`.
- Ran local `zizmor .github/workflows/mobile_demo_telemetry.yaml`: no findings.
- Ran local `trufflehog filesystem --no-update --fail .github/workflows/mobile_demo_telemetry.yaml`: no verified or unverified secrets.
- Verified Alloy v1.14.2 macOS arm64/amd64 release assets exist.
- Confirmed the `SHA256SUMS` verification command works with the downloaded asset filename.