### PR TITLE
chore(mobile): schedule QuickPizza diagnostic data

### DIFF
--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -36,14 +36,58 @@ env:
   FLUTTER_CHANNEL: "stable"
 
 jobs:
+  resolve-diagnostics-cadence:
+    name: Resolve diagnostics cadence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Compute the diagnostics cadence once so the Android and iOS legs stay in
+    # lockstep. Computing it per-leg risked the two runners landing on different
+    # hour buckets across an hour boundary and disagreeing on what to emit.
+    outputs:
+      run_handled_exception: ${{ steps.cadence.outputs.run_handled_exception }}
+      run_crash: ${{ steps.cadence.outputs.run_crash }}
+    steps:
+      - name: Resolve cadence
+        id: cadence
+        env:
+          FORCE_DIAGNOSTICS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_diagnostics == true }}
+        run: |
+          set -euo pipefail
+
+          run_handled_exception=false
+          run_crash=false
+
+          if [ "$FORCE_DIAGNOSTICS" = "true" ]; then
+            run_crash=true
+          elif [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            hour_bucket=$(($(date -u +%s) / 3600))
+            if [ $((hour_bucket % 3)) -eq 0 ]; then
+              run_handled_exception=true
+            fi
+            if [ $((hour_bucket % 10)) -eq 0 ]; then
+              run_crash=true
+              # The crash diagnostics flow already emits one handled exception first.
+              run_handled_exception=false
+            fi
+          fi
+
+          echo "run_handled_exception=${run_handled_exception}" >> "$GITHUB_OUTPUT"
+          echo "run_crash=${run_crash}" >> "$GITHUB_OUTPUT"
+          echo "Handled-exception diagnostics: ${run_handled_exception}"
+          echo "Crash diagnostics: ${run_crash}"
+
   run-mobile-demo:
     name: Run Android Mobile Demo
+    needs: resolve-diagnostics-cadence
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: mobile-demo-telemetry
     permissions:
       id-token: write
       contents: read
+    env:
+      RUN_HANDLED_EXCEPTION_DIAGNOSTICS: ${{ needs.resolve-diagnostics-cadence.outputs.run_handled_exception }}
+      RUN_CRASH_DIAGNOSTICS: ${{ needs.resolve-diagnostics-cadence.outputs.run_crash }}
 
     steps:
       - name: Get Vault secrets
@@ -252,7 +296,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
         env:
           OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
-          RUN_DIAGNOSTICS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_diagnostics == true }}
         with:
           api-level: 34
           arch: x86_64
@@ -304,13 +347,21 @@ jobs:
             # android-emulator-runner executes script lines individually, so
             # keep diagnostics gating as one-line commands instead of a
             # multi-line shell if block.
