### PR TITLE
chore(deps): lower npm min-release-age cooldown to 3 days

### DIFF
--- a/Mobiles/e2e/report-generator/.npmrc
+++ b/Mobiles/e2e/report-generator/.npmrc
@@ -1,4 +1,4 @@
 engine-strict=true
 ignore-scripts=true
-min-release-age=7
+min-release-age=3
 allow-git=none

--- a/Mobiles/react-native/.npmrc
+++ b/Mobiles/react-native/.npmrc
@@ -1,4 +1,4 @@
 engine-strict=true
 ignore-scripts=true
-min-release-age=7
+min-release-age=3
 allow-git=none

--- a/pkg/web/.npmrc
+++ b/pkg/web/.npmrc
@@ -1,4 +1,4 @@
 engine-strict=true
 ignore-scripts=true
-min-release-age=7
+min-release-age=3
 allow-git=none


### PR DESCRIPTION
Lowers the npm `min-release-age` install gate from 7 to 3 across the three `.npmrc` files, aligning with the 3-day Grafana org Renovate default.

_PR description authored by Claude on Domas's behalf._