### PR TITLE
chore(mobile): vary QuickPizza demo app versions

### DIFF
--- a/.github/scripts/read-demo-app-base-version.mjs
+++ b/.github/scripts/read-demo-app-base-version.mjs
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+const TARGETS = {
+  'react-native': {
+    file: 'Mobiles/react-native/src/core/config/appVersionResolver.ts',
+    pattern: /const\s+DEFAULT_APP_VERSION\s*=\s*['"]([^'"]+)['"]/,
+  },
+  'android-native': {
+    file: 'Mobiles/android/app/build.gradle.kts',
+    pattern: /quickPizzaDemoVersionName\s*=\s*providers\.gradleProperty\("quickpizzaDemoVersionName"\)\.orElse\("([^"]+)"\)/,
+  },
+  'ios-native': {
+    file: 'Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj',
+    pattern: /MARKETING_VERSION = ([^;\s]+);/,
+  },
+};
+
+export function readDemoAppBaseVersion(target, { repoRoot = REPO_ROOT } = {}) {
+  const config = TARGETS[target];
+  if (!config) {
+    throw new Error(`Unknown demo app target: ${target}`);
+  }
+
+  const filePath = path.join(repoRoot, config.file);
+  const content = readFileSync(filePath, 'utf8');
+  const version = config.pattern.exec(content)?.[1];
+
+  if (!version) {
+    throw new Error(`Could not resolve base version for ${target}`);
+  }
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error(`Expected semver base version for ${target}, got ${version}`);
+  }
+
+  return version;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(readDemoAppBaseVersion(process.argv[2]));
+}

--- a/.github/scripts/read-demo-app-base-version.test.mjs
+++ b/.github/scripts/read-demo-app-base-version.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { readDemoAppBaseVersion } from './read-demo-app-base-version.mjs';
+
+describe('readDemoAppBaseVersion', () => {
+  it('reads the React Native Faro app version base', () => {
+    assert.equal(readDemoAppBaseVersion('react-native'), '1.0.0');
+  });
+
+  it('reads the native Android versionName base', () => {
+    assert.equal(readDemoAppBaseVersion('android-native'), '1.0.0');
+  });
+
+  it('reads the native iOS MARKETING_VERSION base', () => {
+    assert.equal(readDemoAppBaseVersion('ios-native'), '1.1.0');
+  });
+
+  it('rejects unknown targets', () => {
+    assert.throws(() => readDemoAppBaseVersion('unknown'), /Unknown demo app target/);
+  });
+});

--- a/.github/scripts/resolve-demo-app-version.mjs
+++ b/.github/scripts/resolve-demo-app-version.mjs
@@ -1,0 +1,29 @@
+const baseVersion = process.argv[2] ?? '1.0.0';
+const variants = Number.parseInt(process.env.DEMO_APP_VERSION_VARIANTS ?? '3', 10);
+
+const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(baseVersion);
+if (!match || !Number.isFinite(variants) || variants < 1) {
+  console.log(baseVersion);
+  process.exit(0);
+}
+
+const [major, minor, patch] = match.slice(1).map(Number);
+const now = new Date();
+const hourBucket = [
+  now.getUTCFullYear().toString().padStart(4, '0'),
+  (now.getUTCMonth() + 1).toString().padStart(2, '0'),
+  now.getUTCDate().toString().padStart(2, '0'),
+  now.getUTCHours().toString().padStart(2, '0'),
+].join('');
+
+function stableHash(input) {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = ((hash << 5) + hash) ^ input.charCodeAt(i);
+    hash &= 0x7fffffff;
+  }
+  return hash;
+}
+
+const variant = stableHash(`${baseVersion}|${hourBucket}`) % variants;
+console.log(`${major}.${minor}.${patch + variant}`);

--- a/.github/scripts/resolve-demo-app-version.mjs
+++ b/.github/scripts/resolve-demo-app-version.mjs
@@ -1,20 +1,15 @@
-const baseVersion = process.argv[2] ?? '1.0.0';
-const variants = Number.parseInt(process.env.DEMO_APP_VERSION_VARIANTS ?? '3', 10);
+import { pathToFileURL } from 'node:url';
 
