### PR TITLE
chore(mobile): bump Flutter faro SDK to 0.17.0-beta.1

### DIFF
--- a/Mobiles/flutter/android/gradle.properties
+++ b/Mobiles/flutter/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/Mobiles/flutter/pubspec.lock
+++ b/Mobiles/flutter/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -161,6 +161,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dartastic_opentelemetry:
+    dependency: transitive
+    description:
+      name: dartastic_opentelemetry
+      sha256: "237c60abc468f4f692b25e41d4041c5a5888c6642584fb9364d6ea6e25ea4552"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0-beta.6"
+  dartastic_opentelemetry_api:
+    dependency: transitive
+    description:
+      name: dartastic_opentelemetry_api
+      sha256: "455130f250e007f9ef03eae29ac132dc44e04b606e5b5f011d42cd48f22f32d9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0-beta.7"
   dartypod:
     dependency: transitive
     description:
@@ -213,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: faro
-      sha256: c47ed45c810b3cf541c7163ec3abc541918287280e02a8f22a1199c928e52bb7
+      sha256: c9f055624f4c85e6f0c1e852d5fd21b7d8b450ca6346551e1a4cdc057e7411d1
       url: "https://pub.dev"
     source: hosted
-    version: "0.16.0"
+    version: "0.17.0-beta.1"
   ffi:
     dependency: transitive
     description:
@@ -327,6 +343,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.0.1"
+  google_cloud:
+    dependency: transitive
+    description:
+      name: google_cloud
+      sha256: b385e20726ef5315d302c5933bfb728103116c5be2d3d17094b01a82da538c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  googleapis_auth:
+    dependency: transitive
+    description:
+      name: googleapis_auth
+      sha256: "1417d8846663df5e7b77ca56591c5edd442c66ffc9c01ab036e138a21a148e86"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  grpc:
+    dependency: transitive
+    description:
+      name: grpc
+      sha256: "86be3a7d39ad865b214a7370021ac80e68939238b507730de6d97fc662cb2723"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   html:
     dependency: transitive
     description:
@@ -343,6 +391,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http2:
+    dependency: transitive
+    description:
+      name: http2
+      sha256: "382d3aefc5bd6dc68c6b892d7664f29b5beb3251611ae946a98d35158a82bbfa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -383,14 +439,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -443,26 +491,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -487,14 +535,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  opentelemetry:
-    dependency: transitive
-    description:
-      name: opentelemetry
-      sha256: a942fe0e7fbf4f7370b92f1226354158779fd404197e1ff8153c1612b3e24c58
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.18.10"
   package_config:
     dependency: transitive
     description:
@@ -627,10 +667,10 @@ packages:
     dependency: transitive
     description:
       name: protobuf
-      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      sha256: "75ec242d22e950bdcc79ee38dd520ce4ee0bc491d7fadc4ea47694604d22bf06"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "6.0.0"
   pub_semver:
     dependency: transitive
     description:
@@ -639,14 +679,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
   riverpod:
     dependency: transitive
     description:
@@ -812,6 +844,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   term_glyph:
     dependency: transitive
     description:
@@ -824,26 +864,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -1037,5 +1077,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.1 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.35.0"

--- a/Mobiles/flutter/pubspec.yaml
+++ b/Mobiles/flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  faro: ^0.16.0
+  faro: 0.17.0-beta.1
   flutter_riverpod: ^3.1.0
   http: ^1.1.0
   shared_preferences: ^2.2.2


### PR DESCRIPTION
## Summary

- Bumps the QuickPizza **Flutter** demo app to the `faro` **0.17.0-beta.1** prerelease (pinned exactly, since Dart caret ranges don't select prereleases).
- Regenerates `pubspec.lock`: the beta swaps the internal OTel tracing impl from the Workiva `opentelemetry` package to `dartastic_opentelemetry` (removes `opentelemetry`/`js`/`quiver`, adds `dartastic_opentelemetry(_api)`, `synchronized`, `grpc`/`http2`/`google*`).
- Carries Flutter Gradle migrator flags auto-added to `android/gradle.properties` during the Android build (`android.builtInKotlin=false`, `android.newDsl=false`).

## What's in the beta (0.17.0-beta.1)

- `DeviceId` → renamed to `InstallationId` (old name kept as a deprecated alias; `device_id` storage key unchanged for migration).
- New structured mobile metadata in payloads: `meta.device`, `meta.os`, `meta.app.installationId`, `exception.fatal`.
- Internal tracing impl swapped to `dartastic_opentelemetry` (grafana/faro-flutter-sdk#242).

## Test plan

- [x] `flutter pub get` resolves cleanly
- [x] `flutter analyze` — no issues (no source changes required)
- [x] Manually verified the app builds & runs on **iOS** and **Android**
- [ ] Confirm signals land in Faro app `QuickPizza_Flutter` (id 69), incl. new `meta.*` fields

## Notes

- No app source changes were needed — the `DeviceId` deprecation is aliased, so analysis stays clean.
- The `pubspec.lock` resolves `synchronized 3.4.1` (needs Dart 3.12) because it was generated on Dart ≥3.12. This is **not** a real floor for the app — faro only requires Dart 3.8, and pub will transparently downgrade `synchronized` to 3.4.0 for anyone on an older stable Dart. The app's `environment: sdk: ^3.10.1` is left unchanged intentionally.

Made with [Cursor](https://cursor.com)