### PR TITLE
docs(mobile): add Mobiles/README hub and de-duplicate mobile docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ For a single source of truth on what each app emits, where it lands, and how the
 
 ### Mobile Apps Quick Reference
 
+- **Start here:** [`Mobiles/README.md`](./Mobiles/README.md) is the entry point — supported platforms, run-a-demo steps, and links to every deeper doc.
 - **Demo cloud stack:** internal Grafana Cloud stack — substitute your own (`<your-grafana-cloud-stack>.grafana.net`) when running outside Grafana Labs
 - **Backend (local, mobile):** `docker run --rm -d -p 3333:3333 ghcr.io/grafana/quickpizza-mobile-local:latest` (or `QUICKPIZZA_IMAGE=ghcr.io/grafana/quickpizza-mobile-local:latest` with compose; k6/upstream uses `quickpizza-local`)
 - **Shared feature spec:** [`Mobiles/FEATURES.md`](./Mobiles/FEATURES.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ For a single source of truth on what each app emits, where it lands, and how the
 - **Per-platform READMEs:** [`Mobiles/flutter/README.md`](./Mobiles/flutter/README.md), [`Mobiles/react-native/README.md`](./Mobiles/react-native/README.md), [`Mobiles/ios/README.md`](./Mobiles/ios/README.md), [`Mobiles/android/README.md`](./Mobiles/android/README.md)
 - **OTel mobile SDK gaps & contribution backlog:** [`Mobiles/docs/OTEL_MOBILE_MATURITY.md`](./Mobiles/docs/OTEL_MOBILE_MATURITY.md)
 - **iOS native run:** `cp Mobiles/ios/Config.xcconfig.example Mobiles/ios/Config.xcconfig` (fill in OTLP creds), then `bash Mobiles/ios/Scripts/sim-run.sh`
-- **Android native run:** `cp Mobiles/android/app/src/main/res/raw/config.json.example Mobiles/android/app/src/main/res/raw/config.json` (fill in OTLP creds), then `cd Mobiles/android && ./gradlew installDebug`
+- **Android native run:** `cp Mobiles/android/config.json.example Mobiles/android/app/src/main/res/raw/config.json` (fill in OTLP creds), then `cd Mobiles/android && ./gradlew installDebug`
 
 ## Key Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,12 +134,12 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 ### Android native (`Mobiles/android/`)
 
-- **Stack:** Kotlin, Jetpack Compose, Hilt, OkHttp, `opentelemetry-android` 1.2.0-alpha (the OTel-Android **RUM agent**).
+- **Stack:** Kotlin, Jetpack Compose, Hilt, OkHttp, `opentelemetry-android` 1.4.0-alpha (the OTel-Android **RUM agent**).
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto OkHttp HTTP spans, auto lifecycle spans (`AppStart`, `Paused`, `Stopped`), auto `screen.view` / `app.jank` events, auto `device.crash` (next launch) and `device.anr` (runtime) events, 15-min session tracking, OTLP disk buffering for offline resilience (toggleable via Debug screen).
 - **Where it lands:** OTLP/HTTP → Grafana Cloud Tempo + Loki, visualised via the "Android & iOS OTel RUM" dashboard.
 - **Config:** `app/src/main/res/raw/config.json` — `BASE_URL` (default `http://10.0.2.2:3333` on emulators), `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Android Studio or `cd Mobiles/android && ./gradlew installDebug`. Use Android Studio's bundled JDK (system JDK is often too old).
-- **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `deployment.environment`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version=1.2.0-alpha}`.
+- **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `deployment.environment`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version=1.4.0-alpha}`.
 
 ### Shared Debug screen
 

--- a/Mobiles/README.md
+++ b/Mobiles/README.md
@@ -61,8 +61,9 @@ Whether this is optional depends on the SDK family:
 - **Flutter / React Native (Faro):** a `FARO_COLLECTOR_URL` is **required** —
   these apps throw at startup without one, even for a local-only demo.
 - **iOS / Android native (OpenTelemetry):** Grafana Cloud is **optional** —
-  leave the OTLP fields empty to keep telemetry in the local console, or set
-  them to export.
+  the apps still run with the OTLP fields empty. On iOS (debug builds) spans
+  go to the Xcode console; on Android export is simply disabled (the SDK runs
+  as a noop, so no OTel signals are produced). Set the OTLP fields to export.
 
 One doc covers both: [**Connect to Grafana Cloud**](./docs/CONNECT_GRAFANA_CLOUD.md)
 (Faro collector URL and OTLP endpoint/token).

--- a/Mobiles/README.md
+++ b/Mobiles/README.md
@@ -54,12 +54,18 @@ curl http://localhost:3333/api/pizza   # should return a JSON pizza
 > backend with full local/cloud observability instead, see the Docker Compose
 > options in the [root README](../README.md).
 
-### Step 2 — (Optional) Connect to Grafana Cloud
+### Step 2 — Connect to Grafana Cloud
 
-You can run any app without this — telemetry just stays in the local console.
-To send data to Grafana Cloud, set the SDK credentials once:
-[**Connect to Grafana Cloud**](./docs/CONNECT_GRAFANA_CLOUD.md) (covers both the
-Faro collector URL and the OTLP endpoint/token).
+Whether this is optional depends on the SDK family:
+
+- **Flutter / React Native (Faro):** a `FARO_COLLECTOR_URL` is **required** —
+  these apps throw at startup without one, even for a local-only demo.
+- **iOS / Android native (OpenTelemetry):** Grafana Cloud is **optional** —
+  leave the OTLP fields empty to keep telemetry in the local console, or set
+  them to export.
+
+One doc covers both: [**Connect to Grafana Cloud**](./docs/CONNECT_GRAFANA_CLOUD.md)
+(Faro collector URL and OTLP endpoint/token).
 
 ### Step 3 — Pick a platform and run it
 
@@ -70,7 +76,7 @@ Quick orientation:
   `cd ios && cp Config.xcconfig.example Config.xcconfig && bash Scripts/sim-run.sh`.
   Full steps: [iOS README](./ios/README.md).
 - **Android native** — Android Studio + emulator.
-  `cd android && cp app/src/main/res/raw/config.json.example app/src/main/res/raw/config.json && ./gradlew installDebug`.
+  `cd android && cp config.json.example app/src/main/res/raw/config.json && ./gradlew installDebug`.
   Full steps: [Android README](./android/README.md) ·
   [toolchain setup](./docs/ANDROID_NATIVE_SETUP.md).
 - **Flutter** — needs the Flutter SDK plus a mobile toolchain:

--- a/Mobiles/README.md
+++ b/Mobiles/README.md
@@ -1,0 +1,118 @@
+# QuickPizza Mobile Demos
+
+**Start here.** This directory holds four mobile QuickPizza apps used to demo
+mobile observability with Grafana. They share the same screens and talk to the
+same backend — what differs is the telemetry SDK and where the data lands.
+
+This page is the entry point: it tells you **which platforms are supported**,
+**how to get a demo running**, and **where to go for more detail**. Everything
+deeper lives in linked docs so the same information isn't repeated in five
+places.
+
+---
+
+## Supported platforms
+
+| Platform | Type | Location | SDK | Data lands in | Run guide |
+| --- | --- | --- | --- | --- | --- |
+| **Flutter** (Android + iOS) | Cross-platform | [`flutter/`](./flutter/) | Grafana **Faro** | Frontend Observability | [Flutter README](./flutter/README.md) |
+| **React Native** (Android + iOS) | Cross-platform | [`react-native/`](./react-native/) | Grafana **Faro** | Frontend Observability | [React Native README](./react-native/README.md) |
+| **iOS native** (SwiftUI) | Native | [`ios/`](./ios/) | **OpenTelemetry** Swift | Tempo + Loki | [iOS README](./ios/README.md) |
+| **Android native** (Compose) | Native | [`android/`](./android/) | **OpenTelemetry** Android | Tempo + Loki | [Android README](./android/README.md) |
+
+Two telemetry stories, one backend:
+
+- **Faro** (Flutter, React Native) → exports to the Grafana Cloud **Frontend
+  Observability** plugin.
+- **OpenTelemetry** (iOS, Android) → exports OTLP/HTTP to **Tempo + Loki**,
+  visualized with the [Mobile OTel RUM dashboard](./docs/MOBILE_OTEL_RUM_DASHBOARD.md).
+
+For a side-by-side of what each app actually emits, see
+[`docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./docs/MOBILE_OBSERVABILITY_OVERVIEW.md).
+
+---
+
+## Run a demo in 3 steps
+
+### Step 1 — Start the backend
+
+All four apps need the QuickPizza backend. The simplest way is one container:
+
+```bash
+docker run --rm -d --name quickpizza -p 3333:3333 \
+  ghcr.io/grafana/quickpizza-mobile-local:latest
+```
+
+Verify it's up:
+
+```bash
+curl http://localhost:3333/api/pizza   # should return a JSON pizza
+```
+
+> Use the `quickpizza-mobile-local` image for mobile work. The upstream
+> `quickpizza-local` image is reserved for the k6/web workshops. To run the
+> backend with full local/cloud observability instead, see the Docker Compose
+> options in the [root README](../README.md).
+
+### Step 2 — (Optional) Connect to Grafana Cloud
+
+You can run any app without this — telemetry just stays in the local console.
+To send data to Grafana Cloud, set the SDK credentials once:
+[**Connect to Grafana Cloud**](./docs/CONNECT_GRAFANA_CLOUD.md) (covers both the
+Faro collector URL and the OTLP endpoint/token).
+
+### Step 3 — Pick a platform and run it
+
+Each app has the toolchain prerequisites and full instructions in its README.
+Quick orientation:
+
+- **iOS native** — lightest path on a Mac (Xcode + Docker only).
+  `cd ios && cp Config.xcconfig.example Config.xcconfig && bash Scripts/sim-run.sh`.
+  Full steps: [iOS README](./ios/README.md).
+- **Android native** — Android Studio + emulator.
+  `cd android && cp app/src/main/res/raw/config.json.example app/src/main/res/raw/config.json && ./gradlew installDebug`.
+  Full steps: [Android README](./android/README.md) ·
+  [toolchain setup](./docs/ANDROID_NATIVE_SETUP.md).
+- **Flutter** — needs the Flutter SDK plus a mobile toolchain:
+  [Flutter README](./flutter/README.md) ·
+  [Android toolchain](./docs/FLUTTER_ANDROID_SETUP.md) ·
+  [iOS toolchain](./docs/FLUTTER_IOS_SETUP.md).
+- **React Native** — needs Node ≥ 24.5 + Yarn (and CocoaPods for iOS):
+  [React Native README](./react-native/README.md).
+
+> First-time mobile toolchain setup (Xcode ~15 GB, Android Studio + SDK, or the
+> Flutter/Node toolchains) can take an hour or more if you've never done mobile
+> development. The backend (Step 1) is the only part that's instant.
+
+---
+
+## Shared basics
+
+These apply to every app, so they're stated once here.
+
+- **Login:** username `default`, password `12345678`.
+- **Backend URL on emulators/simulators:** leave `BASE_URL` empty — the apps
+  auto-resolve to `http://10.0.2.2:3333` on Android emulators (which routes to
+  your host) and `http://localhost:3333` on the iOS simulator. For a **physical
+  device**, set `BASE_URL` to your machine's LAN IP (e.g.
+  `http://192.168.1.100:3333`) and make sure the device is on the same network.
+- **Debug tab (the demo driver):** every app has an in-app **Debug** screen to
+  override config at runtime, inject backend errors/latency, and trigger test
+  logs, handled exceptions, and native crashes — this is how you generate
+  telemetry on demand during a demo. Details and per-platform extras are in
+  [`docs/MOBILE_OBSERVABILITY_OVERVIEW.md § The shared Debug screen`](./docs/MOBILE_OBSERVABILITY_OVERVIEW.md#the-shared-debug-screen).
+
+---
+
+## Where to go for more
+
+| I want to… | Read |
+| --- | --- |
+| Understand what each app emits and where it lands | [`docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./docs/MOBILE_OBSERVABILITY_OVERVIEW.md) |
+| Send a mobile app's telemetry to a Grafana Cloud stack (the app's own Faro / OTLP config) | [`docs/CONNECT_GRAFANA_CLOUD.md`](./docs/CONNECT_GRAFANA_CLOUD.md) |
+| See the shared screens & workflows spec | [`FEATURES.md`](./FEATURES.md) |
+| Import the native OTel RUM dashboard | [`docs/MOBILE_OTEL_RUM_DASHBOARD.md`](./docs/MOBILE_OTEL_RUM_DASHBOARD.md) |
+| Deep-dive iOS OTel instrumentation | [`docs/IOS_OBSERVABILITY_OTEL_GUIDE.md`](./docs/IOS_OBSERVABILITY_OTEL_GUIDE.md) |
+| Understand the iOS app architecture | [`docs/IOS_APP_ARCHITECTURE.md`](./docs/IOS_APP_ARCHITECTURE.md) |
+| Run the cross-platform E2E tests | [`e2e/README.md`](./e2e/README.md) |
+| Track OTel mobile SDK gaps / contributions | [`docs/OTEL_MOBILE_MATURITY.md`](./docs/OTEL_MOBILE_MATURITY.md) |

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -25,8 +25,9 @@ platform emits, dashboards) see
 ## Quickstart
 
 ```bash
-# 1. Configure
-cp app/src/main/res/raw/config.json.example \
+# 1. Configure (the example template lives at the project root; a Gradle task
+#    strips any *.example out of res/raw before the resource merger runs)
+cp config.json.example \
    app/src/main/res/raw/config.json
 # edit OTLP_ENDPOINT, OTLP_INSTANCE_ID, OTLP_API_KEY, BASE_URL
 
@@ -83,7 +84,7 @@ The **Debug** tab exposes:
 ## Observability
 
 The app uses [`opentelemetry-android`](https://github.com/open-telemetry/opentelemetry-android)
-1.2.0-alpha and exports via OTLP/HTTP. Init lives in
+1.4.0-alpha and exports via OTLP/HTTP. Init lives in
 `app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt`.
 
 | Signal | Examples |

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -25,7 +25,9 @@ platform emits, dashboards) see
 ## Quickstart
 
 ```bash
-# 1. Configure (the example template lives at the project root; a Gradle task
+cd Mobiles/android
+
+# 1. Configure (the example template lives at this project root; a Gradle task
 #    strips any *.example out of res/raw before the resource merger runs)
 cp config.json.example \
    app/src/main/res/raw/config.json
@@ -36,7 +38,6 @@ docker run --rm -d --name quickpizza -p 3333:3333 \
   ghcr.io/grafana/quickpizza-mobile-local:latest
 
 # 3. Build and install on a running emulator
-cd Mobiles/android
 ./gradlew installDebug
 adb shell am start -n com.grafana.quickpizza/.MainActivity
 ```

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -28,7 +28,7 @@ platform emits, dashboards) see
 cd Mobiles/android
 
 # 1. Configure (the example template lives at this project root; a Gradle task
-#    strips any *.example out of res/raw before the resource merger runs)
+#    deletes the config.json.example file from res/raw before the resource merger runs)
 cp config.json.example \
    app/src/main/res/raw/config.json
 # edit OTLP_ENDPOINT, OTLP_INSTANCE_ID, OTLP_API_KEY, BASE_URL

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -5,6 +5,10 @@ using the [`opentelemetry-android`](https://github.com/open-telemetry/openteleme
 RUM agent. It connects to the QuickPizza backend and exports traces and
 logs over OTLP/HTTP to Grafana Cloud.
 
+> **New here?** Start at [`../README.md`](../README.md) for the overview of all
+> four apps, the backend, and how to get a demo running. This page covers the
+> native Android app specifically.
+
 For setup details (Android Studio, SDK, emulator, physical devices) see
 [`../docs/ANDROID_NATIVE_SETUP.md`](../docs/ANDROID_NATIVE_SETUP.md).
 
@@ -87,23 +91,11 @@ The app uses [`opentelemetry-android`](https://github.com/open-telemetry/opentel
 | **Spans** | `GET` (auto OkHttp), `AppStart` / `Paused` / `Stopped` (auto lifecycle), `pizza.get_recommendation` / `auth.login` / `pizza.rate` (manual) |
 | **Logs** | `screen.view` (auto), `app.jank` (auto, slow rendering), `session.start` (auto), `rum.sdk.init.*` (auto SDK self-telemetry), `exception` (manual `logger.exception`), `device.crash` (auto, next launch), `device.anr` (auto, runtime), `debug.test_event` (manual) |
 
-Resource attributes:
-
-```
-service.name             = quickpizza-android
-service.namespace        = quickpizza
-service.version          = <versionName>
-deployment.environment   = production
-android.os.api_level     = 30/34/...
-device.manufacturer      = Google / ...
-device.model.identifier  = sdk_gphone_arm64 / ...
-network.connection.type  = wifi / cellular / ...
-app.installation.id      = <stable per install>
-session.id               = <15-min inactivity timeout>
-telemetry.sdk.language   = java
-telemetry.sdk.version    = 1.2.0-alpha
-nav.destination          = current Compose route
-```
+Core resource attributes: `service.name=quickpizza-android`,
+`service.namespace=quickpizza`, `service.version`,
+`deployment.environment=production`. The full set (device, network, nav, and
+session attributes) is inventoried in
+[`MOBILE_OBSERVABILITY_OVERVIEW.md § Android native`](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md#android-native-opentelemetry-android).
 
 `OTelService` registers `OpenTelemetryRumInitializer` which wires up:
 
@@ -144,10 +136,12 @@ Where to view the data on the demo stack:
 | `OTLP_ENDPOINT` | OTLP/HTTP base URL (without `/v1/traces`). Empty disables export. |
 | `OTLP_INSTANCE_ID` | Numeric Grafana Cloud OTLP gateway instance ID. |
 | `OTLP_API_KEY` | Grafana Cloud access token (combined with the instance ID into `Authorization: Basic`). |
-| `BASE_URL` | QuickPizza backend URL. Empty auto-resolves to `http://10.0.2.2:3333` on emulators. Set to your machine's LAN IP for physical devices. |
+| `BASE_URL` | QuickPizza backend URL. Empty auto-resolves to `http://10.0.2.2:3333` on emulators. Set to your machine's LAN IP for physical devices ([details](../README.md#shared-basics)). |
 
-All four can be overridden at runtime from **Debug → Config** without a
-rebuild — overrides apply on the next launch.
+To obtain the OTLP endpoint, instance ID, and token, see
+[Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md#opentelemetry-apps-ios-native-android-native).
+All four fields can also be overridden at runtime from **Debug → Config**
+without a rebuild — overrides apply on the next launch.
 
 ---
 

--- a/Mobiles/docs/ANDROID_NATIVE_SETUP.md
+++ b/Mobiles/docs/ANDROID_NATIVE_SETUP.md
@@ -23,7 +23,7 @@ Setup guide for the native Android QuickPizza app (`Mobiles/android/`).
 The app reads `app/src/main/res/raw/config.json` at startup. This file is gitignored so you must create it from the example:
 
 ```bash
-cp Mobiles/android/app/src/main/res/raw/config.json.example \
+cp Mobiles/android/config.json.example \
    Mobiles/android/app/src/main/res/raw/config.json
 ```
 

--- a/Mobiles/docs/ANDROID_NATIVE_SETUP.md
+++ b/Mobiles/docs/ANDROID_NATIVE_SETUP.md
@@ -3,9 +3,10 @@
 Setup guide for the native Android QuickPizza app (`Mobiles/android/`).
 
 > Companion docs:
+> - New here? Start at the [Mobile README](../README.md) for the all-apps overview.
 > - For the cross-platform observability overview (what each mobile app emits, where it lands), see [`MOBILE_OBSERVABILITY_OVERVIEW.md`](./MOBILE_OBSERVABILITY_OVERVIEW.md).
-> - For a higher-level Android README (features + quickstart), see [`../android/README.md`](../android/README.md).
-> - For the **Flutter** Android emulator setup, see [`ANDROID_SETUP.md`](./ANDROID_SETUP.md).
+> - For a higher-level Android README (features + quickstart + config reference), see [`../android/README.md`](../android/README.md).
+> - For the **Flutter** Android emulator setup, see [`FLUTTER_ANDROID_SETUP.md`](./FLUTTER_ANDROID_SETUP.md).
 
 ---
 
@@ -37,21 +38,16 @@ Edit `config.json`:
 }
 ```
 
-| Field | Description |
-|---|---|
-| `OTLP_ENDPOINT` | Your OTLP HTTP base URL (without `/v1/traces`). Leave empty to disable telemetry export. |
-| `OTLP_INSTANCE_ID` | Your Grafana Cloud OTLP Gateway instance ID (numeric). |
-| `OTLP_API_KEY` | Your Grafana Cloud access token (e.g. `glc_xxxxxxxx`). The app combines it with the instance ID to compute `Authorization: Basic base64(instanceId:apiKey)`. |
-| `BASE_URL` | QuickPizza backend URL. **Leave empty** to auto-detect (`http://10.0.2.2:3333` on emulator). Set to your machine's LAN IP for physical devices, e.g. `http://192.168.1.100:3333`. |
+For what each field means, see the
+[config reference in the Android README](../android/README.md#configuration-reference).
+To obtain the OTLP endpoint, instance ID, and token, see
+[Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md#opentelemetry-apps-ios-native-android-native).
+For `BASE_URL` emulator/device defaults (and why Android uses `10.0.2.2` rather
+than `localhost`), see [Shared basics](../README.md#shared-basics).
 
-> All four URL / credential fields can also be overridden at runtime from the in-app
-> **Debug → Config** screen without rebuilding. Overrides take effect after the next
-> app restart.
-
-> **Why `10.0.2.2` and not `localhost`?**
-> Android emulators route `localhost` to the emulator itself, not the host machine.
-> `10.0.2.2` is a special alias for the host's loopback address. The same logic applies to the
-> Flutter implementation (see `Mobiles/flutter/lib/core/config/config_service.dart`).
+> All four fields can also be overridden at runtime from the in-app
+> **Debug → Config** screen without rebuilding. Overrides take effect after the
+> next app restart.
 
 ---
 
@@ -97,41 +93,12 @@ adb shell am start -n com.grafana.quickpizza/.MainActivity
 
 ## Observability
 
-The app uses [opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android) (`1.2.0`) and exports via OTLP HTTP.
-
-### Signals produced
-
-| Signal | Examples |
-|---|---|
-| **Spans** | Manual: `auth.login`, `pizza.get_recommendation`, `pizza.rate`. Auto: `GET` (OkHttp HTTP), `AppStart` / `Paused` / `Stopped` (lifecycle). |
-| **Logs (`event_name=…`)** | Auto: `screen.view`, `app.jank` (slow-rendering), `session.start`, `rum.sdk.init.*` self-telemetry, `device.crash` (next launch), `device.anr` (runtime). Manual: `exception` (`logger.exception(...)`), `debug.test_event` (Debug screen). |
-| **Crashes** | Unhandled exceptions persisted by the OTel-Android `CrashReporter` and exported as `device.crash` log events on the next app launch. |
-| **ANRs** | Detected at runtime by the agent; emitted as `device.anr` log events. |
-| **Sessions** | 15-minute inactivity timeout, `session.id` stamped on every signal. |
-
-For the full cross-platform telemetry comparison (including how this differs from the iOS, Flutter, and React Native apps), see [`MOBILE_OBSERVABILITY_OVERVIEW.md`](./MOBILE_OBSERVABILITY_OVERVIEW.md).
-
-### Resource attributes
-
-All telemetry carries:
-
-```
-service.name        = quickpizza-android
-service.namespace   = quickpizza
-service.version     = <versionName from build>
-deployment.environment = production
-```
-
-Plus automatic attributes from opentelemetry-android: `os.name`, `os.version`, `device.model.name`, `android.api_level`, `app.installation.id`.
-
-### Architecture
-
-```
-OTelService            — Initializes OpenTelemetryRum agent
-AppLogger              — CompositeLogger: Logcat + OtelLogger (OTLP)
-AppTracer              — OtelTracer wrapping the Java SDK Tracer
-ApiClient (OkHttp)     — Call.Factory wrapped by OkHttpTelemetry for auto HTTP spans
-```
+The app uses [opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android)
+and exports via OTLP/HTTP. The signals it produces, the resource attributes, and
+the `OTelService` wiring are documented in the
+[Android README § Observability](../android/README.md#observability); the
+cross-platform comparison (how this differs from iOS, Flutter, and React Native)
+is in [`MOBILE_OBSERVABILITY_OVERVIEW.md`](./MOBILE_OBSERVABILITY_OVERVIEW.md).
 
 ---
 
@@ -157,15 +124,6 @@ Ensure `gradle.properties` has `android.useFullClasspathForDexingTransform=true`
 
 ## In-app Debug screen
 
-The **Debug** tab is the same shape as the other QuickPizza mobile apps and exposes:
-
-- Runtime config overrides (backend URL, OTLP endpoint, instance ID, API key) — restart-required.
-- Backend error/latency injection toggles (`x-error-record-recommendation`, `x-delay-record-recommendation`, `x-error-get-ingredients`, `x-delay-get-ingredients`).
-- Client-side faults (`useV2PizzaSchema` to simulate schema drift, `skipAuthDepInTools`).
-- An **OTel SDK** section with the disk buffering toggle described above.
-- **Quick Signals** — debug log, error log, custom `debug.test_event`.
-- **Handled exception** — calls `logger.exception(...)` so the OTel logger emits an `exception` event.
-- **ANR** — blocks the main thread for 6 s; the OTel agent reports `event_name=device.anr`.
-- **Crash** — `RuntimeException` and simulated `NullPointerException` variants. The agent persists the crash to disk and the exporter delivers it as `event_name=device.crash` on next launch.
-
-Code: `app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt`.
+The **Debug** tab (runtime config overrides, error/latency injection, the disk
+buffering toggle, quick signals, handled exception, ANR, and crash cards) is
+documented in the [Android README § Features](../android/README.md#features).

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -9,9 +9,11 @@ families that authenticate differently:
 | Flutter, React Native | Grafana **Faro** | `FARO_COLLECTOR_URL` | Frontend Observability plugin |
 | iOS native, Android native | **OpenTelemetry** | `OTLP_ENDPOINT` + `OTLP_INSTANCE_ID` + `OTLP_API_KEY` | Tempo (traces) + Loki (logs), viewed via the [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) |
 
-> You can run any app **without** Grafana Cloud — leave the telemetry fields
-> empty and signals are written to the local console only (Xcode/Logcat/Metro).
-> Configure the values below when you want data to show up in Grafana.
+> **Faro apps require a collector URL.** The Flutter and React Native apps
+> throw at startup if `FARO_COLLECTOR_URL` is empty, so you must set it (see
+> below) even for a local-only demo. The **native OTel apps (iOS, Android)** are
+> different — leave the OTLP fields empty and signals go to the local console
+> only (Xcode/Logcat); set them when you want data in Grafana.
 
 Every app can also take these values at runtime from its in-app **Debug →
 Config** screen (applied on next launch), so you can reconfigure during a demo
@@ -28,17 +30,19 @@ The backend emits its **own** traces/metrics/logs (via Grafana Alloy), which is
 what you need if you want to see the **server side** of the HTTP calls the apps
 make — i.e. mobile → backend end-to-end traces in one stack. That is configured
 separately, not here: run the backend with the instrumented Docker Compose setup
-and a `.env` containing `GRAFANA_CLOUD_STACK` + `GRAFANA_CLOUD_TOKEN`, as
-documented in the [root README → *Run locally and observe with Grafana
-Cloud*](../../README.md#run-locally-and-observe-with-grafana-cloud-). Point the
-backend at the **same** Grafana Cloud stack as the app so both land together.
+and a `.env` containing `GRAFANA_CLOUD_STACK` + `GRAFANA_CLOUD_TOKEN`, then turn
+on the relevant solutions as documented in the root README under
+[*Enable Grafana Cloud Observability solutions*](../../README.md#enable-grafana-cloud-observability-solutions)
+(and the Docker Compose `.env` steps just above it). Point the backend at the
+**same** Grafana Cloud stack as the app so both land together.
 
 ---
 
 ## Faro apps (Flutter, React Native)
 
 Faro apps send to a **collector URL** that already encodes the app identity and
-auth — there is no separate token to manage.
+auth — there is no separate token to manage. This URL is **required**: the
+Flutter and React Native apps throw at startup if it is empty.
 
 1. In Grafana Cloud, open **Frontend Observability**.
 2. Create a new app (or open an existing one) and set the domain — for local

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -1,0 +1,120 @@
+# Connect a QuickPizza Mobile App to Grafana Cloud
+
+This is the single place that explains how to point any of the QuickPizza
+mobile apps at a Grafana Cloud stack. The apps split into two telemetry
+families that authenticate differently:
+
+| Apps | SDK family | What you configure | Where the data lands |
+| --- | --- | --- | --- |
+| Flutter, React Native | Grafana **Faro** | `FARO_COLLECTOR_URL` | Frontend Observability plugin |
+| iOS native, Android native | **OpenTelemetry** | `OTLP_ENDPOINT` + `OTLP_INSTANCE_ID` + `OTLP_API_KEY` | Tempo (traces) + Loki (logs), viewed via the [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) |
+
+> You can run any app **without** Grafana Cloud — leave the telemetry fields
+> empty and signals are written to the local console only (Xcode/Logcat/Metro).
+> Configure the values below when you want data to show up in Grafana.
+
+Every app can also take these values at runtime from its in-app **Debug →
+Config** screen (applied on next launch), so you can reconfigure during a demo
+without rebuilding.
+
+### This doc is about the *mobile app's* telemetry, not the backend's
+
+The mobile apps send their telemetry **directly** to Grafana Cloud (Faro
+collector or OTLP gateway) — the QuickPizza backend is not in that path and
+needs no configuration for the apps to report. Everything below configures the
+app, not the backend.
+
+The backend emits its **own** traces/metrics/logs (via Grafana Alloy), which is
+what you need if you want to see the **server side** of the HTTP calls the apps
+make — i.e. mobile → backend end-to-end traces in one stack. That is configured
+separately, not here: run the backend with the instrumented Docker Compose setup
+and a `.env` containing `GRAFANA_CLOUD_STACK` + `GRAFANA_CLOUD_TOKEN`, as
+documented in the [root README → *Run locally and observe with Grafana
+Cloud*](../../README.md#run-locally-and-observe-with-grafana-cloud-). Point the
+backend at the **same** Grafana Cloud stack as the app so both land together.
+
+---
+
+## Faro apps (Flutter, React Native)
+
+Faro apps send to a **collector URL** that already encodes the app identity and
+auth — there is no separate token to manage.
+
+1. In Grafana Cloud, open **Frontend Observability**.
+2. Create a new app (or open an existing one) and set the domain — for local
+   demos `http://localhost:3333` is fine.
+3. Copy the app's **Faro collector URL** (looks like
+   `https://faro-collector-<region>.grafana.net/collect/<token>`).
+4. Put it in the app's `config.json` as `FARO_COLLECTOR_URL` (see the
+   [Flutter](../flutter/README.md) / [React Native](../react-native/README.md)
+   READMEs for the exact file location).
+
+The app then appears in the Frontend Observability plugin. On the demo stack
+these are registered as `QuickPizza_Flutter` and `QuickPizza_ReactNative`.
+
+---
+
+## OpenTelemetry apps (iOS native, Android native)
+
+OTel apps send OTLP/HTTP to the Grafana Cloud OTLP gateway and authenticate
+with an **instance ID + access token**.
+
+### Find your endpoint and credentials
+
+The OTLP endpoint follows the standard Grafana Cloud pattern:
+
+```
+https://otlp-gateway-<clusterSlug>.grafana.net/otlp
+```
+
+To find `clusterSlug`, the numeric Instance ID, and a token:
+
+1. Go to your Grafana Cloud org page (`https://grafana.com/orgs/<your-org>`).
+2. Open the stack — the **cluster slug** and **numeric Instance ID** are listed
+   on its details page.
+3. Generate an **Access Policy token** with scopes `metrics:write`,
+   `logs:write`, `traces:write` (the native apps need logs + traces; metrics is
+   harmless to include).
+
+The app computes `Authorization: Basic base64(instanceId:apiKey)` for you — you
+only supply the three raw values.
+
+### Where to put them
+
+| App | Config location |
+| --- | --- |
+| iOS native | `Mobiles/ios/Config.xcconfig` (`OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`) — see [iOS README](../ios/README.md) |
+| Android native | `Mobiles/android/app/src/main/res/raw/config.json` (same three keys) — see [Android README](../android/README.md) |
+
+Use the OTLP base URL **without** a trailing slash or `/v1/traces` suffix — the
+apps append `/v1/traces` and `/v1/logs` themselves.
+
+### View the data
+
+Traces appear in **Explore → Tempo** within seconds (filter by
+`resource.service.name="quickpizza-ios"` / `"quickpizza-android"`); logs in
+**Explore → Loki** (`service_name="quickpizza-ios"` / `"quickpizza-android"`).
+For a RUM-style view, import the
+[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md).
+
+> **Android latency note:** the OTel-Android SDK buffers exports to disk
+> (~30–45 s) for offline resilience. For live demos, flip **Debug →
+> OpenTelemetry SDK → Disable disk buffering** to drop latency to ~1–6 s.
+
+---
+
+## Troubleshooting
+
+**No data in Grafana**
+
+- Confirm the telemetry values are set (in `config.json` / `Config.xcconfig`, or
+  the Debug → Config overrides) and you relaunched the app.
+- Faro: confirm the collector URL is complete (includes the `/collect/<token>`
+  path).
+- OTel: confirm the endpoint is OTLP/**HTTP** (not gRPC), has no trailing slash,
+  and the token allows `logs:write` + `traces:write`.
+- Use the in-app **Debug** tab to emit a test log / handled exception and
+  confirm it arrives.
+
+For what each app actually emits and how to query it, see
+[`MOBILE_OBSERVABILITY_OVERVIEW.md`](./MOBILE_OBSERVABILITY_OVERVIEW.md).

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -19,7 +19,7 @@ Every app can also take these values at runtime from its in-app **Debug →
 Config** screen (applied on next launch), so you can reconfigure during a demo
 without rebuilding.
 
-### This doc is about the *mobile app's* telemetry, not the backend's
+## This doc is about the *mobile app's* telemetry, not the backend's
 
 The mobile apps send their telemetry **directly** to Grafana Cloud (Faro
 collector or OTLP gateway) — the QuickPizza backend is not in that path and

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -12,8 +12,10 @@ families that authenticate differently:
 > **Faro apps require a collector URL.** The Flutter and React Native apps
 > throw at startup if `FARO_COLLECTOR_URL` is empty, so you must set it (see
 > below) even for a local-only demo. The **native OTel apps (iOS, Android)** are
-> different — leave the OTLP fields empty and signals go to the local console
-> only (Xcode/Logcat); set them when you want data in Grafana.
+> different — they still run with the OTLP fields empty. On iOS (debug builds)
+> spans go to the Xcode console; on Android export is disabled (the SDK runs as
+> a noop, so no OTel signals are produced). Set the OTLP fields when you want
+> data in Grafana.
 
 Every app can also take these values at runtime from its in-app **Debug →
 Config** screen (applied on next launch), so you can reconfigure during a demo
@@ -91,7 +93,8 @@ only supply the three raw values.
 | Android native | `Mobiles/android/app/src/main/res/raw/config.json` (same three keys) — see [Android README](../android/README.md) |
 
 Use the OTLP base URL **without** a trailing slash or `/v1/traces` suffix — the
-apps append `/v1/traces` and `/v1/logs` themselves.
+signal paths (`/v1/traces`, `/v1/logs`) get appended for you: the iOS app builds
+them itself, and on Android the OpenTelemetry SDK exporter handles them.
 
 ### View the data
 

--- a/Mobiles/docs/FLUTTER_ANDROID_SETUP.md
+++ b/Mobiles/docs/FLUTTER_ANDROID_SETUP.md
@@ -1,6 +1,9 @@
-# Android Setup Guide
+# Flutter — Android Toolchain Setup
 
-Simple steps to set up Android development and run the app on Android Emulator.
+Simple steps to set up the Android toolchain (Android Studio + emulator) so you
+can run the **Flutter** QuickPizza app on Android. The native Kotlin/Compose app
+has its own guide ([`ANDROID_NATIVE_SETUP.md`](./ANDROID_NATIVE_SETUP.md)); for
+the other apps see [`../README.md`](../README.md).
 
 ## Setup Steps
 

--- a/Mobiles/docs/FLUTTER_IOS_SETUP.md
+++ b/Mobiles/docs/FLUTTER_IOS_SETUP.md
@@ -1,6 +1,9 @@
-# iOS Setup Guide
+# Flutter — iOS Toolchain Setup
 
-Simple steps to set up iOS development and run the app on iOS Simulator.
+Simple steps to set up the iOS toolchain (Xcode + Simulator) so you can run the
+**Flutter** QuickPizza app on iOS. For the React Native, native iOS, or native
+Android apps, see their own setup docs linked from
+[`../README.md`](../README.md).
 
 ## Setup Steps
 

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -189,7 +189,7 @@ For deeper iOS detail see
 
 ### Android native (OpenTelemetry Android)
 
-- **SDK:** `opentelemetry-android` 1.2.0-alpha (`telemetry_sdk_language=java`)
+- **SDK:** `opentelemetry-android` 1.4.0-alpha (`telemetry_sdk_language=java`)
 - **Init:** `Mobiles/android/app/src/main/java/com/grafana/quickpizza/core/o11y/OTelService.kt`
   → `OpenTelemetryRumInitializer.initialize(...)`
 - **OTel service.name:** `quickpizza-android`, service.namespace `quickpizza`

--- a/Mobiles/flutter/README.md
+++ b/Mobiles/flutter/README.md
@@ -2,7 +2,11 @@
 
 A Flutter mobile application that replicates the QuickPizza web application functionality. This app allows users to get pizza recommendations, rate pizzas, and manage their profile, and demonstrates Grafana Faro mobile telemetry.
 
-> For a cross-platform comparison of all four QuickPizza mobile demos (Flutter, React Native, iOS native, Android native) and what each one emits, see [`../docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md). The shared feature spec lives in [`../FEATURES.md`](../FEATURES.md).
+> **New here?** Start at [`../README.md`](../README.md) for the overview of all
+> four apps, the backend, and how to get a demo running. This page covers the
+> Flutter app specifically.
+>
+> For a cross-platform comparison of what each app emits, see [`../docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md). The shared feature spec lives in [`../FEATURES.md`](../FEATURES.md).
 
 ## Features
 
@@ -29,13 +33,13 @@ A Flutter mobile application that replicates the QuickPizza web application func
 
 **For Android development:**
 
-- Follow the setup guide: [`../docs/ANDROID_SETUP.md`](../docs/ANDROID_SETUP.md)
+- Follow the setup guide: [`../docs/FLUTTER_ANDROID_SETUP.md`](../docs/FLUTTER_ANDROID_SETUP.md)
 - Quick check: Run `flutter doctor` - Android toolchain should show ✓
 - **Quick start:** After setup, use `./scripts/run-android.sh` to automatically open emulator and run the app
 
 **For iOS development (macOS only):**
 
-- Follow the setup guide: [`../docs/XCODE_SETUP.md`](../docs/XCODE_SETUP.md)
+- Follow the setup guide: [`../docs/FLUTTER_IOS_SETUP.md`](../docs/FLUTTER_IOS_SETUP.md)
 - Quick check: Run `flutter doctor` - Xcode should show ✓
 - **Quick start:** After setup, use `./scripts/run-ios.sh` to automatically open simulator and run the app
 
@@ -69,20 +73,13 @@ flutter pub get
 
    **Configuration options:**
 
-   - `FARO_COLLECTOR_URL`: Your Grafana Faro collector URL for observability
-   - `BASE_URL`: Backend API URL (optional - see platform defaults below)
+   - `FARO_COLLECTOR_URL`: Your Grafana Faro collector URL — see
+     [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md). Leave empty to
+     keep telemetry in the console only.
+   - `BASE_URL`: Backend API URL. Leave empty on emulators/simulators; set it to
+     your machine's LAN IP for physical devices. See
+     [emulator/device defaults in the Mobile README](../README.md#shared-basics).
    - `PORT`: Backend port (optional, defaults to `3333`)
-
-   **Platform defaults for BASE_URL:**
-
-   - **Android emulator**: `http://10.0.2.2:3333` (automatically used if BASE_URL is empty)
-   - **iOS simulator**: `http://localhost:3333` (automatically used if BASE_URL is empty)
-   - **Physical devices**: You must set BASE_URL to your machine's IP (e.g., `http://192.168.1.100:3333`)
-
-   > **💡 Tip:** To find your machine's IP address:
-   >
-   > - macOS: `ifconfig | grep "inet " | grep -v 127.0.0.1`
-   > - Make sure your phone is on the same WiFi network as your development machine
 
 3. Run the app:
 
@@ -220,8 +217,7 @@ onPressed: () => actions.ratePizza(stars: 5);
 
 ## Default Login Credentials
 
-- Username: `default`
-- Password: `12345678`
+`default` / `12345678` (see [Shared basics](../README.md#shared-basics)).
 
 ## Running on Different Platforms
 

--- a/Mobiles/flutter/README.md
+++ b/Mobiles/flutter/README.md
@@ -73,9 +73,9 @@ flutter pub get
 
    **Configuration options:**
 
-   - `FARO_COLLECTOR_URL`: Your Grafana Faro collector URL — see
-     [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md). Leave empty to
-     keep telemetry in the console only.
+   - `FARO_COLLECTOR_URL` (**required**): Your Grafana Faro collector URL — see
+     [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md). The app throws
+     at startup if this is empty.
    - `BASE_URL`: Backend API URL. Leave empty on emulators/simulators; set it to
      your machine's LAN IP for physical devices. See
      [emulator/device defaults in the Mobile README](../README.md#shared-basics).

--- a/Mobiles/ios/README.md
+++ b/Mobiles/ios/README.md
@@ -4,7 +4,11 @@ A native SwiftUI app that demonstrates mobile observability using OpenTelemetry.
 It connects to the QuickPizza backend and sends traces/logs to an OTLP collector
 (any Grafana Cloud stack you configure — see [Sending Telemetry to Grafana Cloud](#sending-telemetry-to-grafana-cloud)).
 
-> For a cross-platform comparison of all four QuickPizza mobile demos (Flutter, React Native, iOS native, Android native) and what each one emits, see [`../docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md). For the iOS instrumentation deep-dive see [`../docs/IOS_OBSERVABILITY_OTEL_GUIDE.md`](../docs/IOS_OBSERVABILITY_OTEL_GUIDE.md). The shared feature spec lives in [`../FEATURES.md`](../FEATURES.md).
+> **New here?** Start at [`../README.md`](../README.md) for the overview of all
+> four apps, the backend, and how to get a demo running. This page covers the
+> native iOS app specifically.
+>
+> For a cross-platform comparison of what each app emits, see [`../docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md). For the iOS instrumentation deep-dive see [`../docs/IOS_OBSERVABILITY_OTEL_GUIDE.md`](../docs/IOS_OBSERVABILITY_OTEL_GUIDE.md). The shared feature spec lives in [`../FEATURES.md`](../FEATURES.md).
 
 ---
 
@@ -134,22 +138,10 @@ details.
 
 ## Sending Telemetry to Grafana Cloud
 
-To send traces and logs to a Grafana Cloud stack, you need an OTLP endpoint
-and an API token.
-
-### Find your OTLP endpoint and credentials
-
-The OTLP endpoint follows the standard Grafana Cloud pattern:
-
-```
-https://otlp-gateway-<clusterSlug>.grafana.net/otlp
-```
-
-To find your `clusterSlug`, Instance ID, and API token:
-
-1. Go to your Grafana Cloud org page (`https://grafana.com/orgs/<your-org>`)
-2. Find the stack and click through to its details — the **cluster slug** and **numeric Instance ID** are listed there
-3. Generate an API token with scopes: `metrics:write`, `logs:write`, `traces:write`
+To send traces and logs to a Grafana Cloud stack you need an OTLP endpoint,
+instance ID, and token. Finding those values is the same for both native apps —
+see [**Connect to Grafana Cloud**](../docs/CONNECT_GRAFANA_CLOUD.md#opentelemetry-apps-ios-native-android-native).
+Then fill them into `Config.xcconfig` as shown below.
 
 ### Update Config.xcconfig
 

--- a/Mobiles/react-native/README.md
+++ b/Mobiles/react-native/README.md
@@ -43,9 +43,9 @@ cp config.json.example config.json
 
 Edit `config.json`:
 
-- **FARO_COLLECTOR_URL** (required for cloud): Your Grafana Faro collector URL —
-  see [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md). Leave empty
-  to keep telemetry in the console only.
+- **FARO_COLLECTOR_URL** (**required**): Your Grafana Faro collector URL —
+  see [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md). The app
+  throws at startup if this is empty.
 - **BASE_URL** (optional): Backend API URL. Leave empty on emulators/simulators;
   set to your machine's LAN IP for physical devices. See
   [emulator/device defaults](../README.md#shared-basics).
@@ -253,8 +253,9 @@ When a PASS lands, you can confidently upload, reinstall, and run the full Front
 
 ### Start the QuickPizza backend
 
-**Option A – Monolithic (simple):** the one-container command from
-[Mobile README § Step 1](../README.md#step-1--start-the-backend):
+**Option A – Monolithic (simple):** the one-container backend (see
+[Mobile README § Step 1](../README.md#step-1--start-the-backend) for the
+canonical command). Here it's run interactively rather than detached:
 
 ```bash
 docker run --rm -it -p 3333:3333 ghcr.io/grafana/quickpizza-mobile-local:latest

--- a/Mobiles/react-native/README.md
+++ b/Mobiles/react-native/README.md
@@ -2,7 +2,11 @@
 
 A React Native mobile application that replicates the QuickPizza web and Flutter app functionality. This app demonstrates Grafana Faro SDK integration for mobile observability.
 
-> For a cross-platform comparison of all four QuickPizza mobile demos (Flutter, React Native, iOS native, Android native) and what each one emits, see [MOBILE_OBSERVABILITY_OVERVIEW.md](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md). The shared feature spec lives in [FEATURES.md](../FEATURES.md).
+> **New here?** Start at [`../README.md`](../README.md) for the overview of all
+> four apps, the backend, and how to get a demo running. This page covers the
+> React Native app specifically.
+>
+> For a cross-platform comparison of what each app emits, see [MOBILE_OBSERVABILITY_OVERVIEW.md](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md). The shared feature spec lives in [FEATURES.md](../FEATURES.md).
 
 ## Features
 
@@ -39,11 +43,13 @@ cp config.json.example config.json
 
 Edit `config.json`:
 
-- **FARO_COLLECTOR_URL** (required): Your Grafana Faro collector URL for observability
-- **BASE_URL** (optional): Backend API URL. Leave empty for emulators (uses 10.0.2.2 for Android, localhost for iOS)
+- **FARO_COLLECTOR_URL** (required for cloud): Your Grafana Faro collector URL —
+  see [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md). Leave empty
+  to keep telemetry in the console only.
+- **BASE_URL** (optional): Backend API URL. Leave empty on emulators/simulators;
+  set to your machine's LAN IP for physical devices. See
+  [emulator/device defaults](../README.md#shared-basics).
 - **PORT** (optional): Backend port, defaults to 3333
-
-For physical devices, set `BASE_URL` to your machine's IP (e.g. `http://192.168.1.100:3333`).
 
 ### 3. iOS: Install CocoaPods
 
@@ -247,7 +253,8 @@ When a PASS lands, you can confidently upload, reinstall, and run the full Front
 
 ### Start the QuickPizza backend
 
-**Option A – Monolithic (simple):**
+**Option A – Monolithic (simple):** the one-container command from
+[Mobile README § Step 1](../README.md#step-1--start-the-backend):
 
 ```bash
 docker run --rm -it -p 3333:3333 ghcr.io/grafana/quickpizza-mobile-local:latest
@@ -288,8 +295,7 @@ yarn android
 
 ## Default login credentials
 
-- Username: `default`
-- Password: `12345678`
+`default` / `12345678` (see [Shared basics](../README.md#shared-basics)).
 
 ## Faro SDK
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,11 @@ QuickPizza for mobile observability demonstrations. Each app talks to the
 same QuickPizza backend and implements the same screens — what differs is
 the telemetry SDK and where the data lands in Grafana Cloud.
 
+> **👉 Start at [`Mobiles/README.md`](./Mobiles/README.md)** — it lists the
+> supported platforms, walks through getting a demo running (backend + an app),
+> and links out to the per-platform and observability docs. The rest of this
+> section only covers the backend image naming that's specific to this repo.
+
 ### Backend Docker image (mobile vs k6/web)
 
 This fork publishes a separate GHCR image so releases here do not overwrite the
@@ -375,17 +380,17 @@ For a single container (no compose):
 docker run --rm -it -p 3333:3333 ghcr.io/grafana/quickpizza-mobile-local:latest
 ```
 
-| Platform | Location | SDK | Telemetry destination | Setup |
-| --- | --- | --- | --- | --- |
-| Flutter (Android & iOS) | `Mobiles/flutter/` | Grafana Faro (`faro` Dart SDK) | Frontend Observability plugin | [Flutter README](./Mobiles/flutter/README.md) + [Flutter Android setup](./Mobiles/docs/ANDROID_SETUP.md) / [Flutter iOS setup](./Mobiles/docs/XCODE_SETUP.md) |
-| React Native (Android & iOS) | `Mobiles/react-native/` | Grafana Faro (`@grafana/faro-react-native`) | Frontend Observability plugin | [React Native README](./Mobiles/react-native/README.md) |
-| iOS native (Swift / SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` (+ `URLSessionInstrumentation`, `Sessions`, `MetricKitInstrumentation`) | OTLP/HTTP → Tempo + Loki | [iOS native README](./Mobiles/ios/README.md) |
-| Android native (Kotlin / Compose) | `Mobiles/android/` | `opentelemetry-android` RUM agent | OTLP/HTTP → Tempo + Loki | [Android native README](./Mobiles/android/README.md) + [Android native setup](./Mobiles/docs/ANDROID_NATIVE_SETUP.md) |
+### Supported platforms
 
-For a single document that covers what each platform actually emits, where
-the data lives, and how the Faro and OpenTelemetry SDKs differ
-side-by-side, see
-[`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md).
+| Platform | Location | SDK | Telemetry destination |
+| --- | --- | --- | --- |
+| Flutter (Android & iOS) | `Mobiles/flutter/` | Grafana Faro (`faro` Dart SDK) | Frontend Observability plugin |
+| React Native (Android & iOS) | `Mobiles/react-native/` | Grafana Faro (`@grafana/faro-react-native`) | Frontend Observability plugin |
+| iOS native (Swift / SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | OTLP/HTTP → Tempo + Loki |
+| Android native (Kotlin / Compose) | `Mobiles/android/` | `opentelemetry-android` RUM agent | OTLP/HTTP → Tempo + Loki |
 
-The shared cross-platform feature spec (Home, Login, Profile, About, Debug)
-lives in [`Mobiles/FEATURES.md`](./Mobiles/FEATURES.md).
+Per-platform run guides, the observability deep-dive
+([`MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md)),
+the shared feature spec ([`FEATURES.md`](./Mobiles/FEATURES.md)), and the
+Grafana Cloud connection steps are all linked from
+[`Mobiles/README.md`](./Mobiles/README.md).


### PR DESCRIPTION
## What & why

There was no starting point for the mobile demos — the closest thing was a reference table buried in the root README, and the same facts (backend `docker run`, login `default/12345678`, the `10.0.2.2` emulator default, per-app telemetry tables, resource attributes, OTLP/Faro credential steps) were restated across 6–8 files each. This made it hard for someone new to know **which platforms are supported**, **how to get a demo running**, and **where to look for more**.

This PR introduces a clear information architecture: one entry point that orients you and links out, with each fact living in exactly one place.

## Changes

**New starting point — `Mobiles/README.md`**
- Supported platforms table (Flutter, React Native, iOS native, Android native — native vs cross-platform, SDK, where data lands).
- "Run a demo in 3 steps": start the backend → optionally connect Grafana Cloud → pick a platform (short run snippets inline, full toolchain detail linked).
- "Shared basics" stated once: login creds, emulator/device `BASE_URL` defaults, the Debug-tab demo flow.
- "Where to go for more" index linking every deeper doc.

**De-duplication — each fact gets one home**
- New `docs/CONNECT_GRAFANA_CLOUD.md` consolidates Faro collector URL + OTLP endpoint/token setup, with an explicit callout distinguishing the *mobile app's* telemetry (direct to Grafana Cloud) from the *backend's* telemetry (configured separately via the root README's Compose + `.env`).
- Telemetry inventories / resource attributes stay in `MOBILE_OBSERVABILITY_OVERVIEW.md`; per-app READMEs and `ANDROID_NATIVE_SETUP.md` trimmed to summaries + links.

**File renames (clarify Flutter scope)**
- `docs/XCODE_SETUP.md` → `docs/FLUTTER_IOS_SETUP.md`
- `docs/ANDROID_SETUP.md` → `docs/FLUTTER_ANDROID_SETUP.md`

**Other**
- Slimmed the root `README.md` mobile section to point at the new hub (keeping only the repo-specific backend-image naming).
- Pointed `CLAUDE.md`'s quick reference at the hub.
- All cross-references updated; no broken links to renamed files.

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)