-const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(baseVersion);
-if (!match || !Number.isFinite(variants) || variants < 1) {
-  console.log(baseVersion);
-  process.exit(0);
+const DEFAULT_VARIANTS = 3;
+
+function hourBucketForDate(now) {
+  return [
+    now.getUTCFullYear().toString().padStart(4, '0'),
+    (now.getUTCMonth() + 1).toString().padStart(2, '0'),
+    now.getUTCDate().toString().padStart(2, '0'),
+    now.getUTCHours().toString().padStart(2, '0'),
+  ].join('');
 }
-
-const [major, minor, patch] = match.slice(1).map(Number);
-const now = new Date();
-const hourBucket = [
-  now.getUTCFullYear().toString().padStart(4, '0'),
-  (now.getUTCMonth() + 1).toString().padStart(2, '0'),
-  now.getUTCDate().toString().padStart(2, '0'),
-  now.getUTCHours().toString().padStart(2, '0'),
-].join('');
 
 function stableHash(input) {
   let hash = 5381;
@@ -25,5 +20,20 @@ function stableHash(input) {
   return hash;
 }
 
-const variant = stableHash(`${baseVersion}|${hourBucket}`) % variants;
-console.log(`${major}.${minor}.${patch + variant}`);
+export function resolveDemoAppVersion(baseVersion, { now = new Date(), variants = DEFAULT_VARIANTS } = {}) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(baseVersion);
+  if (!match || !Number.isFinite(variants) || variants < 1) {
+    return baseVersion;
+  }
+
+  const [major, minor, patch] = match.slice(1).map(Number);
+  const variant = stableHash(`${baseVersion}|${hourBucketForDate(now)}`) % variants;
+  return `${major}.${minor}.${patch + variant}`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const baseVersion = process.argv[2] ?? '1.0.0';
+  const variants = Number.parseInt(process.env.DEMO_APP_VERSION_VARIANTS ?? `${DEFAULT_VARIANTS}`, 10);
+
+  console.log(resolveDemoAppVersion(baseVersion, { variants }));
+}

--- a/.github/scripts/resolve-demo-app-version.test.mjs
+++ b/.github/scripts/resolve-demo-app-version.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { resolveDemoAppVersion } from './resolve-demo-app-version.mjs';
+
+describe('resolveDemoAppVersion', () => {
+  const hour = new Date(Date.UTC(2026, 5, 17, 12, 34));
+
+  it('keeps the same version variant within a UTC hour', () => {
+    const first = resolveDemoAppVersion('1.0.0', { now: hour });
+    const second = resolveDemoAppVersion('1.0.0', {
+      now: new Date(Date.UTC(2026, 5, 17, 12, 59)),
+    });
+
+    assert.equal(first, second);
+  });
+
+  it('keeps generated patch versions within the configured variant range', () => {
+    const version = resolveDemoAppVersion('1.0.4', { now: hour, variants: 3 });
+
+    assert.match(version, /^1\.0\.[4-6]$/);
+  });
+
+  it('falls back to the base version for invalid input', () => {
+    assert.equal(resolveDemoAppVersion('1.0', { now: hour }), '1.0');
+    assert.equal(resolveDemoAppVersion('1.0.0', { now: hour, variants: 0 }), '1.0.0');
+    assert.equal(resolveDemoAppVersion('1.0.0', { now: hour, variants: Number.NaN }), '1.0.0');
+  });
+});

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -409,6 +409,11 @@ jobs:
           EOF
           echo "Created Config.xcconfig (secrets redacted)"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ">=24.5.0"
+
       - name: Resolve iOS Native demo app version
         run: |
           IOS_NATIVE_DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.1.0)"
@@ -508,11 +513,6 @@ jobs:
           fi
           echo "Built app: $APP_PATH"
           echo "app_path=$(pwd)/$APP_PATH" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ">=24.5.0"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -18,6 +18,7 @@ on:
       - main
     paths:
       - ".github/workflows/mobile_demo_telemetry.yaml"
