### PR TITLE
feat(mobile): add NDK crash debug screens and SIGSEGV trigger

### DIFF
--- a/Mobiles/android/app/build.gradle.kts
+++ b/Mobiles/android/app/build.gradle.kts
@@ -62,6 +62,12 @@ android {
         compose = true
         buildConfig = true
     }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+        }
+    }
 }
 
 dependencies {

--- a/Mobiles/android/app/proguard-rules.pro
+++ b/Mobiles/android/app/proguard-rules.pro
@@ -2,3 +2,6 @@
 # Keep OpenTelemetry classes
 -keep class io.opentelemetry.** { *; }
 -dontwarn io.opentelemetry.**
+
+# NDK SIGSEGV demo trigger (Debug tab)
+-keep class com.grafana.quickpizza.features.debug.NdkCrashTrigger { *; }

--- a/Mobiles/android/app/src/main/cpp/CMakeLists.txt
+++ b/Mobiles/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(quickpizza_ndk_crash)
+
+add_library(quickpizza_ndk_crash SHARED quickpizza_ndk_crash.cpp)
+
+find_library(log-lib log)
+target_link_libraries(quickpizza_ndk_crash ${log-lib})

--- a/Mobiles/android/app/src/main/cpp/CMakeLists.txt
+++ b/Mobiles/android/app/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22.1)
+cmake_minimum_required(VERSION 3.13)
 project(quickpizza_ndk_crash)
 
 add_library(quickpizza_ndk_crash SHARED quickpizza_ndk_crash.cpp)