-            [ "$RUN_DIAGNOSTICS" = "true" ] || echo "Skipping diagnostics flow. Set workflow_dispatch input run_diagnostics=true to run it manually."
-            [ "$RUN_DIAGNOSTICS" != "true" ] || echo "==> Flutter APK: diagnostics E2E"
-            [ "$RUN_DIAGNOSTICS" != "true" ] || timeout --foreground 20m bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=android --flow=diagnostics
-            [ "$RUN_DIAGNOSTICS" != "true" ] || echo "==> React Native APK: diagnostics E2E"
-            [ "$RUN_DIAGNOSTICS" != "true" ] || timeout --foreground 20m bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=android --flow=diagnostics
-            [ "$RUN_DIAGNOSTICS" != "true" ] || echo "==> Android Native APK: diagnostics E2E"
-            [ "$RUN_DIAGNOSTICS" != "true" ] || timeout --foreground 20m bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android --flow=diagnostics
+            [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" = "true" ] || echo "Skipping handled-exception diagnostics for this run."
+            [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || echo "==> Flutter APK: handled-exception diagnostics E2E"
+            [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || timeout --foreground 15m bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=android --flow=handled-exception
+            [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || echo "==> React Native APK: handled-exception diagnostics E2E"
+            [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || timeout --foreground 15m bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=android --flow=handled-exception
+            [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || echo "==> Android Native APK: handled-exception diagnostics E2E"
+            [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || timeout --foreground 15m bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android --flow=handled-exception
+
+            [ "$RUN_CRASH_DIAGNOSTICS" = "true" ] || echo "Skipping crash diagnostics for this run. Manual runs can force this with run_diagnostics=true."
+            [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || echo "==> Flutter APK: crash diagnostics E2E"
+            [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || timeout --foreground 20m bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=android --flow=diagnostics
+            [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || echo "==> React Native APK: crash diagnostics E2E"
+            [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || timeout --foreground 20m bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=android --flow=diagnostics
+            [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || echo "==> Android Native APK: crash diagnostics E2E"
+            [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || timeout --foreground 20m bash Mobiles/e2e/run_e2e_tests.sh --app=android-native --platform=android --flow=diagnostics
 
             echo "E2E tests completed (Flutter, React Native, Android Native on same emulator)."
 
@@ -344,6 +395,7 @@ jobs:
 
   run-ios-mobile-demo:
     name: Run iOS Mobile Demo
+    needs: resolve-diagnostics-cadence
     # macOS-only: xcrun simctl + the booted iOS simulator only work on macOS.
     runs-on: macos-26
     timeout-minutes: 180
@@ -351,6 +403,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      RUN_HANDLED_EXCEPTION_DIAGNOSTICS: ${{ needs.resolve-diagnostics-cadence.outputs.run_handled_exception }}
+      RUN_CRASH_DIAGNOSTICS: ${{ needs.resolve-diagnostics-cadence.outputs.run_crash }}
 
     steps:
       - name: Get Vault secrets
@@ -740,7 +795,6 @@ jobs:
       - name: Install iOS apps and run e2e tests
         env:
           OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
-          RUN_DIAGNOSTICS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_diagnostics == true }}
           IOS_NATIVE_APP_PATH: ${{ steps.build-ios-app.outputs.app_path }}
           FLUTTER_IOS_APP_PATH: ${{ steps.build-flutter-ios-app.outputs.app_path }}
           REACT_NATIVE_IOS_APP_PATH: ${{ steps.build-react-native-ios-app.outputs.app_path }}
@@ -757,12 +811,12 @@ jobs:
           xcrun simctl get_app_container booted com.grafana.QuickPizzaIos
           bash Mobiles/e2e/run_e2e_tests.sh --app=ios-native --platform=ios
 
-          if [ "$RUN_DIAGNOSTICS" = "true" ]; then
-            echo "==> Native iOS .app: diagnostics E2E"
-            bash Mobiles/e2e/run_e2e_tests.sh --app=ios-native --platform=ios --flow=diagnostics
-          else
-            echo "Skipping diagnostics flow. Set workflow_dispatch input run_diagnostics=true to run it manually."
-          fi
+          [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" = "true" ] || echo "Skipping Native iOS handled-exception diagnostics for this run."
+          [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || echo "==> Native iOS .app: handled-exception diagnostics E2E"
+          [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=ios-native --platform=ios --flow=handled-exception
+          [ "$RUN_CRASH_DIAGNOSTICS" = "true" ] || echo "Skipping Native iOS crash diagnostics for this run. Manual runs can force this with run_diagnostics=true."
+          [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || echo "==> Native iOS .app: crash diagnostics E2E"
+          [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=ios-native --platform=ios --flow=diagnostics
 
           echo "==> Flutter iOS .app: install and E2E"
           if [ ! -d "$FLUTTER_IOS_APP_PATH" ]; then
@@ -773,10 +827,10 @@ jobs:
           xcrun simctl install booted "$FLUTTER_IOS_APP_PATH"
           xcrun simctl get_app_container booted com.example.flutterMobileO11yDemo
           bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=ios
-          if [ "$RUN_DIAGNOSTICS" = "true" ]; then
-            echo "==> Flutter iOS .app: diagnostics E2E"
-            bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=ios --flow=diagnostics
-          fi
+          [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || echo "==> Flutter iOS .app: handled-exception diagnostics E2E"
+          [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=ios --flow=handled-exception
+          [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || echo "==> Flutter iOS .app: crash diagnostics E2E"
+          [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=flutter --platform=ios --flow=diagnostics
 
           echo "==> React Native iOS .app: install and E2E"
           if [ ! -d "$REACT_NATIVE_IOS_APP_PATH" ]; then
@@ -787,10 +841,10 @@ jobs:
           xcrun simctl install booted "$REACT_NATIVE_IOS_APP_PATH"
           xcrun simctl get_app_container booted com.quickpizza
           bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=ios
-          if [ "$RUN_DIAGNOSTICS" = "true" ]; then
-            echo "==> React Native iOS .app: diagnostics E2E"
-            bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=ios --flow=diagnostics
-          fi
+          [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || echo "==> React Native iOS .app: handled-exception diagnostics E2E"
+          [ "$RUN_HANDLED_EXCEPTION_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=ios --flow=handled-exception
+          [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || echo "==> React Native iOS .app: crash diagnostics E2E"
+          [ "$RUN_CRASH_DIAGNOSTICS" != "true" ] || bash Mobiles/e2e/run_e2e_tests.sh --app=react-native --platform=ios --flow=diagnostics
 
           echo "iOS E2E tests completed (Native iOS, Flutter iOS, React Native iOS on same simulator)."
 

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -40,9 +40,8 @@ jobs:
     name: Resolve diagnostics cadence
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Compute the diagnostics cadence once so the Android and iOS legs stay in
-    # lockstep. Computing it per-leg risked the two runners landing on different
-    # hour buckets across an hour boundary and disagreeing on what to emit.
+    # Compute cadence once so the Android and iOS legs agree
+    # (avoids an hour-boundary race between the two runners).
     outputs:
       run_handled_exception: ${{ steps.cadence.outputs.run_handled_exception }}
       run_crash: ${{ steps.cadence.outputs.run_crash }}

--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -55,10 +55,11 @@ jobs:
 
           run_handled_exception=false
           run_crash=false
+          hour_bucket=n/a
 
           if [ "$FORCE_DIAGNOSTICS" = "true" ]; then
             run_crash=true
-          elif [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "push" ]; then
+          elif [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
             hour_bucket=$(($(date -u +%s) / 3600))
             if [ $((hour_bucket % 3)) -eq 0 ]; then
               run_handled_exception=true
@@ -72,6 +73,8 @@ jobs:
 
           echo "run_handled_exception=${run_handled_exception}" >> "$GITHUB_OUTPUT"
           echo "run_crash=${run_crash}" >> "$GITHUB_OUTPUT"
+          echo "Diagnostics event: ${GITHUB_EVENT_NAME}"
+          echo "Diagnostics hour bucket: ${hour_bucket}"
           echo "Handled-exception diagnostics: ${run_handled_exception}"
           echo "Crash diagnostics: ${run_crash}"
 

--- a/Mobiles/e2e/README.md
+++ b/Mobiles/e2e/README.md
@@ -208,5 +208,7 @@ so the demo apps show realistic error/crash signals:
 - manual `workflow_dispatch` runs with `run_diagnostics=true` still force the
   full crash diagnostics flow.
 
-This keeps error data present while targeting roughly 80-90% crash-free demo
-sessions over time.
+This targets roughly 90% crash-free scheduled demo sessions over time. Any
+error signal is more frequent: handled-exception diagnostics run about every
+third scheduled hour, and crash diagnostics run about every tenth scheduled
+hour.

--- a/Mobiles/e2e/README.md
+++ b/Mobiles/e2e/README.md
@@ -142,6 +142,8 @@ The scenario goals live in two parallel templates, one per platform:
 
 - [`arbigent-e2e_basic_pizza_flow.android.yaml.template`](./arbigent-e2e_basic_pizza_flow.android.yaml.template) — Flutter, React Native, and native Android on a running Android emulator.
 - [`arbigent-e2e_basic_pizza_flow.ios.yaml.template`](./arbigent-e2e_basic_pizza_flow.ios.yaml.template) — native iOS (and later Flutter/RN on iOS) on a running iOS simulator.
+- [`arbigent-e2e_handled_exception.android.yaml.template`](./arbigent-e2e_handled_exception.android.yaml.template) and [`arbigent-e2e_handled_exception.ios.yaml.template`](./arbigent-e2e_handled_exception.ios.yaml.template) — Debug-tab handled exception only.
+- [`arbigent-e2e_diagnostics.android.yaml.template`](./arbigent-e2e_diagnostics.android.yaml.template) and [`arbigent-e2e_diagnostics.ios.yaml.template`](./arbigent-e2e_diagnostics.ios.yaml.template) — Debug-tab handled exception plus intentional crash and relaunch.
 
 The split exists because launcher and backgrounding flows differ enough
 between Springboard and the Android launcher that a single template was
@@ -186,11 +188,24 @@ The full telemetry workflow has two independent legs that run in parallel:
   Android emulator, installs each APK in turn, and runs
   `run_e2e_tests.sh --platform=android` for each app. Secret-bearing APKs
   are **not** uploaded as workflow artifacts.
-- **iOS leg** — `macos-26`. Fetches Vault secrets, builds the native iOS
-  `.app` on the runner, boots an iOS simulator, installs the app, and
-  runs `run_e2e_tests.sh --app=ios-native --platform=ios`. The QuickPizza
-  backend is started natively on the macOS runner. The `.app` bundle is
-  **not** uploaded as a workflow artifact.
+- **iOS leg** — `macos-26`. Fetches Vault secrets, builds native iOS,
+  Flutter iOS, and React Native iOS `.app` bundles on the runner, boots
+  one iOS simulator, installs each app in turn, and runs
+  `run_e2e_tests.sh --platform=ios` for each app. The QuickPizza backend
+  is started natively on the macOS runner. The `.app` bundles are **not**
+  uploaded as workflow artifacts.
 
-The iOS variants of Flutter and React Native will be added later by
-plugging their respective .app builds into the iOS leg.
+### Scheduled diagnostic data
+
+The hourly full telemetry workflow also emits a small amount of diagnostic data
+so the Mobile O11y demo apps do not look unrealistically perfect:
+
+- handled exceptions run every third scheduled hour;
+- crash diagnostics run every tenth scheduled hour;
+- when crash diagnostics run, the separate handled-exception flow is skipped
+  because the crash flow emits one handled exception before the crash;
+- manual `workflow_dispatch` runs with `run_diagnostics=true` still force the
+  full crash diagnostics flow.
+
+This keeps error data present while targeting roughly 80-90% crash-free demo
+sessions over time.

--- a/Mobiles/e2e/README.md
+++ b/Mobiles/e2e/README.md
@@ -198,10 +198,11 @@ The full telemetry workflow has two independent legs that run in parallel:
 ### Scheduled diagnostic data
 
 The hourly full telemetry workflow also emits a small amount of diagnostic data
-so the Mobile O11y demo apps do not look unrealistically perfect:
+so the demo apps show realistic error/crash signals:
 
-- handled exceptions run every third scheduled hour;
-- crash diagnostics run every tenth scheduled hour;
+- handled exceptions run every third scheduled hour, based on the shared UTC
+  hour bucket;
+- crash diagnostics run every tenth scheduled hour, based on the same bucket;
 - when crash diagnostics run, the separate handled-exception flow is skipped
   because the crash flow emits one handled exception before the crash;
 - manual `workflow_dispatch` runs with `run_diagnostics=true` still force the

--- a/Mobiles/e2e/arbigent-e2e_handled_exception.android.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_handled_exception.android.yaml.template
@@ -6,8 +6,7 @@
 #
 # This flow intentionally exercises only the Debug tab handled-exception
 # control. The scheduled telemetry workflow can run it more often than crash
-# diagnostics, keeping demo error data realistic without making every session
-# fatal.
+# diagnostics, keeping demo error data realistic without crashing every run.
 
 scenarios:
   - id: "start_app"

--- a/Mobiles/e2e/arbigent-e2e_handled_exception.android.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_handled_exception.android.yaml.template
@@ -1,0 +1,68 @@
+# Shared Arbigent handled-exception project for QuickPizza Android.
+# run_e2e_tests.sh replaces __ANDROID_PACKAGE__ with the app under test:
+#   - Flutter default:        com.example.flutter_mobile_o11y_demo
+#   - React Native default:   com.quickpizza
+#   - Android Native default: com.grafana.quickpizza
+#
+# This flow intentionally exercises only the Debug tab handled-exception
+# control. The scheduled telemetry workflow can run it more often than crash
+# diagnostics, keeping demo error data realistic without making every session
+# fatal.
+
+scenarios:
+  - id: "start_app"
+    goal: |
+      You should see the QuickPizza home screen.
+
+      SUCCESS CRITERIA:
+      - You see the QuickPizza home screen with a "Pizza, Please!" button.
+
+      __RECOVERY_BLOCK__
+
+    initializationMethods:
+      - type: "Back"
+        times: 3
+      - type: "CleanupData"
+        packageName: "__ANDROID_PACKAGE__"
+      - type: "LaunchApp"
+        packageName: "__ANDROID_PACKAGE__"
+    maxRetry: 2
+    maxStep: 5
+
+  - id: "open_debug_tab"
+    dependency: "start_app"
+    goal: |
+      You should open the QuickPizza Debug tab.
+
+      STEPS:
+      - Tap the bottom navigation tab labeled "Debug".
+      - If the bottom navigation is not visible, press Back once or scroll to recover, then tap "Debug".
+
+      SUCCESS CRITERIA:
+      - You see a Debug screen with controls such as "Send Debug Log", "Send Handled Exception", "Handled exception", or crash buttons.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8
+
+  - id: "send_handled_exception"
+    dependency: "open_debug_tab"
+    goal: |
+      You should emit one handled exception from the Debug tab.
+
+      STEPS:
+      - Tap exactly one handled-exception control.
+      - The button may be labeled "Send Handled Exception" or "Handled exception" depending on the app.
+      - Do not tap any crash, ANR, unhandled exception, or error-log button in this scenario.
+      - The UI may not visually change after this tap. That is expected.
+      - After tapping the handled exception button once, OUTPUT "Goal achieved" and STOP. Do not retry the same button just because the screen looks unchanged.
+
+      SUCCESS CRITERIA:
+      - The handled exception action was tapped once.
+      - The app is still running on the Debug screen.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8

--- a/Mobiles/e2e/arbigent-e2e_handled_exception.ios.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_handled_exception.ios.yaml.template
@@ -1,0 +1,66 @@
+# Shared Arbigent handled-exception project for QuickPizza iOS.
+# run_e2e_tests.sh replaces __IOS_BUNDLE_ID__ with the app under test:
+#   - iOS Native default:       com.grafana.QuickPizzaIos
+#   - Flutter iOS default:      com.example.flutterMobileO11yDemo
+#   - React Native iOS default: com.quickpizza
+#
+# This flow intentionally exercises only the Debug tab handled-exception
+# control. The scheduled telemetry workflow can run it more often than crash
+# diagnostics, keeping demo error data realistic without making every session
+# fatal.
+
+scenarios:
+  - id: "start_app"
+    goal: |
+      You should see the QuickPizza home screen.
+
+      SUCCESS CRITERIA:
+      - You see the QuickPizza home screen with a "Pizza, Please!" button.
+
+      __RECOVERY_BLOCK__
+
+    initializationMethods:
+      - type: "CleanupData"
+        packageName: "__IOS_BUNDLE_ID__"
+      - type: "LaunchApp"
+        packageName: "__IOS_BUNDLE_ID__"
+    maxRetry: 2
+    maxStep: 5
+
+  - id: "open_debug_tab"
+    dependency: "start_app"
+    goal: |
+      You should open the QuickPizza Debug tab.
+
+      STEPS:
+      - Tap the bottom tab labeled "Debug".
+      - If the bottom tab bar is not visible, press Back once or scroll to recover, then tap "Debug".
+
+      SUCCESS CRITERIA:
+      - You see a Debug screen with controls such as "Send Debug Log", "Send Handled Exception", "Handled exception", or crash buttons.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8
+
+  - id: "send_handled_exception"
+    dependency: "open_debug_tab"
+    goal: |
+      You should emit one handled exception from the Debug tab.
+
+      STEPS:
+      - Tap exactly one handled-exception control.
+      - The button may be labeled "Send Handled Exception" or "Handled exception" depending on the app.
+      - Do not tap any crash, unhandled exception, or error-log button in this scenario.
+      - The UI may not visually change after this tap. That is expected.
+      - After tapping the handled exception button once, OUTPUT "Goal achieved" and STOP. Do not retry the same button just because the screen looks unchanged.
+
+      SUCCESS CRITERIA:
+      - The handled exception action was tapped once.
+      - The app is still running on the Debug screen.
+
+      __RECOVERY_BLOCK__
+
+    maxRetry: 2
+    maxStep: 8

--- a/Mobiles/e2e/arbigent-e2e_handled_exception.ios.yaml.template
+++ b/Mobiles/e2e/arbigent-e2e_handled_exception.ios.yaml.template
@@ -6,8 +6,7 @@
 #
 # This flow intentionally exercises only the Debug tab handled-exception
 # control. The scheduled telemetry workflow can run it more often than crash
-# diagnostics, keeping demo error data realistic without making every session
-# fatal.
+# diagnostics, keeping demo error data realistic without crashing every run.
 
 scenarios:
   - id: "start_app"

--- a/Mobiles/e2e/run_e2e_tests.sh
+++ b/Mobiles/e2e/run_e2e_tests.sh
@@ -13,6 +13,7 @@
 #   ./Mobiles/e2e/run_e2e_tests.sh --app=react-native    --platform=ios
 #   ./Mobiles/e2e/run_e2e_tests.sh --app=ios-native      --platform=ios
 #   ./Mobiles/e2e/run_e2e_tests.sh --app=flutter         --platform=android --flow=diagnostics
+#   ./Mobiles/e2e/run_e2e_tests.sh --app=flutter         --platform=android --flow=handled-exception
 #
 # Required env vars:
 #   OPENAI_API_KEY    OpenAI API key used by Arbigent.
@@ -50,6 +51,8 @@ TEMPLATE_FILE_ANDROID_BASIC="$SCRIPT_DIR/arbigent-e2e_basic_pizza_flow.android.y
 TEMPLATE_FILE_IOS_BASIC="$SCRIPT_DIR/arbigent-e2e_basic_pizza_flow.ios.yaml.template"
 TEMPLATE_FILE_ANDROID_DIAGNOSTICS="$SCRIPT_DIR/arbigent-e2e_diagnostics.android.yaml.template"
 TEMPLATE_FILE_IOS_DIAGNOSTICS="$SCRIPT_DIR/arbigent-e2e_diagnostics.ios.yaml.template"
+TEMPLATE_FILE_ANDROID_HANDLED_EXCEPTION="$SCRIPT_DIR/arbigent-e2e_handled_exception.android.yaml.template"
+TEMPLATE_FILE_IOS_HANDLED_EXCEPTION="$SCRIPT_DIR/arbigent-e2e_handled_exception.ios.yaml.template"
 RECOVERY_HINTS_FILE="$SCRIPT_DIR/arbigent-recovery-hints.txt"
 RENDER_HELPER="$SCRIPT_DIR/render-template.js"
 
@@ -125,7 +128,7 @@ Required:
   --platform=<android|ios>                                 Target platform
 
 Other:
-  --flow=<basic|diagnostics>                               Scenario flow (default: basic)
+  --flow=<basic|diagnostics|handled-exception>              Scenario flow (default: basic)
   -h, --help                                               Show this help message
 
 Examples:
@@ -136,6 +139,7 @@ Examples:
   bash $0 --app=react-native --platform=ios
   bash $0 --app=ios-native --platform=ios
   bash $0 --app=flutter --platform=android --flow=diagnostics
+  bash $0 --app=flutter --platform=android --flow=handled-exception
 
 Required env vars:
   OPENAI_API_KEY                    OpenAI key used by Arbigent
@@ -165,8 +169,8 @@ done
 [ -n "$PLATFORM" ] || { show_help; print_error "--platform is required"; }
 
 case "$FLOW" in
-    basic|diagnostics) ;;
-    *) print_error "Unsupported --flow=$FLOW (supported: basic, diagnostics)" ;;
+    basic|diagnostics|handled-exception) ;;
+    *) print_error "Unsupported --flow=$FLOW (supported: basic, diagnostics, handled-exception)" ;;
 esac
 
 ### App configuration table ###################################################
@@ -396,11 +400,13 @@ render_template() {
 
     local template_file
     case "$FLOW:$PLATFORM" in
-        basic:android)       template_file="$TEMPLATE_FILE_ANDROID_BASIC" ;;
-        basic:ios)           template_file="$TEMPLATE_FILE_IOS_BASIC" ;;
-        diagnostics:android) template_file="$TEMPLATE_FILE_ANDROID_DIAGNOSTICS" ;;
-        diagnostics:ios)     template_file="$TEMPLATE_FILE_IOS_DIAGNOSTICS" ;;
-        *)                   print_error "render_template: unsupported flow/platform '$FLOW/$PLATFORM'" ;;
+        basic:android)                template_file="$TEMPLATE_FILE_ANDROID_BASIC" ;;
+        basic:ios)                    template_file="$TEMPLATE_FILE_IOS_BASIC" ;;
+        diagnostics:android)          template_file="$TEMPLATE_FILE_ANDROID_DIAGNOSTICS" ;;
+        diagnostics:ios)              template_file="$TEMPLATE_FILE_IOS_DIAGNOSTICS" ;;
+        handled-exception:android)    template_file="$TEMPLATE_FILE_ANDROID_HANDLED_EXCEPTION" ;;
+        handled-exception:ios)        template_file="$TEMPLATE_FILE_IOS_HANDLED_EXCEPTION" ;;
+        *)                            print_error "render_template: unsupported flow/platform '$FLOW/$PLATFORM'" ;;
     esac
     if [ ! -f "$template_file" ]; then
         print_error "Missing Arbigent template for flow=$FLOW platform=$PLATFORM: $template_file"


### PR DESCRIPTION
## Why

The QuickPizza mobile demo automations currently make the apps look unrealistically clean because scheduled runs mostly emit successful sessions without regular errors or crashes. For Mobile O11y overview work, we need a small amount of predictable diagnostic data so demo apps show realistic error/crash signals over time.

## What

- Adds a shared diagnostics cadence job for the full telemetry workflow.
- Runs handled-exception diagnostics every 3rd scheduled hour.
- Runs crash diagnostics every 10th scheduled hour, skipping the separate handled-exception flow because the crash flow already emits one first.
- Keeps `workflow_dispatch` with `run_diagnostics=true` as a manual force path for crash diagnostics.
- Adds dedicated handled-exception Arbigent templates for Android and iOS.
- Documents the scheduled diagnostic cadence in the E2E README.

## Links

Closes grafana/app-o11y-kwl#3629

## Validation

- `git diff --check origin/main...HEAD`
- `bash -n Mobiles/e2e/run_e2e_tests.sh`
- YAML parsed successfully for:
  - `.github/workflows/mobile_demo_telemetry.yaml`
  - `Mobiles/e2e/arbigent-e2e_handled_exception.android.yaml.template`
  - `Mobiles/e2e/arbigent-e2e_handled_exception.ios.yaml.template`