+      - ".github/scripts/**"
       - "Mobiles/e2e/**"
       - "Mobiles/flutter/**"
       - "Mobiles/react-native/**"
@@ -146,6 +147,12 @@ jobs:
           EOF
           echo "Created React Native config.json (FARO_COLLECTOR_URL redacted)"
 
+      - name: Resolve React Native demo app version
+        run: |
+          DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.0.0)"
+          echo "DEMO_APP_VERSION=${DEMO_APP_VERSION}" >> "$GITHUB_ENV"
+          echo "React Native demo app version: ${DEMO_APP_VERSION}"
+
       - name: Bundle JS for offline debug APK
         working-directory: Mobiles/react-native
         run: |
@@ -182,11 +189,17 @@ jobs:
           EOF
           echo "Created Android Native config.json (secrets redacted)"
 
+      - name: Resolve Android Native demo app version
+        run: |
+          ANDROID_NATIVE_DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.0.0)"
+          echo "ANDROID_NATIVE_DEMO_APP_VERSION=${ANDROID_NATIVE_DEMO_APP_VERSION}" >> "$GITHUB_ENV"
+          echo "Android Native demo app version: ${ANDROID_NATIVE_DEMO_APP_VERSION}"
+
       - name: Build Android Native APK (debug)
         working-directory: Mobiles/android
         run: |
           echo "Building native Android APK..."
-          ./gradlew :app:assembleDebug
+          ./gradlew :app:assembleDebug -PquickpizzaDemoVersionName="${ANDROID_NATIVE_DEMO_APP_VERSION}"
           ls -la app/build/outputs/apk/debug/
 
       - name: Stage APKs for e2e
@@ -396,6 +409,12 @@ jobs:
           EOF
           echo "Created Config.xcconfig (secrets redacted)"
 
+      - name: Resolve iOS Native demo app version
+        run: |
+          IOS_NATIVE_DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.1.0)"
+          echo "IOS_NATIVE_DEMO_APP_VERSION=${IOS_NATIVE_DEMO_APP_VERSION}" >> "$GITHUB_ENV"
+          echo "iOS Native demo app version: ${IOS_NATIVE_DEMO_APP_VERSION}"
+
       - name: Build iOS .app for Simulator
         id: build-ios-app
         working-directory: Mobiles/ios
@@ -414,6 +433,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="${IOS_NATIVE_DEMO_APP_VERSION}" \
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
             build > build/ci/xcodebuild.log 2>&1
@@ -529,6 +549,12 @@ jobs:
           }
           EOF
           echo "Created React Native config.json (FARO_COLLECTOR_URL redacted)"
+
+      - name: Resolve React Native demo app version
+        run: |
+          DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.0.0)"
+          echo "DEMO_APP_VERSION=${DEMO_APP_VERSION}" >> "$GITHUB_ENV"
+          echo "React Native demo app version: ${DEMO_APP_VERSION}"
 
       - name: Build React Native iOS .app for Simulator
         id: build-react-native-ios-app

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -149,9 +149,10 @@ jobs:
 
       - name: Resolve React Native demo app version
         run: |
-          DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.0.0)"
+          DEMO_APP_BASE_VERSION="$(node .github/scripts/read-demo-app-base-version.mjs react-native)"
+          DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs "${DEMO_APP_BASE_VERSION}")"
           echo "DEMO_APP_VERSION=${DEMO_APP_VERSION}" >> "$GITHUB_ENV"
-          echo "React Native demo app version: ${DEMO_APP_VERSION}"
+          echo "React Native demo app version: ${DEMO_APP_VERSION} (base: ${DEMO_APP_BASE_VERSION})"
 
       - name: Bundle JS for offline debug APK
         working-directory: Mobiles/react-native
@@ -191,9 +192,10 @@ jobs:
 
       - name: Resolve Android Native demo app version
         run: |
-          ANDROID_NATIVE_DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.0.0)"
+          ANDROID_NATIVE_DEMO_BASE_VERSION="$(node .github/scripts/read-demo-app-base-version.mjs android-native)"
+          ANDROID_NATIVE_DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs "${ANDROID_NATIVE_DEMO_BASE_VERSION}")"
           echo "ANDROID_NATIVE_DEMO_APP_VERSION=${ANDROID_NATIVE_DEMO_APP_VERSION}" >> "$GITHUB_ENV"