--- a/Mobiles/android/app/src/main/cpp/quickpizza_ndk_crash.cpp
+++ b/Mobiles/android/app/src/main/cpp/quickpizza_ndk_crash.cpp
@@ -1,0 +1,85 @@
+#include <jni.h>
+
+#include <dlfcn.h>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unwind.h>
+
+struct BacktraceState {
+  void **frames;
+  size_t count;
+  size_t max;
+};
+
+static _Unwind_Reason_Code unwindCallback(_Unwind_Context *context, void *arg) {
+  auto *state = static_cast<BacktraceState *>(arg);
+  if (state->count >= state->max) {
+    return _URC_END_OF_STACK;
+  }
+  state->frames[state->count++] =
+      reinterpret_cast<void *>(_Unwind_GetIP(context));
+  return _URC_NO_REASON;
+}
+
+static std::string abiLabel() {
+#if defined(__aarch64__)
+  return "arm64";
+#elif defined(__arm__)
+  return "arm";
+#elif defined(__x86_64__)
+  return "x86_64";
+#elif defined(__i386__)
+  return "x86";
+#else
+  return "unknown";
+#endif
+}
+
+static std::string formatBacktrace(void **frames, size_t count) {
+  std::ostringstream out;
+  out << "*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***\n";
+  out << "ABI: '" << abiLabel() << "'\n";
+  out << "backtrace:\n";
+
+  for (size_t i = 0; i < count && i < 32; ++i) {
+    Dl_info info {};
+    const auto pc = reinterpret_cast<uintptr_t>(frames[i]);
+    dladdr(frames[i], &info);
+    const char *library =
+        (info.dli_fname != nullptr) ? info.dli_fname : "unknown";
+    out << "      #" << std::setw(2) << std::setfill('0') << i << " pc "
+        << std::hex << std::uppercase << std::setw(16) << std::setfill('0')
+        << pc << "  " << library;
+    if (info.dli_sname != nullptr) {
+      out << " (" << info.dli_sname << ")";
+    }
+    out << "\n";
+  }
+
+  return out.str();
+}
+
+static std::string captureCurrentBacktrace() {
+  void *frames[32];
+  BacktraceState state {frames, 0, 32};
+  _Unwind_Backtrace(unwindCallback, &state);
+  return formatBacktrace(frames, state.count);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_grafana_quickpizza_features_debug_NdkCrashTrigger_captureBacktraceForCache(
+    JNIEnv *env,
+    jobject /* thiz */) {
+  const std::string trace = captureCurrentBacktrace();
+  return env->NewStringUTF(trace.c_str());
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_grafana_quickpizza_features_debug_NdkCrashTrigger_nativeCrash(
+    JNIEnv * /* env */,
+    jobject /* thiz */) {
+  // Intentional null dereference → SIGSEGV with a native tombstone stack trace.
+  volatile int *ptr = nullptr;
+  *ptr = 42;
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugNativeCrashTraceCache.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugNativeCrashTraceCache.kt
@@ -1,0 +1,33 @@
+package com.grafana.quickpizza.features.debug
+
+import android.content.Context
+
+/**
+ * Demo-only writer for a pending native tombstone between SIGSEGV and the next launch.
+ *
+ * Uses the same SharedPreferences contract as [com.grafana.quickpizza.nativecrash.NativeCrashTraceCache]
+ * (added in a follow-up PR) so [ApplicationExitInfo.traceInputStream] null cases on emulators still
+ * have a backtrace to replay.
+ */
+internal object DebugNativeCrashTraceCache {
+    const val PREFS_NAME = "com.grafana.quickpizza.native_crash_trace_cache"
+    const val KEY_TRACE = "pending_trace"
+    const val KEY_TIMESTAMP = "pending_timestamp"
+
+    fun savePendingCrashTrace(context: Context, trace: String, timestampMs: Long) {
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_TRACE, trace)
+            .putLong(KEY_TIMESTAMP, timestampMs)
+            .commit()
+    }
+}
+
+internal fun looksLikeNativeBacktrace(trace: String): Boolean {
+    if (trace.isBlank()) {
+        return false
+    }
+    val nativeFrameLine = Regex("""^\s*#\d+\s+pc\s+(?:0x)?[0-9a-fA-F]+\s+\S+""")
+    return trace.lineSequence().any { nativeFrameLine.containsMatchIn(it) }
+}

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
@@ -217,6 +217,8 @@ private fun ErrorSimulationSection(settings: DebugSettings, viewModel: DebugView
 
 @Composable
 private fun ClientDiagnosticsSection(viewModel: DebugViewModel) {
+    var pendingNdkCrash by rememberSaveable { mutableStateOf(false) }
+
     SectionHeader("Client Diagnostics")
 
     QuickSignalsCard(viewModel)
@@ -231,14 +233,46 @@ private fun ClientDiagnosticsSection(viewModel: DebugViewModel) {
 
     DiagnosticActionCard(
         title = "ANR",
-        description = "Blocks the main thread for 6 seconds, exceeding Android's 5s ANR threshold. " +
-            "The system shows an ANR dialog and the OTel agent reports it.",
+        description = "Blocks the main thread for 10 seconds (same as the RN demo) so the " +
+            "system ANR dialog stays open long enough to tap Close app or Wait. The OTel " +
+            "agent reports device.anr with the main-thread stack.",
         buttonText = "Trigger ANR",
         danger = true,
         onClick = viewModel::triggerAnr,
     )
 
     CrashCard(viewModel)
+
+    DiagnosticActionCard(
+        title = "NDK crash (C++ / tombstone)",
+        description = "Real SIGSEGV in native code; stack frames use per-ABI .so symbols " +
+            "(arm64-v8a.zip) and R8 mapping.txt after relaunch.",
+        buttonText = "SIGSEGV (null dereference)",
+        danger = true,
+        onClick = { pendingNdkCrash = true },
+    )
+
+    if (pendingNdkCrash) {
+        AlertDialog(
+            onDismissRequest = { pendingNdkCrash = false },
+            title = { Text("Trigger native SIGSEGV?") },
+            text = {
+                Text(
+                    "Causes a real SIGSEGV with a native tombstone. The app will terminate; " +
+                        "relaunch to report via OTLP (device.crash + context.trace).",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    pendingNdkCrash = false
+                    viewModel.triggerNdkCrash()
+                }) { Text("Crash now", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingNdkCrash = false }) { Text("Cancel") }
+            },
+        )
+    }
 }
 
 @Composable

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugScreen.kt
@@ -245,8 +245,8 @@ private fun ClientDiagnosticsSection(viewModel: DebugViewModel) {
 
     DiagnosticActionCard(
         title = "NDK crash (C++ / tombstone)",
-        description = "Real SIGSEGV in native code; stack frames use per-ABI .so symbols " +
-            "(arm64-v8a.zip) and R8 mapping.txt after relaunch.",
+        description = "Real SIGSEGV in native code; stack frames symbolicate with per-ABI " +
+            ".so symbols (arm64-v8a.zip) after relaunch.",
         buttonText = "SIGSEGV (null dereference)",
         danger = true,
         onClick = { pendingNdkCrash = true },

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugViewModel.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/DebugViewModel.kt
@@ -1,5 +1,6 @@
 package com.grafana.quickpizza.features.debug
 
+import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.grafana.quickpizza.core.config.DebugSettings
@@ -59,6 +60,7 @@ fun computeRestartBanner(
 
 @HiltViewModel
 class DebugViewModel @Inject constructor(
+    private val application: Application,
     private val debugSettings: DebugSettingsRepository,
     private val runtimeConfig: RuntimeConfigHolder,
     private val logger: AppLogger,
@@ -149,9 +151,9 @@ class DebugViewModel @Inject constructor(
     }
 
     fun triggerAnr() {
-        // Block the main thread long enough to exceed Android's 5s ANR threshold.
-        // Caller invokes from main thread; intentionally not dispatched off it.
-        Thread.sleep(6000)
+        // Match the RN demo (QuickPizzaCrashModule): block ~10s so the system ANR
+        // dialog stays up ~5s after the ~5s threshold (6s was too short to tap Close).
+        Thread.sleep(10_000)
     }
 
     /**
@@ -170,6 +172,11 @@ class DebugViewModel @Inject constructor(
     fun triggerCrashNullPointer() {
         val nothing: String? = null
         nothing!!.length
+    }
+
+    /** Real SIGSEGV; tombstone replay is handled by `nativecrash` in a follow-up PR (OTel #764). */
+    fun triggerNdkCrash() {
+        NdkCrashTrigger.crash(application)
     }
 
     // ---------------------------------------------------------------------

--- a/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/NdkCrashTrigger.kt
+++ b/Mobiles/android/app/src/main/java/com/grafana/quickpizza/features/debug/NdkCrashTrigger.kt
@@ -1,0 +1,41 @@
+package com.grafana.quickpizza.features.debug
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/**
+ * Demo SIGSEGV trigger for the Debug tab (Android OTel app).
+ *
+ * Tombstone replay/export lives in `com.grafana.quickpizza.nativecrash` (separate PR) until
+ * [opentelemetry-android#764](https://github.com/open-telemetry/opentelemetry-android/issues/764).
+ * Mirrors [com.quickpizza.QuickPizzaNdkCrashModule] in the React Native demo.
+ */
+object NdkCrashTrigger {
+    private const val TAG = "NdkCrashTrigger"
+
+    init {
+        System.loadLibrary("quickpizza_ndk_crash")
+    }
+
+    fun crash(context: Context) {
+        Handler(Looper.getMainLooper()).post {
+            val trace = captureBacktraceForCache()
+            if (trace.isNotBlank() && looksLikeNativeBacktrace(trace)) {
+                DebugNativeCrashTraceCache.savePendingCrashTrace(
+                    context.applicationContext,
+                    trace.trim(),
+                    System.currentTimeMillis(),
+                )
+                Log.i(TAG, "Cached pending native tombstone (${trace.lineSequence().count()} lines)")
+            }
+            Log.i(TAG, "Triggering native SIGSEGV")
+            nativeCrash()
+        }
+    }
+
+    private external fun captureBacktraceForCache(): String
+
+    private external fun nativeCrash()
+}

--- a/Mobiles/react-native/android/app/build.gradle
+++ b/Mobiles/react-native/android/app/build.gradle
@@ -84,6 +84,16 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        externalNativeBuild {
+            cmake {
+                cppFlags "-std=c++17"
+            }
+        }
+    }
+    externalNativeBuild {
+        cmake {
+            path "src/main/jni/CMakeLists.txt"
+        }
     }
     signingConfigs {
         debug {

--- a/Mobiles/react-native/android/app/proguard-rules.pro
+++ b/Mobiles/react-native/android/app/proguard-rules.pro
@@ -7,4 +7,13 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# Add any project specific keep options here:
+# --- Demo native modules (JNI + React Native bridge) ---
+-keep class com.quickpizza.QuickPizzaNdkCrashModule { *; }
+
+# --- Android native crash symbolication (R8 retrace) ---
+# Preserve source file + line number metadata so obfuscated stack traces can be
+# retraced against mapping.txt (server-side R8 retrace in the Faro collector).
+# Rename the source file attribute to a constant so it leaks no original names
+# while still keeping the line table that retrace needs.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaCrashModule.kt
+++ b/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaCrashModule.kt
@@ -2,6 +2,7 @@ package com.quickpizza
 
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
@@ -16,12 +17,46 @@ class QuickPizzaCrashModule(
   fun crash(variant: String) {
     Handler(Looper.getMainLooper()).post {
       when (variant) {
-        "nullPointer" -> {
-          val value: String? = null
-          value!!
-        }
-        else -> throw RuntimeException("QuickPizza RN intentional native crash")
+        "nullPointer" -> triggerNullPointer()
+        "anr" -> triggerApplicationNotResponding()
+        else -> triggerRuntimeException()
       }
     }
+  }
+
+  // The helpers below are intentionally private so R8/ProGuard renames them in
+  // release builds. The resulting obfuscated stack frames are what we retrace
+  // against mapping.txt to prove Android symbolication end to end.
+
+  private fun triggerRuntimeException() {
+    raiseQuickPizzaFailure("QuickPizza RN intentional Java crash (R8 retrace)")
+  }
+
+  private fun triggerNullPointer() {
+    val value: String? = readMissingValue()
+    // Kotlin not-null assertion on a null value throws NullPointerException.
+    value!!.length
+  }
+
+  private fun triggerApplicationNotResponding() {
+    // Block the main (UI) thread well beyond the ANR watchdog timeout so Faro's
+    // ANR tracker records an ANR event with the main-thread stack.
+    val blockForMs = 10_000L
+    val deadline = SystemClock.uptimeMillis() + blockForMs
+    while (SystemClock.uptimeMillis() < deadline) {
+      busyWaitOnMainThread()
+    }
+  }
+
+  private fun readMissingValue(): String? = null
+
+  private fun busyWaitOnMainThread() {
+    // Tight loop keeps the main looper busy without sleeping so the
+    // platform/Faro watchdog classifies it as an ANR.
+    Thread.yield()
+  }
+
+  private fun raiseQuickPizzaFailure(message: String): Nothing {
+    throw RuntimeException(message)
   }
 }

--- a/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaNativeCrashTraceCache.kt
+++ b/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaNativeCrashTraceCache.kt
@@ -1,0 +1,33 @@
+package com.quickpizza
+
+import android.content.Context
+
+/**
+ * Demo-only writer for a pending native tombstone between SIGSEGV and the next launch.
+ *
+ * Uses the same SharedPreferences contract as Faro RN
+ * `com.grafana.faro.crash_trace_cache` (available in newer SDK releases). Published
+ * 1.3.0 does not read this yet, but caching keeps emulator tombstone fallback ready.
+ */
+internal object QuickPizzaNativeCrashTraceCache {
+    const val PREFS_NAME = "com.grafana.faro.crash_trace_cache"
+    const val KEY_TRACE = "pending_trace"
+    const val KEY_TIMESTAMP = "pending_timestamp"
+
+    fun savePendingCrashTrace(context: Context, trace: String, timestampMs: Long) {
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_TRACE, trace)
+            .putLong(KEY_TIMESTAMP, timestampMs)
+            .commit()
+    }
+}
+
+internal fun looksLikeNativeBacktrace(trace: String): Boolean {
+    if (trace.isBlank()) {
+        return false
+    }
+    val nativeFrameLine = Regex("""^\s*#\d+\s+pc\s+(?:0x)?[0-9a-fA-F]+\s+\S+""")
+    return trace.lineSequence().any { nativeFrameLine.containsMatchIn(it) }
+}

--- a/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaNdkCrashModule.kt
+++ b/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaNdkCrashModule.kt
@@ -5,7 +5,6 @@ import android.os.Looper
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import com.grafana.faro.reactnative.FaroCrashReporter
 
 class QuickPizzaNdkCrashModule(
   reactContext: ReactApplicationContext
@@ -17,8 +16,12 @@ class QuickPizzaNdkCrashModule(
   fun crash() {
     Handler(Looper.getMainLooper()).post {
       val trace = captureBacktraceForCache()
-      if (trace.isNotBlank()) {
-        FaroCrashReporter.cachePendingNativeCrashTrace(reactApplicationContext, trace)
+      if (trace.isNotBlank() && looksLikeNativeBacktrace(trace)) {
+        QuickPizzaNativeCrashTraceCache.savePendingCrashTrace(
+          reactApplicationContext,
+          trace.trim(),
+          System.currentTimeMillis(),
+        )
       }
       nativeCrash()
     }

--- a/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaNdkCrashModule.kt
+++ b/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaNdkCrashModule.kt
@@ -1,0 +1,36 @@
+package com.quickpizza
+
+import android.os.Handler
+import android.os.Looper
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.grafana.faro.reactnative.FaroCrashReporter
+
+class QuickPizzaNdkCrashModule(
+  reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+
+  override fun getName(): String = "QuickPizzaNdkCrash"
+
+  @ReactMethod
+  fun crash() {
+    Handler(Looper.getMainLooper()).post {
+      val trace = captureBacktraceForCache()
+      if (trace.isNotBlank()) {
+        FaroCrashReporter.cachePendingNativeCrashTrace(reactApplicationContext, trace)
+      }
+      nativeCrash()
+    }
+  }
+
+  private external fun captureBacktraceForCache(): String
+
+  private external fun nativeCrash()
+
+  companion object {
+    init {
+      System.loadLibrary("quickpizza_ndk_crash")
+    }
+  }
+}

--- a/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaPackage.kt
+++ b/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaPackage.kt
@@ -8,7 +8,11 @@ import com.facebook.react.uimanager.ViewManager
 class QuickPizzaPackage : ReactPackage {
   override fun createNativeModules(
     reactContext: ReactApplicationContext
-  ): List<NativeModule> = listOf(QuickPizzaCrashModule(reactContext))
+  ): List<NativeModule> =
+    listOf(
+      QuickPizzaCrashModule(reactContext),
+      QuickPizzaNdkCrashModule(reactContext),
+    )
 
   override fun createViewManagers(
     reactContext: ReactApplicationContext

--- a/Mobiles/react-native/android/app/src/main/jni/CMakeLists.txt
+++ b/Mobiles/react-native/android/app/src/main/jni/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.13)
+
+# RN New Architecture app modules (TurboModules, Fabric, autolinking).
+project(appmodules)
+
+include(${REACT_ANDROID_DIR}/cmake-utils/ReactNative-application.cmake)
+
+# Separate JNI lib for the demo SIGSEGV button (System.loadLibrary in Kotlin).
+add_library(quickpizza_ndk_crash SHARED quickpizza_ndk_crash.cpp)
+
+find_library(log-lib log)
+target_link_libraries(quickpizza_ndk_crash ${log-lib})

--- a/Mobiles/react-native/android/app/src/main/jni/OnLoad.cpp
+++ b/Mobiles/react-native/android/app/src/main/jni/OnLoad.cpp
@@ -73,8 +73,6 @@ std::shared_ptr<TurboModule> cxxModuleProvider(
 
   // And we fallback to the CXX module providers autolinked
   return autolinking_cxxModuleProvider(name, jsInvoker);
-
-  return nullptr;
 }
 
 std::shared_ptr<TurboModule> javaModuleProvider(

--- a/Mobiles/react-native/android/app/src/main/jni/OnLoad.cpp
+++ b/Mobiles/react-native/android/app/src/main/jni/OnLoad.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// This C++ file is part of the default configuration used by apps and is placed
+// inside react-native to encapsulate it from user space (so you won't need to
+// touch C++/Cmake code at all on Android).
+//
+// If you wish to customize it (because you want to manually link a C++ library
+// or pass a custom compilation flag) you can:
+//
+// 1. Copy this CMake file inside the `android/app/src/main/jni` folder of your
+// project
+// 2. Copy the OnLoad.cpp (in this same folder) file inside the same folder as
+// above.
+// 3. Extend your `android/app/build.gradle` as follows
+//
+// android {
+//    // Other config here...
+//    externalNativeBuild {
+//        cmake {
+//            path "src/main/jni/CMakeLists.txt"
+//        }
+//    }
+// }
+
+#include <DefaultComponentsRegistry.h>
+#include <DefaultTurboModuleManagerDelegate.h>
+#include <FBReactNativeSpec.h>
+#include <autolinking.h>
+#include <fbjni/fbjni.h>
+#include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+
+#ifdef REACT_NATIVE_APP_CODEGEN_HEADER
+#include REACT_NATIVE_APP_CODEGEN_HEADER
+#endif
+#ifdef REACT_NATIVE_APP_COMPONENT_DESCRIPTORS_HEADER
+#include REACT_NATIVE_APP_COMPONENT_DESCRIPTORS_HEADER
+#endif
+
+namespace facebook::react {
+
+void registerComponents(
+    std::shared_ptr<const ComponentDescriptorProviderRegistry> registry) {
+  // Custom Fabric Components go here. You can register custom
+  // components coming from your App or from 3rd party libraries here.
+  //
+  // providerRegistry->add(concreteComponentDescriptorProvider<
+  //        MyComponentDescriptor>());
+
+  // We link app local components if available
+#ifdef REACT_NATIVE_APP_COMPONENT_REGISTRATION
+  REACT_NATIVE_APP_COMPONENT_REGISTRATION(registry);
+#endif
+
+  // And we fallback to the components autolinked
+  autolinking_registerProviders(registry);
+}
+
+std::shared_ptr<TurboModule> cxxModuleProvider(
+    const std::string& name,
+    const std::shared_ptr<CallInvoker>& jsInvoker) {
+  // Here you can provide your CXX Turbo Modules coming from
+  // either your application or from external libraries. The approach to follow
+  // is similar to the following (for a module called `NativeCxxModuleExample`):
+  //
+  // if (name == NativeCxxModuleExample::kModuleName) {
+  //   return std::make_shared<NativeCxxModuleExample>(jsInvoker);
+  // }
+
+  // And we fallback to the CXX module providers autolinked
+  return autolinking_cxxModuleProvider(name, jsInvoker);
+
+  return nullptr;
+}
+
+std::shared_ptr<TurboModule> javaModuleProvider(
+    const std::string& name,
+    const JavaTurboModule::InitParams& params) {
+  // Here you can provide your own module provider for TurboModules coming from
+  // either your application or from external libraries. The approach to follow
+  // is similar to the following (for a library called `samplelibrary`):
+  //
+  // auto module = samplelibrary_ModuleProvider(name, params);
+  // if (module != nullptr) {
+  //    return module;
+  // }
+  // return rncore_ModuleProvider(name, params);
+
+  // We link app local modules if available
+#ifdef REACT_NATIVE_APP_MODULE_PROVIDER
+  auto module = REACT_NATIVE_APP_MODULE_PROVIDER(name, params);
+  if (module != nullptr) {
+    return module;
+  }
+#endif
+
+  // We first try to look up core modules
+  if (auto module = FBReactNativeSpec_ModuleProvider(name, params)) {
+    return module;
+  }
+
+  // And we fallback to the module providers autolinked
+  if (auto module = autolinking_ModuleProvider(name, params)) {
+    return module;
+  }
+
+  return nullptr;
+}
+
+} // namespace facebook::react
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
+  return facebook::jni::initialize(vm, [] {
+    facebook::react::DefaultTurboModuleManagerDelegate::cxxModuleProvider =
+        &facebook::react::cxxModuleProvider;
+    facebook::react::DefaultTurboModuleManagerDelegate::javaModuleProvider =
+        &facebook::react::javaModuleProvider;
+    facebook::react::DefaultComponentsRegistry::
+        registerComponentDescriptorsFromEntryPoint =
+            &facebook::react::registerComponents;
+  });
+}

--- a/Mobiles/react-native/android/app/src/main/jni/quickpizza_ndk_crash.cpp
+++ b/Mobiles/react-native/android/app/src/main/jni/quickpizza_ndk_crash.cpp
@@ -1,0 +1,84 @@
+#include <jni.h>
+
+#include <dlfcn.h>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unwind.h>
+
+struct BacktraceState {
+  void **frames;
+  size_t count;
+  size_t max;
+};
+
+static _Unwind_Reason_Code unwindCallback(_Unwind_Context *context, void *arg) {
+  auto *state = static_cast<BacktraceState *>(arg);
+  if (state->count >= state->max) {
+    return _URC_END_OF_STACK;
+  }
+  state->frames[state->count++] =
+      reinterpret_cast<void *>(_Unwind_GetIP(context));
+  return _URC_NO_REASON;
+}
+
+static std::string abiLabel() {
+#if defined(__aarch64__)
+  return "arm64";
+#elif defined(__arm__)
+  return "arm";
+#elif defined(__x86_64__)
+  return "x86_64";
+#elif defined(__i386__)
+  return "x86";
+#else
+  return "unknown";
+#endif
+}
+
+static std::string formatBacktrace(void **frames, size_t count) {
+  std::ostringstream out;
+  out << "*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***\n";
+  out << "ABI: '" << abiLabel() << "'\n";
+  out << "backtrace:\n";
+
+  for (size_t i = 0; i < count && i < 32; ++i) {
+    Dl_info info {};
+    const auto pc = reinterpret_cast<uintptr_t>(frames[i]);
+    dladdr(frames[i], &info);
+    const char *library =
+        (info.dli_fname != nullptr) ? info.dli_fname : "unknown";
+    out << "      #" << std::setw(2) << std::setfill('0') << i << " pc "
+        << std::hex << std::uppercase << std::setw(16) << std::setfill('0')
+        << pc << "  " << library;
+    if (info.dli_sname != nullptr) {
+      out << " (" << info.dli_sname << ")";
+    }
+    out << "\n";
+  }
+
+  return out.str();
+}
+
+static std::string captureCurrentBacktrace() {
+  void *frames[32];
+  BacktraceState state {frames, 0, 32};
+  _Unwind_Backtrace(unwindCallback, &state);
+  return formatBacktrace(frames, state.count);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_quickpizza_QuickPizzaNdkCrashModule_captureBacktraceForCache(
+    JNIEnv *env,
+    jobject /* thiz */) {
+  const std::string trace = captureCurrentBacktrace();
+  return env->NewStringUTF(trace.c_str());
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_quickpizza_QuickPizzaNdkCrashModule_nativeCrash(JNIEnv * /* env */,
+                                                         jobject /* thiz */) {
+  // Intentional null dereference → SIGSEGV with a native tombstone stack trace.
+  volatile int *ptr = nullptr;
+  *ptr = 42;
+}

--- a/Mobiles/react-native/scripts/run-android.sh
+++ b/Mobiles/react-native/scripts/run-android.sh
@@ -1,8 +1,231 @@
 #!/bin/bash
+set -euo pipefail
 
-# Script to run React Native app on Android emulator
+# Run React Native on Android. Starts an emulator when none is connected.
+#
+# Usage:
+#   ./scripts/run-android.sh                 # debug install (yarn android)
+#   ./scripts/run-android.sh --emulator-only # boot emulator only (E2E / CI)
 
 cd "$(dirname "$0")/.."
+
+EMULATOR_ONLY=0
+AVD_CLI=""
+
+usage() {
+  cat <<'USAGE'
+Run the React Native QuickPizza app on Android.
+
+  ./scripts/run-android.sh
+  ./scripts/run-android.sh --emulator-only
+
+Options:
+  --emulator-only   Start/wait for an emulator only; do not run yarn android
+  --avd <name>      AVD to launch when several exist (or set ANDROID_AVD)
+  -h, --help        Show this help
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --emulator-only)
+      EMULATOR_ONLY=1
+      shift
+      ;;
+    --avd)
+      AVD_CLI="${2:-}"
+      [[ -n "$AVD_CLI" ]] || { echo "❌ --avd requires a name (see: emulator -list-avds)" >&2; exit 1; }
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1 (try --help)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+resolve_android_sdk() {
+  if [ -n "${ANDROID_SDK_ROOT:-}" ] && [ -d "${ANDROID_SDK_ROOT}/emulator" ]; then
+    printf '%s' "$ANDROID_SDK_ROOT"
+  elif [ -n "${ANDROID_HOME:-}" ] && [ -d "${ANDROID_HOME}/emulator" ]; then
+    printf '%s' "$ANDROID_HOME"
+  elif [ -d "$HOME/Library/Android/sdk/emulator" ]; then
+    printf '%s' "$HOME/Library/Android/sdk"
+  else
+    printf ''
+  fi
+}
+
+has_android_device() {
+  command -v adb >/dev/null 2>&1 || return 1
+  adb devices 2>/dev/null | awk 'NR>1 && $2=="device" { found=1 } END { exit !found }'
+}
+
+adb_lists_emulator() {
+  command -v adb >/dev/null 2>&1 || return 1
+  adb devices 2>/dev/null | awk 'NR>1 && $1 ~ /^emulator-/ { found=1 } END { exit !found }'
+}
+
+emulator_process_running() {
+  pgrep -f 'qemu-system|/emulator/emulator.*-avd' >/dev/null 2>&1
+}
+
+wait_for_adb_device() {
+  local attempts="${1:-120}"
+  local i=1
+
+  while [ "$i" -le "$attempts" ]; do
+    if has_android_device; then
+      return 0
+    fi
+    if [ $((i % 10)) -eq 0 ]; then
+      echo "Still waiting for adb device... ($i/${attempts}s)"
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+wait_for_android_boot() {
+  local attempts="${1:-120}"
+  local i=1
+  local boot
+
+  adb wait-for-device
+
+  while [ "$i" -le "$attempts" ]; do
+    boot="$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r\n')"
+    if [ "$boot" = "1" ]; then
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+
+  echo "❌ Timed out waiting for Android boot (sys.boot_completed)." >&2
+  echo "   Restart the emulator, then run this script again." >&2
+  exit 1
+}
+
+wait_for_existing_emulator() {
+  echo "Emulator already running; waiting for adb (not launching a second instance)..."
+
+  if wait_for_adb_device 120; then
+    echo "✅ Emulator ready in adb"
+    wait_for_android_boot
+    adb devices -l
+    return 0
+  fi
+
+  echo "❌ Emulator is running but adb never reported device state." >&2
+  echo "   Restart the emulator (cold boot in Android Studio), then run this script again." >&2
+  adb devices -l >&2 || true
+  exit 1
+}
+
+choose_avd() {
+  local emu="$1"
+  local chosen="" count=0 first="" line=""
+
+  if [ -n "$AVD_CLI" ]; then
+    printf '%s' "$AVD_CLI"
+    return 0
+  fi
+  if [ -n "${ANDROID_AVD:-}" ]; then
+    printf '%s' "$ANDROID_AVD"
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    count=$((count + 1))
+    [ "$count" -eq 1 ] && first="$line"
+  done <<EOF
+$("$emu" -list-avds 2>/dev/null || true)
+EOF
+
+  if [ "$count" -eq 0 ]; then
+    echo "❌ No AVDs found. Create one in Android Studio Device Manager." >&2
+    return 1
+  elif [ "$count" -eq 1 ]; then
+    printf '%s' "$first"
+    return 0
+  fi
+
+  echo "❌ Multiple AVDs; pass --avd <name> or set ANDROID_AVD:" >&2
+  "$emu" -list-avds 2>/dev/null || true
+  return 1
+}
+
+ensure_android_emulator() {
+  if has_android_device; then
+    echo "✅ Android device/emulator already connected"
+    wait_for_android_boot
+    adb devices -l
+    return 0
+  fi
+
+  if adb_lists_emulator || emulator_process_running; then
+    wait_for_existing_emulator
+    return 0
+  fi
+
+  local sdk emu chosen
+  sdk="$(resolve_android_sdk)"
+  if [ -z "$sdk" ]; then
+    echo "❌ Android SDK not found. Set ANDROID_SDK_ROOT or ANDROID_HOME." >&2
+    exit 1
+  fi
+
+  emu="$sdk/emulator/emulator"
+  if [ ! -x "$emu" ]; then
+    echo "❌ Emulator binary not found at: $emu" >&2
+    exit 1
+  fi
+
+  export PATH="$sdk/platform-tools:$sdk/emulator:$PATH"
+  chosen="$(choose_avd "$emu")" || exit 1
+
+  if ! "$emu" -list-avds 2>/dev/null | grep -Fxq "$chosen"; then
+    echo "❌ AVD not found: $chosen" >&2
+    "$emu" -list-avds 2>/dev/null || true
+    exit 1
+  fi
+
+  echo "No Android device found. Launching emulator: $chosen"
+  nohup "$emu" -avd "$chosen" -no-snapshot-load >/tmp/quickpizza-emulator.log 2>&1 &
+  echo "Emulator starting (log: /tmp/quickpizza-emulator.log) ..."
+
+  local i=1
+  local max_wait=120
+  while [ "$i" -le "$max_wait" ]; do
+    if has_android_device; then
+      echo "✅ Emulator ready"
+      wait_for_android_boot
+      adb devices -l
+      return 0
+    fi
+    if [ $((i % 10)) -eq 0 ]; then
+      echo "Still waiting for emulator... ($i/${max_wait}s)"
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+
+  echo "❌ Timed out waiting for emulator to appear in adb devices" >&2
+  exit 1
+}
+
+ensure_android_emulator
+
+if [ "$EMULATOR_ONLY" -eq 1 ]; then
+  exit 0
+fi
 
 # ============================================
 # Config file check (config.json, same as Flutter)
@@ -11,25 +234,25 @@ CONFIG_FILE="config.json"
 CONFIG_EXAMPLE="config.json.example"
 
 if [ ! -f "$CONFIG_FILE" ]; then
+  echo ""
+  echo "⚠️  WARNING: $CONFIG_FILE not found!"
+  echo ""
+
+  if [ -f "$CONFIG_EXAMPLE" ]; then
+    echo "Creating $CONFIG_FILE from $CONFIG_EXAMPLE..."
+    cp "$CONFIG_EXAMPLE" "$CONFIG_FILE"
     echo ""
-    echo "⚠️  WARNING: $CONFIG_FILE not found!"
+    echo "📝 Please edit $CONFIG_FILE with your actual values:"
+    echo "   - FARO_COLLECTOR_URL: Your Grafana Faro collector URL"
+    echo "   - BASE_URL: Backend API URL (optional, has platform defaults)"
+    echo "   - PORT: Backend port (optional, defaults to 3333)"
     echo ""
-    
-    if [ -f "$CONFIG_EXAMPLE" ]; then
-        echo "Creating $CONFIG_FILE from $CONFIG_EXAMPLE..."
-        cp "$CONFIG_EXAMPLE" "$CONFIG_FILE"
-        echo ""
-        echo "📝 Please edit $CONFIG_FILE with your actual values:"
-        echo "   - FARO_COLLECTOR_URL: Your Grafana Faro collector URL"
-        echo "   - BASE_URL: Backend API URL (optional, has platform defaults)"
-        echo "   - PORT: Backend port (optional, defaults to 3333)"
-        echo ""
-        echo "Then run this script again."
-        exit 1
-    else
-        echo "❌ ERROR: $CONFIG_EXAMPLE not found!"
-        exit 1
-    fi
+    echo "Then run this script again."
+    exit 1
+  else
+    echo "❌ ERROR: $CONFIG_EXAMPLE not found!"
+    exit 1
+  fi
 fi
 
 echo "✅ Using config from $CONFIG_FILE"

--- a/Mobiles/react-native/src/bootstrap.ts
+++ b/Mobiles/react-native/src/bootstrap.ts
@@ -7,6 +7,7 @@ import {
 import { InternalLoggerLevel, LogLevel, SamplingRate, initializeFaro, type ReactNativeConfig } from './core/o11y/faroSdk';
 
 import { extractTokenFromCollectorUrl } from './core/utils/faroUtils';
+import { resolveTelemetryAppVersion } from './core/config/appVersionResolver';
 import { getFaroCollectorUrl, getQuickPizzaTracePropagationUrlPatterns } from './core/config/configService';
 
 /**
@@ -21,7 +22,7 @@ const ENABLE_FARO_PAYLOAD_DIAGNOSTICS =
 /** Must match `app.name` and Metro `@grafana/faro-metro-plugin` `appName`. */
 const FARO_APP_NAME = 'QuickPizza_ReactNative';
 
-const APP_VERSION = '1.0.0';
+const APP_VERSION = resolveTelemetryAppVersion(process.env.DEMO_APP_VERSION);
 const APP_ENV = __DEV__ ? 'development' : 'production';
 
 // Capture the original console BEFORE any patching happens (RN DevTools, LogBox, etc.)

--- a/Mobiles/react-native/src/bootstrap.ts
+++ b/Mobiles/react-native/src/bootstrap.ts
@@ -7,7 +7,6 @@ import {
 import { InternalLoggerLevel, LogLevel, SamplingRate, initializeFaro, type ReactNativeConfig } from './core/o11y/faroSdk';
 
 import { extractTokenFromCollectorUrl } from './core/utils/faroUtils';
-import { resolveTelemetryAppVersion } from './core/config/appVersionResolver';
 import { getFaroCollectorUrl, getQuickPizzaTracePropagationUrlPatterns } from './core/config/configService';
 
 /**
@@ -22,7 +21,7 @@ const ENABLE_FARO_PAYLOAD_DIAGNOSTICS =
 /** Must match `app.name` and Metro `@grafana/faro-metro-plugin` `appName`. */
 const FARO_APP_NAME = 'QuickPizza_ReactNative';
 
-const APP_VERSION = resolveTelemetryAppVersion(process.env.DEMO_APP_VERSION);
+const APP_VERSION = '1.0.0';
 const APP_ENV = __DEV__ ? 'development' : 'production';
 
 // Capture the original console BEFORE any patching happens (RN DevTools, LogBox, etc.)
@@ -128,6 +127,9 @@ export async function initFaro(): Promise<void> {
     memoryUsageVitals: true,
     refreshRateVitals: true,
     anrTracking: true,
+    anrOptions: {
+      pollingInterval: __DEV__ ? 5000 : 10000,
+    },
     fetchVitalsInterval: __DEV__ ? 5000 : 30000,
 
     enableErrorReporting: true,

--- a/Mobiles/react-native/src/core/native/nativeCrash.ts
+++ b/Mobiles/react-native/src/core/native/nativeCrash.ts
@@ -1,19 +1,37 @@
 import { NativeModules } from 'react-native';
 
-type CrashVariant = 'runtimeException' | 'nullPointer';
+type JavaCrashVariant = 'runtimeException' | 'nullPointer' | 'anr';
 
 type QuickPizzaCrashModule = {
-  crash: (variant: CrashVariant) => void;
+  crash: (variant: JavaCrashVariant) => void;
 };
 
-const crashModule = NativeModules.QuickPizzaCrash as
+type QuickPizzaNdkCrashModule = {
+  crash: () => void;
+};
+
+const javaCrashModule = NativeModules.QuickPizzaCrash as
   | QuickPizzaCrashModule
   | undefined;
 
-export function triggerNativeCrash(variant: CrashVariant): void {
-  if (!crashModule?.crash) {
+const ndkCrashModule = NativeModules.QuickPizzaNdkCrash as
+  | QuickPizzaNdkCrashModule
+  | undefined;
+
+/** Java/Kotlin crash reported via R8 mapping.txt retrace (not an NDK tombstone). */
+export function triggerJavaCrash(variant: JavaCrashVariant): void {
+  if (!javaCrashModule?.crash) {
     throw new Error('QuickPizzaCrash native module is not available');
   }
 
-  crashModule.crash(variant);
+  javaCrashModule.crash(variant);
+}
+
+/** Real C++ SIGSEGV crash with a native tombstone (Android NDK symbols zip). */
+export function triggerNdkCrash(): void {
+  if (!ndkCrashModule?.crash) {
+    throw new Error('QuickPizzaNdkCrash native module is not available');
+  }
+
+  ndkCrashModule.crash();
 }

--- a/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
+++ b/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
@@ -136,9 +136,12 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
   };
 
   const confirmJavaCrash = (variant: 'runtimeException' | 'nullPointer') => {
+    const isAndroid = Platform.OS === 'android';
     Alert.alert(
-      'Trigger Java crash?',
-      'Throws a Java/Kotlin exception (R8 mapping.txt retrace). The app will terminate; relaunch to report via Faro.',
+      isAndroid ? 'Trigger Java crash?' : 'Trigger native crash?',
+      isAndroid
+        ? 'Throws a Java/Kotlin exception (R8 mapping.txt retrace). The app will terminate; relaunch to report via Faro.'
+        : 'Triggers a Swift fatalError. The app will terminate; relaunch to report via Faro.',
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -307,9 +310,15 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Java crash (R8 / mapping.txt)</Text>
+          <Text style={styles.sectionTitle}>
+            {Platform.OS === 'android'
+              ? 'Java crash (R8 / mapping.txt)'
+              : 'Native crash (Swift)'}
+          </Text>
           <Text style={styles.settingSubtitle}>
-            Java/Kotlin exceptions retrace against mapping.txt after relaunch.
+            {Platform.OS === 'android'
+              ? 'Java/Kotlin exceptions retrace against mapping.txt after relaunch.'
+              : 'Intentional fatalError in native Swift code. Reported after relaunch.'}
           </Text>
           <View style={styles.buttonGrid}>
             <ActionButton
@@ -322,11 +331,13 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
               tone="danger"
               onPress={() => confirmJavaCrash('nullPointer')}
             />
-            <ActionButton
-              title="ANR (block main thread ~10s)"
-              tone="danger"
-              onPress={confirmNativeAnr}
-            />
+            {Platform.OS === 'android' && (
+              <ActionButton
+                title="ANR (block main thread ~10s)"
+                tone="danger"
+                onPress={confirmNativeAnr}
+              />
+            )}
           </View>
         </View>
 

--- a/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
+++ b/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import {
   Alert,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -11,7 +12,7 @@ import {
 import MaterialIcons from '@react-native-vector-icons/material-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { triggerNativeCrash } from '../../../core/native/nativeCrash';
+import { triggerJavaCrash, triggerNdkCrash } from '../../../core/native/nativeCrash';
 import { reportError } from '../../../core/o11y/o11yErrors';
 import { trackEvent } from '../../../core/o11y/o11yEvents';
 import { pushDebugLog, pushErrorLog } from '../../../core/o11y/o11yLogs';
@@ -134,16 +135,46 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
     }, 0);
   };
 
-  const confirmNativeCrash = (variant: 'runtimeException' | 'nullPointer') => {
+  const confirmJavaCrash = (variant: 'runtimeException' | 'nullPointer') => {
     Alert.alert(
-      'Trigger native crash?',
-      'The app will terminate. Relaunch it to let Faro report the crash.',
+      'Trigger Java crash?',
+      'Throws a Java/Kotlin exception (R8 mapping.txt retrace). The app will terminate; relaunch to report via Faro.',
       [
         { text: 'Cancel', style: 'cancel' },
         {
           text: 'Crash',
           style: 'destructive',
-          onPress: () => triggerNativeCrash(variant),
+          onPress: () => triggerJavaCrash(variant),
+        },
+      ],
+    );
+  };
+
+  const confirmNdkCrash = () => {
+    Alert.alert(
+      'Trigger NDK crash?',
+      'Causes a real SIGSEGV with a native tombstone (arm64-v8a.zip symbolication). The app will terminate; relaunch to report via Faro.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Crash',
+          style: 'destructive',
+          onPress: () => triggerNdkCrash(),
+        },
+      ],
+    );
+  };
+
+  const confirmNativeAnr = () => {
+    Alert.alert(
+      'Trigger native ANR?',
+      'The UI will freeze for ~10s while the main thread is blocked. Faro reports it as an ANR.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Freeze',
+          style: 'destructive',
+          onPress: () => triggerJavaCrash('anr'),
         },
       ],
     );
@@ -276,23 +307,45 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Native crash</Text>
+          <Text style={styles.sectionTitle}>Java crash (R8 / mapping.txt)</Text>
           <Text style={styles.settingSubtitle}>
-            These intentionally terminate the app and are reported after relaunch.
+            Java/Kotlin exceptions retrace against mapping.txt after relaunch.
           </Text>
           <View style={styles.buttonGrid}>
             <ActionButton
-              title="RuntimeException / fatalError"
+              title="RuntimeException"
               tone="danger"
-              onPress={() => confirmNativeCrash('runtimeException')}
+              onPress={() => confirmJavaCrash('runtimeException')}
             />
             <ActionButton
-              title="Null pointer / force unwrap"
+              title="Null pointer"
               tone="danger"
-              onPress={() => confirmNativeCrash('nullPointer')}
+              onPress={() => confirmJavaCrash('nullPointer')}
+            />
+            <ActionButton
+              title="ANR (block main thread ~10s)"
+              tone="danger"
+              onPress={confirmNativeAnr}
             />
           </View>
         </View>
+
+        {Platform.OS === 'android' && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>NDK crash (C++ / tombstone)</Text>
+            <Text style={styles.settingSubtitle}>
+              Real SIGSEGV in native code; stack frames use per-ABI .so symbols
+              (arm64-v8a.zip) after relaunch.
+            </Text>
+            <View style={styles.buttonGrid}>
+              <ActionButton
+                title="SIGSEGV (null dereference)"
+                tone="danger"
+                onPress={confirmNdkCrash}
+              />
+            </View>
+          </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary

Adds **demo-only crash triggers** to the Debug tab in both mobile apps so we can exercise Java/Kotlin crashes, ANR, and real native SIGSEGV (NDK tombstone) paths without external tooling.

This is **PR 1 of 3** split from the original native-symbolication work. It is **self-contained**: builds on `main`, does not require other PRs to merge, and only adds trigger UI + native JNI wiring + tombstone **cache writers**.

### What this PR solves

| App | Debug actions added |
|-----|---------------------|
| **React Native** (`Mobiles/react-native`) | Java `RuntimeException`, null pointer, **ANR** (~10s main-thread block), **NDK SIGSEGV** (Android only) |
| **Android OTel** (`Mobiles/android`) | Existing Java crash card unchanged; **ANR** extended to 10s (matches RN); **NDK SIGSEGV** card with confirmation dialog |

**Infrastructure included**

- JNI/CMake `quickpizza_ndk_crash` library (SIGSEGV + pre-crash backtrace capture) in both apps
- RN bridge modules: `QuickPizzaCrash` (Java/ANR) + `QuickPizzaNdkCrash` (SIGSEGV)
- Demo tombstone cache writers (SharedPreferences contracts for follow-up replay PRs):
  - OTel: `com.grafana.quickpizza.native_crash_trace_cache`
  - RN: `com.grafana.faro.crash_trace_cache`
- `run-android.sh`: auto-start/wait for emulator when no device is connected (local Android testing)
- Platform-specific RN Debug copy (Android Java/R8 vs iOS Swift; ANR + NDK hidden on iOS)

### What you can test (in this PR alone)

**React Native — Android**

1. `./scripts/run-android.sh` (or `yarn android` with emulator already running)
2. Open **Debug** tab
3. **Java crash** → RuntimeException / Null pointer → app terminates → relaunch → Faro reports exception
4. **ANR** → UI freezes ~10s → Faro ANR event after detection
5. **NDK SIGSEGV** → app terminates → relaunch → Faro reports crash (native stack may be unsymbolicated until PR #85)

**React Native — iOS**

1. Run on simulator/device
2. Debug → **Native crash (Swift)** buttons (no ANR / NDK sections)
3. Relaunch → Faro reports `fatalError` crash

**Android OTel app**

1. Build/install debug APK
2. Debug → **ANR** (10s block) or **NDK SIGSEGV**
3. Relaunch → OTel crash/ANR telemetry is emitted (tombstone replay from cache is **not** in this PR — see PR #86)

**CI**

- `assembleDebug` for RN and Android OTel (workflow on this PR)

### Depends on other PRs (for full end-to-end, not to merge this PR)

| Follow-up PR | What it adds | Needed for |
|--------------|--------------|------------|
| [#85 — Android symbolification config](https://github.com/grafana/mobile-o11y-demo/pull/85) | R8 minify, Faro Gradle plugin, Metro bundle id, NDK/Java symbol upload | **Readable** Java stack retrace (`mapping.txt`) and **symbolicated** NDK frames (`arm64-v8a.zip`) in Grafana |
| [#86 — nativecrash replay module](https://github.com/grafana/mobile-o11y-demo/pull/86) | Reads cached tombstones on next launch (`ApplicationExitInfo` fallback) | Emulator cases where `traceInputStream` is null; full OTel `device.crash` replay from prefs |

**Without #85 / #86:** triggers still work, apps still crash/ANR as intended, and builds pass — you just will not see fully symbolicated stacks or prefs-based tombstone replay yet.

### Out of scope (intentionally in other PRs)

- R8 / ProGuard release pipeline and symbol upload (#85)
- `com.grafana.quickpizza.nativecrash` replay + OTel flush wiring (#86)
- Faro RN `cachePendingNativeCrashTrace` API (uses demo-side cache writer compatible with published `@grafana/faro-react-native@1.3.0`)

## Screenshots

**React Native Debug Tab**: 
<img width="356" height="811" alt="Screenshot 2026-07-07 at 14 00 26" src="https://github.com/user-attachments/assets/be5856ee-31fc-4a85-9e60-d9f01d4562c5" />

**Android Native Debug Tab**: 
<img width="383" height="858" alt="Screenshot 2026-07-07 at 14 08 44" src="https://github.com/user-attachments/assets/bf224a78-2a00-44ce-a2d8-683904d1fe7d" />