-          echo "Android Native demo app version: ${ANDROID_NATIVE_DEMO_APP_VERSION}"
+          echo "Android Native demo app version: ${ANDROID_NATIVE_DEMO_APP_VERSION} (base: ${ANDROID_NATIVE_DEMO_BASE_VERSION})"
 
       - name: Build Android Native APK (debug)
         working-directory: Mobiles/android
@@ -416,9 +418,10 @@ jobs:
 
       - name: Resolve iOS Native demo app version
         run: |
-          IOS_NATIVE_DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.1.0)"
+          IOS_NATIVE_DEMO_BASE_VERSION="$(node .github/scripts/read-demo-app-base-version.mjs ios-native)"
+          IOS_NATIVE_DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs "${IOS_NATIVE_DEMO_BASE_VERSION}")"
           echo "IOS_NATIVE_DEMO_APP_VERSION=${IOS_NATIVE_DEMO_APP_VERSION}" >> "$GITHUB_ENV"
-          echo "iOS Native demo app version: ${IOS_NATIVE_DEMO_APP_VERSION}"
+          echo "iOS Native demo app version: ${IOS_NATIVE_DEMO_APP_VERSION} (base: ${IOS_NATIVE_DEMO_BASE_VERSION})"
 
       - name: Build iOS .app for Simulator
         id: build-ios-app
@@ -552,9 +555,10 @@ jobs:
 
       - name: Resolve React Native demo app version
         run: |
-          DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs 1.0.0)"
+          DEMO_APP_BASE_VERSION="$(node .github/scripts/read-demo-app-base-version.mjs react-native)"
+          DEMO_APP_VERSION="$(node .github/scripts/resolve-demo-app-version.mjs "${DEMO_APP_BASE_VERSION}")"
           echo "DEMO_APP_VERSION=${DEMO_APP_VERSION}" >> "$GITHUB_ENV"
-          echo "React Native demo app version: ${DEMO_APP_VERSION}"
+          echo "React Native demo app version: ${DEMO_APP_VERSION} (base: ${DEMO_APP_BASE_VERSION})"
 
       - name: Build React Native iOS .app for Simulator
         id: build-react-native-ios-app

--- a/.github/workflows/mobile_demo_telemetry_build.yaml
+++ b/.github/workflows/mobile_demo_telemetry_build.yaml
@@ -55,6 +55,24 @@ jobs:
           done <<< "$CHANGED"
           echo "mobile=$mobile" >> "$GITHUB_OUTPUT"
 
+  test-demo-version-script:
+    name: Test demo app version script
+    needs: mobile-changes
+    if: needs.mobile-changes.outputs.mobile == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ">=24.5.0"
+
+      - name: Test demo app version script
+        run: node --test .github/scripts/resolve-demo-app-version.test.mjs
+
   build-flutter-apk:
     name: Build check — Flutter APK
     needs: mobile-changes

--- a/.github/workflows/mobile_demo_telemetry_build.yaml
+++ b/.github/workflows/mobile_demo_telemetry_build.yaml
@@ -45,6 +45,7 @@ jobs:
             case "$file" in
               .github/workflows/mobile_demo_telemetry.yaml|\
               .github/workflows/mobile_demo_telemetry_build.yaml|\
+              .github/scripts/**|\
               Mobiles/*|\
               compose.grafana-cloud.microservices.yaml)
                 mobile=true

--- a/.github/workflows/mobile_demo_telemetry_build.yaml
+++ b/.github/workflows/mobile_demo_telemetry_build.yaml
@@ -55,8 +55,8 @@ jobs:
           done <<< "$CHANGED"
           echo "mobile=$mobile" >> "$GITHUB_OUTPUT"
 
-  test-demo-version-script:
-    name: Test demo app version script
+  test-demo-version-scripts:
+    name: Test demo app version scripts
     needs: mobile-changes
     if: needs.mobile-changes.outputs.mobile == 'true'
     runs-on: ubuntu-latest
@@ -70,8 +70,8 @@ jobs:
         with:
           node-version: ">=24.5.0"
 
-      - name: Test demo app version script
-        run: node --test .github/scripts/resolve-demo-app-version.test.mjs
+      - name: Test demo app version scripts
+        run: node --test .github/scripts/*.test.mjs
 
   build-flutter-apk:
     name: Build check — Flutter APK

--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -22,6 +22,8 @@ tasks.register<Delete>("deleteExampleConfig") {
 tasks.matching { it.name.contains("mergeDebugResources") || it.name.contains("mergeReleaseResources") || it.name.contains("packageDebugResources") || it.name.contains("packageReleaseResources") }
     .configureEach { dependsOn("deleteExampleConfig") }
 
+val quickPizzaDemoVersionName = providers.gradleProperty("quickpizzaDemoVersionName").orElse("1.0")
+
 android {
     namespace = "com.grafana.quickpizza"
     compileSdk = 36
@@ -31,7 +33,7 @@ android {
         minSdk = 23
         targetSdk = 36
         versionCode = 1
-        versionName = "1.0"
+        versionName = quickPizzaDemoVersionName.get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.register<Delete>("deleteExampleConfig") {
 tasks.matching { it.name.contains("mergeDebugResources") || it.name.contains("mergeReleaseResources") || it.name.contains("packageDebugResources") || it.name.contains("packageReleaseResources") }
     .configureEach { dependsOn("deleteExampleConfig") }
 
-val quickPizzaDemoVersionName = providers.gradleProperty("quickpizzaDemoVersionName").orElse("1.0")
+val quickPizzaDemoVersionName = providers.gradleProperty("quickpizzaDemoVersionName").orElse("1.0.0")
 
 android {
     namespace = "com.grafana.quickpizza"

--- a/Mobiles/react-native/babel.config.js
+++ b/Mobiles/react-native/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
     [
       'babel-plugin-transform-inline-environment-variables',
       {
-        include: ['ENABLE_FARO_PAYLOAD_DIAGNOSTICS'],
+        include: ['DEMO_APP_VERSION', 'ENABLE_FARO_PAYLOAD_DIAGNOSTICS'],
       },
     ],
   ],

--- a/Mobiles/react-native/src/bootstrap.ts
+++ b/Mobiles/react-native/src/bootstrap.ts
@@ -7,6 +7,7 @@ import {
 import { InternalLoggerLevel, LogLevel, SamplingRate, initializeFaro, type ReactNativeConfig } from './core/o11y/faroSdk';
 
 import { extractTokenFromCollectorUrl } from './core/utils/faroUtils';
+import { resolveTelemetryAppVersion } from './core/config/appVersionResolver';
 import { getFaroCollectorUrl, getQuickPizzaTracePropagationUrlPatterns } from './core/config/configService';
 
 /**
@@ -21,7 +22,7 @@ const ENABLE_FARO_PAYLOAD_DIAGNOSTICS =
 /** Must match `app.name` and Metro `@grafana/faro-metro-plugin` `appName`. */
 const FARO_APP_NAME = 'QuickPizza_ReactNative';
 
-const APP_VERSION = '1.0.0';
+const APP_VERSION = resolveTelemetryAppVersion(process.env.DEMO_APP_VERSION);
 const APP_ENV = __DEV__ ? 'development' : 'production';
 
 // Capture the original console BEFORE any patching happens (RN DevTools, LogBox, etc.)

--- a/Mobiles/react-native/src/core/config/appVersionResolver.test.ts
+++ b/Mobiles/react-native/src/core/config/appVersionResolver.test.ts
@@ -1,0 +1,16 @@
+import { resolveTelemetryAppVersion } from './appVersionResolver';
+
+describe('resolveTelemetryAppVersion', () => {
+  it('uses the default app version when no demo version is provided', () => {
+    expect(resolveTelemetryAppVersion()).toBe('1.0.0');
+  });
+
+  it('uses the CI-provided demo app version when it is valid', () => {
+    expect(resolveTelemetryAppVersion('1.0.2')).toBe('1.0.2');
+  });
+
+  it('falls back to the default app version when the demo version is invalid', () => {
+    expect(resolveTelemetryAppVersion('1.0')).toBe('1.0.0');
+    expect(resolveTelemetryAppVersion('')).toBe('1.0.0');
+  });
+});

--- a/Mobiles/react-native/src/core/config/appVersionResolver.ts
+++ b/Mobiles/react-native/src/core/config/appVersionResolver.ts
@@ -1,0 +1,10 @@
+const DEFAULT_APP_VERSION = '1.0.0';
+const APP_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+export function resolveTelemetryAppVersion(demoAppVersion?: string): string {
+  const trimmed = demoAppVersion?.trim();
+  if (trimmed && APP_VERSION_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  return DEFAULT_APP_VERSION;
+}

--- a/README.md
+++ b/README.md
@@ -382,6 +382,16 @@ docker run --rm -it -p 3333:3333 ghcr.io/grafana/quickpizza-mobile-local:latest
 | iOS native (Swift / SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` (+ `URLSessionInstrumentation`, `Sessions`, `MetricKitInstrumentation`) | OTLP/HTTP → Tempo + Loki | [iOS native README](./Mobiles/ios/README.md) |
 | Android native (Kotlin / Compose) | `Mobiles/android/` | `opentelemetry-android` RUM agent | OTLP/HTTP → Tempo + Loki | [Android native README](./Mobiles/android/README.md) + [Android native setup](./Mobiles/docs/ANDROID_NATIVE_SETUP.md) |
 
+### Demo app version variation
+
+The mobile telemetry workflow varies app versions for demo data so Mobile O11y
+can show a small app-version distribution instead of a single flat version.
+Flutter resolves this at runtime when `CI_DEMO_VERSIONING=true`. React Native
+resolves the Faro-reported app version at bundle time. Native Android and
+native iOS resolve the version during the CI build and bake it into
+`versionName` / `MARKETING_VERSION`, so their installed app metadata and
+emitted telemetry use the same version for that run.
+
 For a single document that covers what each platform actually emits, where
 the data lives, and how the Faro and OpenTelemetry SDKs differ
 side-by-side, see


### PR DESCRIPTION
## Why

QuickPizza Flutter already varies demo app versions in CI so Mobile O11y can show app version distribution. React Native and native iOS/Android were still reporting fixed versions, which made the version breakdowns less useful in demo data.

## What

- Adds a shared CI helper to generate deterministic hourly demo app version variants.
- Uses `DEMO_APP_VERSION` for the React Native Faro app version.
- Makes native Android `versionName` overridable via `-PquickpizzaDemoVersionName`.
- Passes generated `MARKETING_VERSION` into native iOS simulator builds.
- Adds focused tests for the shared demo app version resolver.
- Keeps Flutter unchanged as the existing reference implementation.

## Verification
- `node --test .github/scripts/resolve-demo-app-version.test.mjs`
- CI: `Test demo app version script` passed in the PR build workflow.
- Local resolver examples:
  - `2026-06-17T12:00:00.000Z -> 1.0.1`
  - `2026-06-17T13:00:00.000Z -> 1.0.0`
  - `2026-06-17T14:00:00.000Z -> 1.0.2`
- Native Android local proof:
  - built with `-PquickpizzaDemoVersionName=1.0.2`
  - APK metadata shows `versionName='1.0.2'`
- Native iOS local proof:
  - built with `MARKETING_VERSION=1.1.2`
  - built app plist shows `CFBundleShortVersionString=1.1.2`
  
## Screenshots
N/A for UI screenshots before merge. Final Mobile O11y Cloud proof requires this to run from `main` through the scheduled/full telemetry workflow for a few cycles so multiple hourly versions appear in the app version breakdown.

## Notes

Final Grafana Cloud proof requires this to run from `main` through the scheduled/full telemetry workflow for a few cycles so the hourly version spread can show up in Mobile O11y.

Refs grafana/app-o11y-kwl#3630