### PR TITLE
feat(flutter): demo a second RUM SDK alongside Faro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 - **Where it lands:** Frontend Observability plugin (Faro app `QuickPizza_Flutter`, id `69`). SDK is configured to send `app_name=QuickPizza_Flutter` to match the registry; older telemetry may still carry the legacy `quickpizza-flutter` kebab-case name.
 - **Config:** `config.json` at project root — `BASE_URL`, `FARO_COLLECTOR_URL`.
 - **Build:** `flutter run --dart-define-from-file=config.json` or `./scripts/run-android.sh` / `./scripts/run-ios.sh`.
+- **Also runs a second, made-up "DemoRum" RUM SDK** alongside Faro purely to demo how two mobile RUM SDKs coexist in one app — this is intentional, not a mistake to "clean up". DemoRum is a local **no-op stand-in** (no third-party SDK, no network): every call is inert and echoes to the console (`[DemoRum]` logs), except it installs chained `FlutterError`/`PlatformDispatcher` error handlers and forwards HTTP so the demo is honest. Swap `core/o11y/demo_rum/sdk/demo_rum.dart` for a real vendor SDK to make it live. Details are local to `Mobiles/flutter/` (see its README and `core/o11y/{demo_rum,faro}/`).
 
 ### React Native (`Mobiles/react-native/`)
 

--- a/Mobiles/flutter/README.md
+++ b/Mobiles/flutter/README.md
@@ -1,6 +1,6 @@
 # QuickPizza Flutter Mobile App
 
-A Flutter mobile application that replicates the QuickPizza web application functionality. This app allows users to get pizza recommendations, rate pizzas, and manage their profile, and demonstrates Grafana Faro mobile telemetry.
+A Flutter mobile application that replicates the QuickPizza web application functionality. This app allows users to get pizza recommendations, rate pizzas, and manage their profile, and demonstrates Grafana Faro mobile telemetry. It also runs a second, made-up RUM SDK alongside Faro to show how two mobile RUM SDKs coexist in one app — see [Running a second RUM SDK alongside Faro](#running-a-second-rum-sdk-alongside-faro).
 
 > **New here?** Start at [`../README.md`](../README.md) for the overview of all
 > four apps, the backend, and how to get a demo running. This page covers the
@@ -204,6 +204,39 @@ onPressed: () => actions.ratePizza(stars: 5);
 - **Readability**: No Riverpod-specific syntax (`.notifier`) in widget code
 - **Separation**: UI state is a pure data class, actions are interface methods
 - **Discoverability**: New developers see plain Dart interfaces
+
+## Running a second RUM SDK alongside Faro
+
+Grafana Faro is the primary — and only *real* — instrumentation for this app.
+Alongside it runs **DemoRum**, a small **made-up, no-op RUM SDK** defined
+locally in [`core/o11y/demo_rum/`](lib/core/o11y/demo_rum/). Its whole purpose is
+to demonstrate *how you would wire a second mobile RUM SDK into an app that
+already uses Faro* — the shared `core/o11y/` layer fans every error, log, event
+and span out to both, so you can see the exact call sites a second SDK plugs
+into.
+
+- **It's a stand-in, not a real backend.** DemoRum sends nothing over the
+  network. Every method is a no-op that echoes to the console (look for
+  `[DemoRum]` logs) so you can *see* it receiving the same telemetry as Faro. To
+  ship a real second SDK, swap the types in `core/o11y/demo_rum/sdk/demo_rum.dart`
+  for the vendor's and keep the surrounding code essentially unchanged. Its API
+  is deliberately shaped like a typical RUM SDK (init + options, root widget,
+  navigation observer, HTTP client wrapper, exception capture, structured logs,
+  scope/user, and spans).
+- **It behaves like a real SDK where it matters.** DemoRum installs *chained*
+  `FlutterError.onError` / `PlatformDispatcher.onError` handlers (the same
+  cooperative pattern real SDKs use — save + call the previous handler), so both
+  Faro and DemoRum observe every Dart error. Its HTTP client wrapper forwards
+  each request (Faro's `HttpOverrides` underneath still does the real capture),
+  and its spans run their callbacks so instrumenting a call site never changes
+  behavior.
+- **How it's wired:** `bootstrap.dart` nests the two (DemoRum wraps Faro wraps
+  the app). Each SDK's init + widget wrapper live in
+  [`core/o11y/demo_rum/`](lib/core/o11y/demo_rum/) and
+  [`core/o11y/faro/`](lib/core/o11y/faro/).
+- **Verify:** the in-app **Debug** tab triggers errors/logs/events (they reach
+  Faro *and* echo through DemoRum), plus a dedicated "Capture DemoRum Test
+  Exception" button.
 
 ## API Endpoints Used
 

--- a/Mobiles/flutter/config.json.example
+++ b/Mobiles/flutter/config.json.example
@@ -1,6 +1,6 @@
 {
   "FARO_COLLECTOR_URL": "https://your-faro-collector-url.grafana.net/collect/xxx",
-  
+
   "_BASE_URL_comment": "Leave empty for emulators (uses 10.0.2.2 for Android, localhost for iOS). For physical devices, set to your machine's IP like http://192.168.1.100:3333",
   "BASE_URL": "",
   

--- a/Mobiles/flutter/lib/bootstrap.dart
+++ b/Mobiles/flutter/lib/bootstrap.dart
@@ -1,19 +1,15 @@
-import 'dart:io';
-
-import 'package:faro/faro.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/config/app_version_resolver.dart';
 import 'core/config/app_version_provider.dart';
 import 'core/config/config_service.dart';
-import 'core/config/debug_settings.dart';
-import 'core/config/runtime_config.dart';
+import 'core/config/shared_preferences_provider.dart';
 import 'core/localization/app_localizations.dart';
-import 'core/o11y/faro/faro.dart';
+import 'core/o11y/demo_rum/demo_rum_init.dart';
+import 'core/o11y/faro/faro_init.dart';
 import 'core/o11y/loggers/o11y_logger.dart';
 import 'core/router/app_router.dart';
-import 'core/utils/faro_utils.dart';
 import 'core/widgets/toast_listener.dart';
 import 'features/auth/domain/auth_provider.dart';
 
@@ -37,22 +33,15 @@ class BootstrapConfig {
 Future<void> bootstrap(BootstrapConfig config) async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // IMPORTANT: Set HttpOverrides BEFORE creating any http.Client instances!
-  // The http package uses IOClient on mobile, which creates an HttpClient
-  // at construction time. If HttpOverrides is set after the client is created,
-  // Faro won't intercept those HTTP requests.
-  HttpOverrides.global = FaroHttpOverrides(HttpOverrides.current);
+  // Install Faro's HttpOverrides FIRST — before anything can construct an
+  // http.Client, or that client would permanently bypass Faro's HTTP
+  // auto-instrumentation. See installFaroHttpOverrides for the full rationale.
+  installFaroHttpOverrides();
 
-  final container = ProviderContainer();
-
-  // Resolve the RuntimeConfig BEFORE Riverpod / Faro init, so any
-  // debug override the user saved in a previous session is honored for
-  // this entire session. Awaiting here guarantees that downstream
-  // consumers can safely use requireValue on runtimeConfigProvider.
-  final runtimeConfig = await container.read(runtimeConfigProvider.future);
-
-  // Force-load debug settings so the UI sees saved values on first frame.
-  await container.read(debugSettingsProvider.notifier).reload();
+  // Root container with SharedPreferences resolved + bound, so config +
+  // debug providers can read overrides synchronously (see
+  // createAppProviderContainer).
+  final container = await createAppProviderContainer();
 
   // Access the logger via Riverpod
   final logger = container.read(o11yLoggerProvider);
@@ -61,10 +50,49 @@ Future<void> bootstrap(BootstrapConfig config) async {
       : '';
   logger.debug('App initialization started$driverSuffix');
 
-  // Restore auth session if user was previously logged in
-  await container.read(authStateProvider.notifier).restoreSession();
+  final appVersion = await _resolveTelemetryAppVersion(container, logger);
 
-  // Get app version from package info provider (warms up the provider for later use)
+  // Telemetry nesting: DemoRum (outer) -> Faro (inner) -> runApp. DemoRum is a
+  // no-op stand-in SDK (see core/o11y/demo_rum/) run alongside Faro purely to
+  // demo how a second RUM SDK plugs in; the nesting order is illustrative. The
+  // widget tree wraps as wrapWithDemoRum(wrapWithFaro(app)).
+  await startDemoRum(
+    appEnv: config.appEnv,
+    appVersion: appVersion,
+    appRunner: () async {
+      // Restore the auth session here (inside the app runners, after
+      // installFaroHttpOverrides ran). restoreSession pulls in
+      // apiClientProvider, which constructs the app's http.Client — it must
+      // happen AFTER the Faro HttpOverrides are installed so Faro still sees
+      // the traffic. See installFaroHttpOverrides for the full rationale.
+      await container.read(authStateProvider.notifier).restoreSession();
+
+      // Explicit await so the Faro startup Future is always awaited end-to-end,
+      // even if this closure is later refactored to a block body.
+      await startFaro(
+        container: container,
+        appEnv: config.appEnv,
+        appVersion: appVersion,
+        appRunner: () {
+          runApp(
+            // Used by Riverpod to provide providers to the app
+            UncontrolledProviderScope(
+              container: container,
+              child: wrapWithDemoRum(wrapWithFaro(const QuickPizzaApp())),
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+/// Resolves the app version used across all telemetry SDKs (Faro appVersion,
+/// DemoRum release). Warms [packageInfoProvider] for later use.
+Future<String> _resolveTelemetryAppVersion(
+  ProviderContainer container,
+  O11yLogger logger,
+) async {
   final packageInfo = await container.read(packageInfoProvider.future);
   final baseAppVersion = packageInfo.version;
   final versionResolver = container.read(appVersionResolverProvider);
@@ -80,42 +108,7 @@ Future<void> bootstrap(BootstrapConfig config) async {
       'ciDemoVersioning': ConfigService.ciDemoVersioning.toString(),
     },
   );
-
-  final apiKey = extractTokenFromCollectorUrl(runtimeConfig.faroCollectorUrl);
-
-  // Access Faro instance from the container
-  final faro = container.read(faroProvider);
-
-  faro.transports.add(
-    OfflineTransport(maxCacheDuration: const Duration(days: 3)),
-  );
-
-  faro.runApp(
-    optionsConfiguration: FaroConfig(
-      appName: 'QuickPizza_Flutter',
-      appVersion: appVersion,
-      appEnv: config.appEnv,
-      apiKey: apiKey,
-      collectorUrl: runtimeConfig.faroCollectorUrl,
-      cpuUsageVitals: true,
-      memoryUsageVitals: true,
-      anrTracking: true,
-      refreshRateVitals: true,
-      fetchVitalsInterval: const Duration(seconds: 30),
-      enableCrashReporting: true,
-    ),
-    appRunner: () {
-      runApp(
-        // Used by Riverpod to provide providers to the app
-        UncontrolledProviderScope(
-          container: container,
-          child: FaroAssetTracking(
-            child: const FaroUserInteractionWidget(child: QuickPizzaApp()),
-          ),
-        ),
-      );
-    },
-  );
+  return appVersion;
 }
 
 /// The main QuickPizza application widget.

--- a/Mobiles/flutter/lib/core/api/api_client.dart
+++ b/Mobiles/flutter/lib/core/api/api_client.dart
@@ -6,24 +6,31 @@ import 'package:http/http.dart' as http;
 
 import '../config/debug_settings.dart';
 import '../config/runtime_config.dart';
+import '../o11y/demo_rum/sdk/demo_rum.dart';
 import '../o11y/errors/o11y_errors.dart';
 import '../o11y/metrics/o11y_metrics.dart';
 import '../storage/token_storage.dart';
 
 final apiClientProvider = Provider((ref) {
   // baseUrl is fixed for the session — captured from RuntimeConfig at bootstrap.
-  // Bootstrap awaits runtimeConfigProvider.future before runApp, so
-  // requireValue is always safe here.
+  // runtimeConfigProvider is synchronous (backed by sharedPreferencesProvider),
+  // so this read never sees a loading state.
   //
   // Error-injection headers are read live via a lambda, so toggles take
   // effect without needing to recreate the client.
-  final runtimeConfig = ref.watch(runtimeConfigProvider).requireValue;
+  final runtimeConfig = ref.watch(runtimeConfigProvider);
   final apiClient = ApiClient(
     baseUrl: runtimeConfig.backendBaseUrl,
     tokenStorage: ref.watch(tokenStorageProvider),
     o11yMetrics: ref.watch(o11yMetricsProvider),
     o11yErrors: ref.watch(o11yErrorsProvider),
-    httpClient: http.Client(),
+    // Dual HTTP instrumentation, wrapping at two different layers so they
+    // stack rather than conflict: DemoRumHttpClient (where a real second SDK
+    // would emit its HTTP span) -> http.Client()/IOClient -> Faro's
+    // HttpOverrides-wrapped HttpClient (Faro event). The inner http.Client()
+    // must stay constructed here, after installFaroHttpOverrides() ran in
+    // bootstrap, so Faro still sees traffic.
+    httpClient: DemoRumHttpClient(client: http.Client()),
     errorHeadersProvider: () =>
         ref.read(debugSettingsProvider).errorInjectionHeaders,
   );

--- a/Mobiles/flutter/lib/core/config/backend_url_service.dart
+++ b/Mobiles/flutter/lib/core/config/backend_url_service.dart
@@ -3,9 +3,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'config_service.dart';
 import 'debug_settings.dart';
+import 'shared_preferences_provider.dart';
 
 final backendUrlServiceProvider = Provider<BackendUrlService>((ref) {
-  return BackendUrlService(ref.watch(configServiceProvider));
+  return BackendUrlService(
+    ref.watch(configServiceProvider),
+    ref.watch(sharedPreferencesProvider),
+  );
 });
 
 /// Thin wrapper around the backend base URL source.
@@ -14,18 +18,18 @@ final backendUrlServiceProvider = Provider<BackendUrlService>((ref) {
 /// directly, because it transparently applies any runtime override the
 /// user saved from the debug Config screen.
 class BackendUrlService {
-  const BackendUrlService(this._configService);
+  const BackendUrlService(this._configService, this._prefs);
 
   final ConfigService _configService;
+  final SharedPreferences _prefs;
 
   /// Returns the effective backend base URL to use for this session.
   ///
   /// Order of precedence:
   /// 1. Override in SharedPreferences (set via debug Config screen)
   /// 2. Build-time env / platform default (via [ConfigService.baseUrl])
-  Future<String> getUrl() async {
-    final prefs = await SharedPreferences.getInstance();
-    final override = prefs.getString(DebugSettingsKeys.backendUrl);
+  String getUrl() {
+    final override = _prefs.getString(DebugSettingsKeys.backendUrl);
     if (override != null && override.trim().isNotEmpty) {
       return override.trim();
     }

--- a/Mobiles/flutter/lib/core/config/debug_settings.dart
+++ b/Mobiles/flutter/lib/core/config/debug_settings.dart
@@ -8,6 +8,7 @@ import 'shared_preferences_provider.dart';
 abstract class DebugSettingsKeys {
   static const backendUrl = 'debug_backend_url';
   static const faroCollectorUrl = 'debug_faro_collector_url';
+  static const faroSampleRate = 'debug_faro_sample_rate';
   static const errorRecommendations = 'debug_error_recommendations';
   static const errorIngredients = 'debug_error_ingredients';
   static const slowRecommendations = 'debug_slow_recommendations';
@@ -24,6 +25,10 @@ final debugSettingsProvider =
 class DebugSettings {
   final String? backendUrlOverride;
   final String? faroCollectorUrlOverride;
+
+  /// Faro session sampling rate override (0.0–1.0). `null` = use the default
+  /// ([kDefaultFaroSampleRate]). Applied at Faro init, so it needs a restart.
+  final double? faroSampleRateOverride;
   final bool errorOnRecommendations;
   final bool errorOnIngredients;
   final bool slowRecommendations;
@@ -34,6 +39,7 @@ class DebugSettings {
   const DebugSettings({
     this.backendUrlOverride,
     this.faroCollectorUrlOverride,
+    this.faroSampleRateOverride,
     this.errorOnRecommendations = false,
     this.errorOnIngredients = false,
     this.slowRecommendations = false,
@@ -45,6 +51,7 @@ class DebugSettings {
   DebugSettings copyWith({
     String? Function()? backendUrlOverride,
     String? Function()? faroCollectorUrlOverride,
+    double? Function()? faroSampleRateOverride,
     bool? errorOnRecommendations,
     bool? errorOnIngredients,
     bool? slowRecommendations,
@@ -59,6 +66,9 @@ class DebugSettings {
       faroCollectorUrlOverride: faroCollectorUrlOverride != null
           ? faroCollectorUrlOverride()
           : this.faroCollectorUrlOverride,
+      faroSampleRateOverride: faroSampleRateOverride != null
+          ? faroSampleRateOverride()
+          : this.faroSampleRateOverride,
       errorOnRecommendations:
           errorOnRecommendations ?? this.errorOnRecommendations,
       errorOnIngredients: errorOnIngredients ?? this.errorOnIngredients,
@@ -72,6 +82,7 @@ class DebugSettings {
   bool get hasActiveOverrides =>
       backendUrlOverride != null ||
       faroCollectorUrlOverride != null ||
+      faroSampleRateOverride != null ||
       errorOnRecommendations ||
       errorOnIngredients ||
       slowRecommendations ||
@@ -127,6 +138,9 @@ class DebugSettingsNotifier extends Notifier<DebugSettings> {
       faroCollectorUrlOverride: _prefs.getString(
         DebugSettingsKeys.faroCollectorUrl,
       ),
+      faroSampleRateOverride: _prefs.getDouble(
+        DebugSettingsKeys.faroSampleRate,
+      ),
       errorOnRecommendations:
           _prefs.getBool(DebugSettingsKeys.errorRecommendations) ?? false,
       errorOnIngredients:
@@ -142,20 +156,23 @@ class DebugSettingsNotifier extends Notifier<DebugSettings> {
     );
   }
 
-  /// Persists the backend URL and Faro collector URL overrides atomically.
-  /// Empty/whitespace values clear the corresponding override.
+  /// Persists the backend URL, Faro collector URL, and Faro sample-rate
+  /// overrides atomically. A `null` value clears the corresponding override
+  /// (empty/whitespace URLs are treated as `null`).
   ///
-  /// Returns `true` if either override actually changed, so the caller can
-  /// decide whether to show the restart banner.
-  Future<bool> saveUrls({
+  /// Returns `true` if any override actually changed, so the caller can decide
+  /// whether to show the restart banner.
+  Future<bool> saveConfigOverrides({
     required String? backendUrl,
     required String? faroCollectorUrl,
+    required double? faroSampleRate,
   }) async {
     final normalizedBackend = _normalize(backendUrl);
     final normalizedFaro = _normalize(faroCollectorUrl);
 
     final prevBackend = state.backendUrlOverride;
     final prevFaro = state.faroCollectorUrlOverride;
+    final prevRate = state.faroSampleRateOverride;
 
     if (normalizedBackend != null) {
       await _prefs.setString(DebugSettingsKeys.backendUrl, normalizedBackend);
@@ -172,12 +189,21 @@ class DebugSettingsNotifier extends Notifier<DebugSettings> {
       await _prefs.remove(DebugSettingsKeys.faroCollectorUrl);
     }
 
+    if (faroSampleRate != null) {
+      await _prefs.setDouble(DebugSettingsKeys.faroSampleRate, faroSampleRate);
+    } else {
+      await _prefs.remove(DebugSettingsKeys.faroSampleRate);
+    }
+
     state = state.copyWith(
       backendUrlOverride: () => normalizedBackend,
       faroCollectorUrlOverride: () => normalizedFaro,
+      faroSampleRateOverride: () => faroSampleRate,
     );
 
-    return prevBackend != normalizedBackend || prevFaro != normalizedFaro;
+    return prevBackend != normalizedBackend ||
+        prevFaro != normalizedFaro ||
+        prevRate != faroSampleRate;
   }
 
   String? _normalize(String? value) {
@@ -219,6 +245,7 @@ class DebugSettingsNotifier extends Notifier<DebugSettings> {
   Future<void> resetAll() async {
     await _prefs.remove(DebugSettingsKeys.backendUrl);
     await _prefs.remove(DebugSettingsKeys.faroCollectorUrl);
+    await _prefs.remove(DebugSettingsKeys.faroSampleRate);
     await _prefs.remove(DebugSettingsKeys.errorRecommendations);
     await _prefs.remove(DebugSettingsKeys.errorIngredients);
     await _prefs.remove(DebugSettingsKeys.slowRecommendations);

--- a/Mobiles/flutter/lib/core/config/debug_settings.dart
+++ b/Mobiles/flutter/lib/core/config/debug_settings.dart
@@ -1,9 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'shared_preferences_provider.dart';
+
 /// SharedPreferences keys used by debug settings. Exposed so other
-/// services (e.g. FaroCollectorService) can read the same values
-/// before Riverpod is available.
+/// services (e.g. FaroCollectorService) can read the same values.
 abstract class DebugSettingsKeys {
   static const backendUrl = 'debug_backend_url';
   static const faroCollectorUrl = 'debug_faro_collector_url';
@@ -113,57 +114,43 @@ class DebugSettings {
 }
 
 class DebugSettingsNotifier extends Notifier<DebugSettings> {
+  /// Cached, synchronously-available prefs (resolved at bootstrap and
+  /// exposed via [sharedPreferencesProvider]).
+  SharedPreferences get _prefs => ref.read(sharedPreferencesProvider);
+
   @override
-  DebugSettings build() {
-    _loadFromPrefs();
-    return const DebugSettings();
-  }
+  DebugSettings build() => _readFromPrefs();
 
-  /// Synchronously populates from prefs (best-effort). Callers who need
-  /// guaranteed up-to-date state should await [reload].
-  Future<void> _loadFromPrefs() async {
-    state = await _readFromPrefs();
-  }
-
-  Future<DebugSettings> _readFromPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
+  DebugSettings _readFromPrefs() {
     return DebugSettings(
-      backendUrlOverride: prefs.getString(DebugSettingsKeys.backendUrl),
-      faroCollectorUrlOverride: prefs.getString(
+      backendUrlOverride: _prefs.getString(DebugSettingsKeys.backendUrl),
+      faroCollectorUrlOverride: _prefs.getString(
         DebugSettingsKeys.faroCollectorUrl,
       ),
       errorOnRecommendations:
-          prefs.getBool(DebugSettingsKeys.errorRecommendations) ?? false,
+          _prefs.getBool(DebugSettingsKeys.errorRecommendations) ?? false,
       errorOnIngredients:
-          prefs.getBool(DebugSettingsKeys.errorIngredients) ?? false,
+          _prefs.getBool(DebugSettingsKeys.errorIngredients) ?? false,
       slowRecommendations:
-          prefs.getBool(DebugSettingsKeys.slowRecommendations) ?? false,
+          _prefs.getBool(DebugSettingsKeys.slowRecommendations) ?? false,
       slowIngredients:
-          prefs.getBool(DebugSettingsKeys.slowIngredients) ?? false,
+          _prefs.getBool(DebugSettingsKeys.slowIngredients) ?? false,
       useV2PizzaSchema:
-          prefs.getBool(DebugSettingsKeys.useV2PizzaSchema) ?? false,
+          _prefs.getBool(DebugSettingsKeys.useV2PizzaSchema) ?? false,
       skipAuthDepInTools:
-          prefs.getBool(DebugSettingsKeys.skipAuthDepInTools) ?? false,
+          _prefs.getBool(DebugSettingsKeys.skipAuthDepInTools) ?? false,
     );
   }
 
-  /// Force a re-read from SharedPreferences. Useful in bootstrap where
-  /// we want state to be guaranteed-loaded before the UI renders.
-  Future<void> reload() async {
-    state = await _readFromPrefs();
-  }
-
-  /// Persists both URL overrides atomically. Empty/whitespace values
-  /// clear the corresponding override.
+  /// Persists the backend URL and Faro collector URL overrides atomically.
+  /// Empty/whitespace values clear the corresponding override.
   ///
-  /// Returns `true` if either URL override actually changed, so the
-  /// caller can decide whether to show the restart banner.
+  /// Returns `true` if either override actually changed, so the caller can
+  /// decide whether to show the restart banner.
   Future<bool> saveUrls({
     required String? backendUrl,
     required String? faroCollectorUrl,
   }) async {
-    final prefs = await SharedPreferences.getInstance();
-
     final normalizedBackend = _normalize(backendUrl);
     final normalizedFaro = _normalize(faroCollectorUrl);
 
@@ -171,15 +158,18 @@ class DebugSettingsNotifier extends Notifier<DebugSettings> {
     final prevFaro = state.faroCollectorUrlOverride;
 
     if (normalizedBackend != null) {
-      await prefs.setString(DebugSettingsKeys.backendUrl, normalizedBackend);
+      await _prefs.setString(DebugSettingsKeys.backendUrl, normalizedBackend);
     } else {
-      await prefs.remove(DebugSettingsKeys.backendUrl);
+      await _prefs.remove(DebugSettingsKeys.backendUrl);
     }
 
     if (normalizedFaro != null) {
-      await prefs.setString(DebugSettingsKeys.faroCollectorUrl, normalizedFaro);
+      await _prefs.setString(
+        DebugSettingsKeys.faroCollectorUrl,
+        normalizedFaro,
+      );
     } else {
-      await prefs.remove(DebugSettingsKeys.faroCollectorUrl);
+      await _prefs.remove(DebugSettingsKeys.faroCollectorUrl);
     }
 
     state = state.copyWith(
@@ -197,51 +187,44 @@ class DebugSettingsNotifier extends Notifier<DebugSettings> {
   }
 
   Future<void> setErrorOnRecommendations(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(DebugSettingsKeys.errorRecommendations, value);
+    await _prefs.setBool(DebugSettingsKeys.errorRecommendations, value);
     state = state.copyWith(errorOnRecommendations: value);
   }
 
   Future<void> setErrorOnIngredients(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(DebugSettingsKeys.errorIngredients, value);
+    await _prefs.setBool(DebugSettingsKeys.errorIngredients, value);
     state = state.copyWith(errorOnIngredients: value);
   }
 
   Future<void> setSlowRecommendations(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(DebugSettingsKeys.slowRecommendations, value);
+    await _prefs.setBool(DebugSettingsKeys.slowRecommendations, value);
     state = state.copyWith(slowRecommendations: value);
   }
 
   Future<void> setSlowIngredients(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(DebugSettingsKeys.slowIngredients, value);
+    await _prefs.setBool(DebugSettingsKeys.slowIngredients, value);
     state = state.copyWith(slowIngredients: value);
   }
 
   Future<void> setUseV2PizzaSchema(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(DebugSettingsKeys.useV2PizzaSchema, value);
+    await _prefs.setBool(DebugSettingsKeys.useV2PizzaSchema, value);
     state = state.copyWith(useV2PizzaSchema: value);
   }
 
   Future<void> setSkipAuthDepInTools(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(DebugSettingsKeys.skipAuthDepInTools, value);
+    await _prefs.setBool(DebugSettingsKeys.skipAuthDepInTools, value);
     state = state.copyWith(skipAuthDepInTools: value);
   }
 
   Future<void> resetAll() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(DebugSettingsKeys.backendUrl);
-    await prefs.remove(DebugSettingsKeys.faroCollectorUrl);
-    await prefs.remove(DebugSettingsKeys.errorRecommendations);
-    await prefs.remove(DebugSettingsKeys.errorIngredients);
-    await prefs.remove(DebugSettingsKeys.slowRecommendations);
-    await prefs.remove(DebugSettingsKeys.slowIngredients);
-    await prefs.remove(DebugSettingsKeys.useV2PizzaSchema);
-    await prefs.remove(DebugSettingsKeys.skipAuthDepInTools);
+    await _prefs.remove(DebugSettingsKeys.backendUrl);
+    await _prefs.remove(DebugSettingsKeys.faroCollectorUrl);
+    await _prefs.remove(DebugSettingsKeys.errorRecommendations);
+    await _prefs.remove(DebugSettingsKeys.errorIngredients);
+    await _prefs.remove(DebugSettingsKeys.slowRecommendations);
+    await _prefs.remove(DebugSettingsKeys.slowIngredients);
+    await _prefs.remove(DebugSettingsKeys.useV2PizzaSchema);
+    await _prefs.remove(DebugSettingsKeys.skipAuthDepInTools);
     state = const DebugSettings();
   }
 }

--- a/Mobiles/flutter/lib/core/config/faro_collector_service.dart
+++ b/Mobiles/flutter/lib/core/config/faro_collector_service.dart
@@ -3,9 +3,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'config_service.dart';
 import 'debug_settings.dart';
+import 'shared_preferences_provider.dart';
 
 final faroCollectorServiceProvider = Provider<FaroCollectorService>((ref) {
-  return const FaroCollectorService();
+  return FaroCollectorService(ref.watch(sharedPreferencesProvider));
 });
 
 /// Thin wrapper around the Faro collector URL source.
@@ -14,16 +15,17 @@ final faroCollectorServiceProvider = Provider<FaroCollectorService>((ref) {
 /// directly, because it transparently applies any runtime override the
 /// user saved from the debug Config screen.
 class FaroCollectorService {
-  const FaroCollectorService();
+  const FaroCollectorService(this._prefs);
+
+  final SharedPreferences _prefs;
 
   /// Returns the effective collector URL to use for this session.
   ///
   /// Order of precedence:
   /// 1. Override in SharedPreferences (set via debug Config screen)
   /// 2. Build-time env (`FARO_COLLECTOR_URL`)
-  Future<String> getUrl() async {
-    final prefs = await SharedPreferences.getInstance();
-    final override = prefs.getString(DebugSettingsKeys.faroCollectorUrl);
+  String getUrl() {
+    final override = _prefs.getString(DebugSettingsKeys.faroCollectorUrl);
     if (override != null && override.trim().isNotEmpty) {
       return override.trim();
     }

--- a/Mobiles/flutter/lib/core/config/faro_sample_rate_service.dart
+++ b/Mobiles/flutter/lib/core/config/faro_sample_rate_service.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'debug_settings.dart';
+import 'shared_preferences_provider.dart';
+
+/// Default Faro session sampling rate when no override is saved: sample every
+/// session (100%). Matches Faro's own default of `SamplingRate(1.0)`.
+const double kDefaultFaroSampleRate = 1.0;
+
+final faroSampleRateServiceProvider = Provider<FaroSampleRateService>((ref) {
+  return FaroSampleRateService(ref.watch(sharedPreferencesProvider));
+});
+
+/// Thin wrapper around the Faro session sampling-rate source.
+///
+/// The value only takes effect when Faro initializes (the sampling decision is
+/// made once per session at startup), so changing the override requires an app
+/// restart — same as the collector URL.
+class FaroSampleRateService {
+  const FaroSampleRateService(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  /// Returns the effective sampling rate (0.0–1.0) to use for this session.
+  ///
+  /// Order of precedence:
+  /// 1. Override in SharedPreferences (set via debug Config screen)
+  /// 2. [kDefaultFaroSampleRate]
+  ///
+  /// Any out-of-range persisted value is clamped defensively.
+  double getRate() {
+    final override = _prefs.getDouble(DebugSettingsKeys.faroSampleRate);
+    if (override == null) return kDefaultFaroSampleRate;
+    return override.clamp(0.0, 1.0);
+  }
+}

--- a/Mobiles/flutter/lib/core/config/runtime_config.dart
+++ b/Mobiles/flutter/lib/core/config/runtime_config.dart
@@ -23,16 +23,14 @@ class RuntimeConfig {
   final String faroCollectorUrl;
 }
 
-/// Resolves the effective backend + Faro URLs once, via the service
-/// providers. Bootstrap awaits [runtimeConfigProvider.future] before
-/// running the app, so downstream consumers can safely use
-/// `ref.watch(runtimeConfigProvider).requireValue` without dealing
-/// with a loading state.
-final runtimeConfigProvider = FutureProvider<RuntimeConfig>((ref) async {
-  final backendBaseUrl = await ref.watch(backendUrlServiceProvider).getUrl();
-  final faroCollectorUrl = await ref
-      .watch(faroCollectorServiceProvider)
-      .getUrl();
+/// Resolves the effective backend + Faro values once, via the service
+/// providers. These reads are synchronous because the underlying
+/// [SharedPreferences] instance is resolved once at bootstrap and exposed
+/// via [sharedPreferencesProvider], so consumers can read
+/// `ref.watch(runtimeConfigProvider)` directly without a loading state.
+final runtimeConfigProvider = Provider<RuntimeConfig>((ref) {
+  final backendBaseUrl = ref.watch(backendUrlServiceProvider).getUrl();
+  final faroCollectorUrl = ref.watch(faroCollectorServiceProvider).getUrl();
   return RuntimeConfig(
     backendBaseUrl: backendBaseUrl,
     faroCollectorUrl: faroCollectorUrl,

--- a/Mobiles/flutter/lib/core/config/runtime_config.dart
+++ b/Mobiles/flutter/lib/core/config/runtime_config.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'backend_url_service.dart';
 import 'faro_collector_service.dart';
+import 'faro_sample_rate_service.dart';
 
 /// Immutable snapshot of configuration values captured once at app
 /// bootstrap and held for the lifetime of the session.
@@ -17,10 +18,15 @@ class RuntimeConfig {
   const RuntimeConfig({
     required this.backendBaseUrl,
     required this.faroCollectorUrl,
+    required this.faroSampleRate,
   });
 
   final String backendBaseUrl;
   final String faroCollectorUrl;
+
+  /// Faro session sampling rate (0.0–1.0) that Faro actually initialized with
+  /// this session.
+  final double faroSampleRate;
 }
 
 /// Resolves the effective backend + Faro values once, via the service
@@ -31,8 +37,10 @@ class RuntimeConfig {
 final runtimeConfigProvider = Provider<RuntimeConfig>((ref) {
   final backendBaseUrl = ref.watch(backendUrlServiceProvider).getUrl();
   final faroCollectorUrl = ref.watch(faroCollectorServiceProvider).getUrl();
+  final faroSampleRate = ref.watch(faroSampleRateServiceProvider).getRate();
   return RuntimeConfig(
     backendBaseUrl: backendBaseUrl,
     faroCollectorUrl: faroCollectorUrl,
+    faroSampleRate: faroSampleRate,
   );
 });

--- a/Mobiles/flutter/lib/core/config/shared_preferences_provider.dart
+++ b/Mobiles/flutter/lib/core/config/shared_preferences_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Exposes a resolved [SharedPreferences] instance to the provider tree so
+/// config services can read overrides *synchronously* instead of each
+/// awaiting `SharedPreferences.getInstance()`.
+///
+/// `bootstrap` awaits `getInstance()` once and overrides this provider with
+/// the concrete instance (see [sharedPreferencesProvider] override there).
+/// It intentionally throws if read without that override so a missing setup
+/// fails loudly rather than silently returning defaults.
+final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
+  throw StateError(
+    'sharedPreferencesProvider must be overridden with a resolved '
+    'SharedPreferences instance (done in bootstrap / tests).',
+  );
+});
+
+/// Builds the app's root [ProviderContainer] with [SharedPreferences]
+/// resolved up front and bound to [sharedPreferencesProvider].
+///
+/// Resolving prefs here is what lets config services (backend URL, Faro
+/// collector) and debug settings read overrides synchronously
+/// instead of each awaiting `getInstance()`. Keeping the wiring next to the
+/// provider means callers (bootstrap) just do:
+///
+/// ```dart
+/// final container = await createAppProviderContainer();
+/// ```
+Future<ProviderContainer> createAppProviderContainer() async {
+  final prefs = await SharedPreferences.getInstance();
+  return ProviderContainer(
+    overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+  );
+}

--- a/Mobiles/flutter/lib/core/o11y/demo_rum/demo_rum_init.dart
+++ b/Mobiles/flutter/lib/core/o11y/demo_rum/demo_rum_init.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'sdk/demo_rum.dart';
+
+/// Owns startup + configuration for the made-up [DemoRum] SDK.
+///
+/// DemoRum runs *alongside* Grafana Faro to demo two mobile RUM SDKs coexisting
+/// in one app. It's a no-op stand-in (see `sdk/demo_rum.dart`), so unlike Faro
+/// it has no endpoint/credentials to configure and can't fail — it always
+/// "initializes" and runs the app.
+///
+/// [startDemoRum] runs as the OUTER half of the telemetry nesting
+/// (`startFaro` is the inner half). DemoRum installs *chained*
+/// `FlutterError.onError` / `PlatformDispatcher.onError` handlers (echo-only,
+/// see `sdk/demo_rum.dart`), exactly as a real cooperating SDK would. Because
+/// both DemoRum and Faro chain (save + call the previous handler), init order
+/// only decides who runs first, not who captures — both observe every error.
+Future<void> startDemoRum({
+  required String appEnv,
+  required String appVersion,
+  required FutureOr<void> Function() appRunner,
+}) async {
+  await DemoRum.init((options) {
+    options.environment = appEnv;
+    options.release = 'quickpizza-flutter@$appVersion';
+
+    // Echo every signal to the console so the demo can *show* the second SDK
+    // receiving the same telemetry as Faro. A real SDK would send to a backend.
+    options.echoToConsole = true;
+  }, appRunner: appRunner);
+}
+
+/// Wraps the app root with DemoRum's widget. Composed by `bootstrap` as
+/// `wrapWithDemoRum(wrapWithFaro(app))`, mirroring where a real SDK's root
+/// widget would sit above `MaterialApp`.
+Widget wrapWithDemoRum(Widget child) => DemoRumWidget(child: child);

--- a/Mobiles/flutter/lib/core/o11y/demo_rum/sdk/demo_rum.dart
+++ b/Mobiles/flutter/lib/core/o11y/demo_rum/sdk/demo_rum.dart
@@ -1,0 +1,316 @@
+/// DemoRum — a made-up, no-op RUM SDK used purely for demonstration.
+///
+/// This app's real instrumentation is **Grafana Faro**. DemoRum exists to show
+/// how you would run a *second* RUM SDK side by side with Faro: the shared
+/// `core/o11y/` layer fans every error / log / event / span out to both Faro
+/// and DemoRum, so you can see the exact call sites a second SDK would plug
+/// into.
+///
+/// It is intentionally a **stand-in**: every method is a no-op that (optionally)
+/// echoes to the console instead of sending anything over the network. That
+/// keeps the demo free of any third-party SDK or service. The public API here
+/// is deliberately shaped like a typical mobile RUM SDK (init + options, a root
+/// widget, a navigation observer, an HTTP client wrapper, exception capture,
+/// structured logs, scope/user, and spans), so to wire up a *real* SDK you can
+/// swap this file's types for the vendor's and keep the surrounding code
+/// essentially unchanged.
+///
+/// A few things do real work so the demo is honest and the app keeps
+/// functioning: [DemoRum.startSpan] runs its callback and returns the result,
+/// [DemoRumHttpClient] forwards the request to its inner client (and echoes
+/// it), and [DemoRum.init] installs *chained* `FlutterError.onError` /
+/// `PlatformDispatcher.onError` handlers (the same cooperative pattern real
+/// SDKs use) that echo and then delegate to the previously-installed handler.
+/// Nothing is ever sent over the network.
+library;
+
+import 'dart:async';
+import 'dart:developer' as developer;
+import 'dart:ui' show PlatformDispatcher;
+
+import 'package:flutter/widgets.dart';
+import 'package:http/http.dart' as http;
+
+/// Status a span can finish in. Mirrors the ok/error split every RUM SDK has.
+enum DemoRumSpanStatus { ok, error }
+
+/// Build-time configuration handed to [DemoRum.init]. A real SDK would also
+/// take an ingest endpoint + API key/client token (plus knobs like a traces
+/// sample rate) here; this stand-in keeps the identity fields worth showing in
+/// the demo plus one knob it actually honors: [echoToConsole].
+class DemoRumOptions {
+  String environment = '';
+  String release = '';
+
+  /// When true, DemoRum echoes every (otherwise no-op) call to the console so
+  /// you can *see* the second SDK receiving the same telemetry as Faro. A real
+  /// SDK would send to its backend instead; this is the demo's stand-in for
+  /// "where do signals go?".
+  bool echoToConsole = true;
+}
+
+/// Entry point for the made-up RUM SDK.
+class DemoRum {
+  const DemoRum._();
+
+  /// Backs [DemoRumOptions.echoToConsole]; set once from [init]. Defaults to
+  /// true so calls made before/without init still surface during a demo.
+  static bool _echoToConsole = true;
+
+  static final DemoRumLogger logger = DemoRumLogger._();
+
+  /// Initializes the SDK and then runs the app. Mirrors the
+  /// `Sdk.init(configure, appRunner: ...)` shape common to Flutter RUM SDKs.
+  static Future<void> init(
+    void Function(DemoRumOptions options) configure, {
+    required FutureOr<void> Function() appRunner,
+  }) async {
+    final options = DemoRumOptions();
+    configure(options);
+    _echoToConsole = options.echoToConsole;
+    _echo('init', {
+      'environment': options.environment,
+      'release': options.release,
+    });
+    _installErrorHandlers();
+    await appRunner();
+  }
+
+  /// Installs *chained* global error handlers — the real cooperative pattern a
+  /// RUM SDK uses: save the handler that's already installed, run our own
+  /// (here just an echo), then call the saved one so nothing downstream is
+  /// swallowed. Because DemoRum inits before Faro, the resulting chain is
+  /// Faro → DemoRum → Flutter default, so both SDKs observe every error. This
+  /// is why init order between cooperating SDKs doesn't decide *who* captures,
+  /// only who runs first.
+  static void _installErrorHandlers() {
+    if (_handlersInstalled) return;
+    _handlersInstalled = true;
+
+    final previousOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      _echo('FlutterError.onError', {'exception': details.exceptionAsString()});
+      previousOnError?.call(details);
+    };
+
+    final previousPlatformOnError = PlatformDispatcher.instance.onError;
+    PlatformDispatcher.instance.onError = (error, stack) {
+      _echo('PlatformDispatcher.onError', {'exception': error.toString()});
+      return previousPlatformOnError?.call(error, stack) ?? false;
+    };
+  }
+
+  static bool _handlersInstalled = false;
+
+  /// Reports a handled exception. [withScope] lets the caller attach tags /
+  /// contexts / user for just this event, matching the common SDK signature.
+  static void captureException(
+    Object throwable, {
+    StackTrace? stackTrace,
+    void Function(DemoRumScope scope)? withScope,
+  }) {
+    final scope = DemoRumScope();
+    withScope?.call(scope);
+    _echo('captureException', {
+      'exception': throwable.toString(),
+      if (stackTrace != null) 'hasStackTrace': true,
+      ...scope._snapshot(),
+    });
+  }
+
+  /// Mutates the global scope (user, tags, contexts) that future signals carry.
+  static void configureScope(void Function(DemoRumScope scope) configure) {
+    final scope = DemoRumScope();
+    configure(scope);
+    _echo('configureScope', scope._snapshot());
+  }
+
+  /// Runs [body] inside a span named [name] and finishes it automatically,
+  /// marking it failed if [body] throws. The body IS executed (and its result
+  /// returned), so instrumenting a call site with a span never changes app
+  /// behavior.
+  static FutureOr<T> startSpan<T>(
+    String name,
+    FutureOr<T> Function(DemoRumSpan span) body, {
+    Map<String, Object> attributes = const {},
+    DemoRumSpan? parentSpan,
+  }) {
+    final span = startInactiveSpan(
+      name,
+      attributes: attributes,
+      parentSpan: parentSpan,
+    );
+    try {
+      final result = body(span);
+      if (result is Future<T>) {
+        return result.then(
+          (value) {
+            span.end();
+            return value;
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            span.status = DemoRumSpanStatus.error;
+            span.end();
+            throw error;
+          },
+        );
+      }
+      span.end();
+      return result;
+    } catch (_) {
+      span.status = DemoRumSpanStatus.error;
+      span.end();
+      rethrow;
+    }
+  }
+
+  /// Starts a span whose lifecycle the caller owns (must call [DemoRumSpan.end]).
+  static DemoRumSpan startInactiveSpan(
+    String name, {
+    Map<String, Object> attributes = const {},
+    DemoRumSpan? parentSpan,
+  }) {
+    _echo('startSpan', {'name': name, if (parentSpan != null) 'parent': parentSpan.name});
+    return DemoRumSpan._(name, attributes);
+  }
+
+  static void _echo(String api, Map<String, Object?> fields) {
+    if (!_echoToConsole) return;
+    final details = fields.entries.map((e) => '${e.key}=${e.value}').join(', ');
+    developer.log(details.isEmpty ? api : '$api($details)', name: 'DemoRum');
+  }
+}
+
+/// Structured-log surface. Mirrors `sdk.logger.debug/info/warn/error(...)`.
+class DemoRumLogger {
+  DemoRumLogger._();
+
+  void debug(String message, {Map<String, Object>? attributes}) =>
+      DemoRum._echo('log.debug', {'message': message, ...?attributes});
+
+  void info(String message, {Map<String, Object>? attributes}) =>
+      DemoRum._echo('log.info', {'message': message, ...?attributes});
+
+  void warn(String message, {Map<String, Object>? attributes}) =>
+      DemoRum._echo('log.warn', {'message': message, ...?attributes});
+
+  void error(String message, {Map<String, Object>? attributes}) =>
+      DemoRum._echo('log.error', {'message': message, ...?attributes});
+}
+
+/// Per-event / global scope. Collects the metadata a real SDK would attach.
+class DemoRumScope {
+  DemoRumUser? _user;
+  final Map<String, String> _tags = {};
+  final Map<String, Map<String, String>> _contexts = {};
+
+  void setUser(DemoRumUser? user) => _user = user;
+
+  void setTag(String key, String value) => _tags[key] = value;
+
+  void setContexts(String key, Map<String, String> context) =>
+      _contexts[key] = context;
+
+  Map<String, Object?> _snapshot() => {
+    if (_user != null) 'user': _user!.id ?? _user!.email ?? _user!.username,
+    if (_tags.isNotEmpty) 'tags': _tags,
+    if (_contexts.isNotEmpty) 'contexts': _contexts,
+  };
+}
+
+/// Identity attached to the scope.
+class DemoRumUser {
+  DemoRumUser({this.id, this.username, this.email, this.data});
+
+  final String? id;
+  final String? username;
+  final String? email;
+  final Map<String, String>? data;
+}
+
+/// A span/segment. Attributes and status are recorded (echoed); nothing is sent.
+class DemoRumSpan {
+  DemoRumSpan._(this.name, Map<String, Object> attributes)
+    : _attributes = {...attributes};
+
+  final String name;
+  final Map<String, Object> _attributes;
+  DemoRumSpanStatus status = DemoRumSpanStatus.ok;
+  bool _ended = false;
+
+  void setAttribute(String key, Object value) {
+    _attributes[key] = value;
+    DemoRum._echo('span.setAttribute', {'span': name, key: value});
+  }
+
+  void end() {
+    if (_ended) return;
+    _ended = true;
+    DemoRum._echo('span.end', {'name': name, 'status': status.name});
+  }
+}
+
+/// Root widget wrapper. A real SDK anchors screenshot / view-hierarchy / replay
+/// capture here; the stand-in just returns its child unchanged.
+class DemoRumWidget extends StatelessWidget {
+  const DemoRumWidget({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => child;
+}
+
+/// Navigation observer. A real SDK derives screen/transaction names from routes
+/// here; the stand-in just echoes a `screen.view` for whichever route becomes
+/// visible after each transition. `didRemove` and the user-gesture callbacks
+/// are intentionally ignored — they rarely map to a visible screen change and
+/// would only add console noise.
+class DemoRumNavigatorObserver extends NavigatorObserver {
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    // The pushed route is now on top.
+    _echoScreenView(route);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    // `route` was popped; `previousRoute` is visible again.
+    _echoScreenView(previousRoute);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    // `newRoute` took `oldRoute`'s place on top.
+    _echoScreenView(newRoute);
+  }
+
+  void _echoScreenView(Route<dynamic>? route) {
+    final name = route?.settings.name;
+    if (name != null) DemoRum._echo('screen.view', {'name': name});
+  }
+}
+
+/// HTTP client wrapper. A real SDK would time the request and emit an HTTP span
+/// here; the stand-in forwards to its inner client so traffic still flows (and
+/// Faro's HttpOverrides underneath still does the real instrumentation).
+class DemoRumHttpClient extends http.BaseClient {
+  DemoRumHttpClient({required http.Client client}) : _inner = client;
+
+  final http.Client _inner;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    DemoRum._echo('http', {'method': request.method, 'url': request.url.toString()});
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}

--- a/Mobiles/flutter/lib/core/o11y/demo_rum/sdk/demo_rum.dart
+++ b/Mobiles/flutter/lib/core/o11y/demo_rum/sdk/demo_rum.dart
@@ -151,7 +151,7 @@ class DemoRum {
           onError: (Object error, StackTrace stackTrace) {
             span.status = DemoRumSpanStatus.error;
             span.end();
-            throw error;
+            Error.throwWithStackTrace(error, stackTrace);
           },
         );
       }

--- a/Mobiles/flutter/lib/core/o11y/errors/o11y_errors.dart
+++ b/Mobiles/flutter/lib/core/o11y/errors/o11y_errors.dart
@@ -1,10 +1,26 @@
 import 'package:faro/faro.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../demo_rum/sdk/demo_rum.dart';
 import '../faro/faro.dart';
 
-final o11yErrorsProvider = Provider<O11yErrors>((ref) {
+final faroO11yErrorsProvider = Provider<O11yErrors>((ref) {
   return FaroO11yErrors(faro: ref.watch(faroProvider));
+});
+
+final demoRumO11yErrorsProvider = Provider<O11yErrors>((ref) {
+  return DemoRumO11yErrors();
+});
+
+/// Fans manual error reports out to every configured RUM SDK (Faro +
+/// DemoRum) so both receive the same handled exceptions.
+final o11yErrorsProvider = Provider<O11yErrors>((ref) {
+  return CompositeO11yErrors(
+    delegates: [
+      ref.watch(faroO11yErrorsProvider),
+      ref.watch(demoRumO11yErrorsProvider),
+    ],
+  );
 });
 
 abstract class O11yErrors {
@@ -14,6 +30,43 @@ abstract class O11yErrors {
     StackTrace? stacktrace,
     Map<String, String>? context,
   });
+}
+
+/// Wraps a synthesized manual error so an SDK has a throwable to capture.
+/// The caller's [type] is surfaced as a tag (`o11y.error_type`) since the
+/// exception type is fixed to this class.
+class O11yReportedException implements Exception {
+  O11yReportedException({required this.type, required this.value});
+
+  final String type;
+  final String value;
+
+  @override
+  String toString() => '$type: $value';
+}
+
+class CompositeO11yErrors implements O11yErrors {
+  CompositeO11yErrors({required List<O11yErrors> delegates})
+    : _delegates = delegates;
+
+  final List<O11yErrors> _delegates;
+
+  @override
+  void reportError({
+    required String type,
+    required String error,
+    StackTrace? stacktrace,
+    Map<String, String>? context,
+  }) {
+    for (final delegate in _delegates) {
+      delegate.reportError(
+        type: type,
+        error: error,
+        stacktrace: stacktrace,
+        context: context,
+      );
+    }
+  }
 }
 
 class FaroO11yErrors implements O11yErrors {
@@ -33,6 +86,27 @@ class FaroO11yErrors implements O11yErrors {
       value: error,
       stacktrace: stacktrace,
       context: context,
+    );
+  }
+}
+
+class DemoRumO11yErrors implements O11yErrors {
+  @override
+  void reportError({
+    required String type,
+    required String error,
+    StackTrace? stacktrace,
+    Map<String, String>? context,
+  }) {
+    DemoRum.captureException(
+      O11yReportedException(type: type, value: error),
+      stackTrace: stacktrace,
+      withScope: (scope) {
+        scope.setTag('o11y.error_type', type);
+        if (context != null && context.isNotEmpty) {
+          scope.setContexts('o11y', context);
+        }
+      },
     );
   }
 }

--- a/Mobiles/flutter/lib/core/o11y/events/o11y_events.dart
+++ b/Mobiles/flutter/lib/core/o11y/events/o11y_events.dart
@@ -1,10 +1,25 @@
 import 'package:faro/faro.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../demo_rum/sdk/demo_rum.dart';
 import '../faro/faro.dart';
 
-final o11yEventsProvider = Provider<O11yEvents>((ref) {
+final faroO11yEventsProvider = Provider<O11yEvents>((ref) {
   return FaroO11yEvents(faro: ref.watch(faroProvider));
+});
+
+final demoRumO11yEventsProvider = Provider<O11yEvents>((ref) {
+  return DemoRumO11yEvents();
+});
+
+/// Fans custom events and user identity out to every configured RUM SDK.
+final o11yEventsProvider = Provider<O11yEvents>((ref) {
+  return CompositeO11yEvents(
+    delegates: [
+      ref.watch(faroO11yEventsProvider),
+      ref.watch(demoRumO11yEventsProvider),
+    ],
+  );
 });
 
 abstract class O11yEvents {
@@ -16,6 +31,37 @@ abstract class O11yEvents {
     String? email,
     Map<String, String>? attributes,
   });
+}
+
+class CompositeO11yEvents implements O11yEvents {
+  CompositeO11yEvents({required List<O11yEvents> delegates})
+    : _delegates = delegates;
+
+  final List<O11yEvents> _delegates;
+
+  @override
+  void trackEvent(String name, {Map<String, String>? context}) {
+    for (final delegate in _delegates) {
+      delegate.trackEvent(name, context: context);
+    }
+  }
+
+  @override
+  void setUser({
+    String? id,
+    String? name,
+    String? email,
+    Map<String, String>? attributes,
+  }) {
+    for (final delegate in _delegates) {
+      delegate.setUser(
+        id: id,
+        name: name,
+        email: email,
+        attributes: attributes,
+      );
+    }
+  }
 }
 
 class FaroO11yEvents implements O11yEvents {
@@ -38,12 +84,52 @@ class FaroO11yEvents implements O11yEvents {
     final user =
         id == null && name == null && email == null && attributes == null
         ? FaroUser.cleared()
-        : FaroUser(
+          : FaroUser(
             id: id,
             username: name,
             email: email,
             attributes: attributes,
           );
     _faro.setUser(user);
+  }
+}
+
+/// Many RUM SDKs have no first-class custom-event stream like Faro, so we
+/// route [trackEvent] into the SDK's structured Logs. The
+/// `telemetry.type=event` attribute keeps these separable from real logs
+/// emitted by [DemoRumO11yLogger]. [setUser] maps to the SDK scope user.
+class DemoRumO11yEvents implements O11yEvents {
+  @override
+  void trackEvent(String name, {Map<String, String>? context}) {
+    final attributes = <String, Object>{
+      'telemetry.type': 'event',
+      'event.name': name,
+    };
+    context?.forEach((k, v) => attributes[k] = v);
+    DemoRum.logger.info(name, attributes: attributes);
+  }
+
+  @override
+  void setUser({
+    String? id,
+    String? name,
+    String? email,
+    Map<String, String>? attributes,
+  }) {
+    // Clear the scope user when no identifier is provided (matches
+    // FaroUser.cleared() semantics).
+    final hasIdentity = id != null || name != null || email != null;
+    DemoRum.configureScope((scope) {
+      scope.setUser(
+        hasIdentity
+            ? DemoRumUser(
+                id: id,
+                username: name,
+                email: email,
+                data: attributes,
+              )
+            : null,
+      );
+    });
   }
 }

--- a/Mobiles/flutter/lib/core/o11y/faro/faro_data_collection_provider.dart
+++ b/Mobiles/flutter/lib/core/o11y/faro/faro_data_collection_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'faro.dart';
+
+/// Exposes Faro's global data-collection switch (`Faro().enableDataCollection`)
+/// as reactive state for the debug UI.
+///
+/// Unlike the URL / sample-rate overrides, this takes effect **immediately**:
+/// the Faro transport checks the flag on every send. Faro also persists the
+/// value across app restarts on its own (via its `DataCollectionPolicy`), so
+/// there is no separate SharedPreferences plumbing here — this notifier is just
+/// a thin, reactive mirror of the SDK's own state.
+final faroDataCollectionProvider =
+    NotifierProvider<FaroDataCollectionNotifier, bool>(
+      FaroDataCollectionNotifier.new,
+    );
+
+class FaroDataCollectionNotifier extends Notifier<bool> {
+  @override
+  bool build() => ref.read(faroProvider).enableDataCollection;
+
+  /// Enable or disable Faro telemetry collection live. Persisted by Faro.
+  void setEnabled(bool value) {
+    ref.read(faroProvider).enableDataCollection = value;
+    state = value;
+  }
+}

--- a/Mobiles/flutter/lib/core/o11y/faro/faro_init.dart
+++ b/Mobiles/flutter/lib/core/o11y/faro/faro_init.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:faro/faro.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../config/runtime_config.dart';
+import '../../utils/faro_utils.dart';
+import 'faro.dart';
+
+/// Installs Faro's [HttpOverrides] so the SDK can auto-instrument HTTP.
+///
+/// IMPORTANT: call this BEFORE anything constructs an `http.Client`! The http
+/// package uses `IOClient` on mobile, which creates its `HttpClient` at
+/// construction time — if the override is installed afterwards, that client
+/// (and, since [apiClientProvider] is a cached singleton, the whole app) will
+/// bypass Faro's HTTP interception. `bootstrap` therefore calls this right
+/// after `WidgetsFlutterBinding.ensureInitialized()` — before the provider
+/// container, provider reads, and session restore — not inside [startFaro]
+/// (which runs much later, wrapping the app runner).
+void installFaroHttpOverrides() {
+  HttpOverrides.global = FaroHttpOverrides(HttpOverrides.current);
+}
+
+/// Owns all Grafana Faro SDK startup and configuration for QuickPizza.
+///
+/// Runs as the INNER half of the telemetry nesting (`startDemoRum` is the
+/// outer half) — a convention, not a requirement. [Faro.runApp] installs
+/// Faro's chained `FlutterError.onError` / `PlatformDispatcher.onError`
+/// handlers; because both SDKs chain (save + call the previously-installed
+/// handler), either init order lets both observe the same Dart errors. See
+/// [startDemoRum] for the full rationale.
+Future<void> startFaro({
+  required ProviderContainer container,
+  required String appEnv,
+  required String appVersion,
+  required FutureOr<void> Function() appRunner,
+}) async {
+  final faroCollectorUrl = container
+      .read(runtimeConfigProvider)
+      .faroCollectorUrl;
+  final apiKey = extractTokenFromCollectorUrl(faroCollectorUrl);
+  final faro = container.read(faroProvider);
+
+  faro.transports.add(
+    OfflineTransport(maxCacheDuration: const Duration(days: 3)),
+  );
+
+  await faro.runApp(
+    optionsConfiguration: FaroConfig(
+      appName: 'QuickPizza_Flutter',
+      appVersion: appVersion,
+      appEnv: appEnv,
+      apiKey: apiKey,
+      collectorUrl: faroCollectorUrl,
+      cpuUsageVitals: true,
+      memoryUsageVitals: true,
+      anrTracking: true,
+      refreshRateVitals: true,
+      fetchVitalsInterval: const Duration(seconds: 30),
+      enableCrashReporting: true,
+    ),
+    appRunner: appRunner,
+  );
+}
+
+/// Wraps the app root with Faro's tracking widgets. Composed by `bootstrap`
+/// as `wrapWithDemoRum(wrapWithFaro(app))`.
+Widget wrapWithFaro(Widget child) =>
+    FaroAssetTracking(child: FaroUserInteractionWidget(child: child));

--- a/Mobiles/flutter/lib/core/o11y/faro/faro_init.dart
+++ b/Mobiles/flutter/lib/core/o11y/faro/faro_init.dart
@@ -37,9 +37,8 @@ Future<void> startFaro({
   required String appVersion,
   required FutureOr<void> Function() appRunner,
 }) async {
-  final faroCollectorUrl = container
-      .read(runtimeConfigProvider)
-      .faroCollectorUrl;
+  final runtimeConfig = container.read(runtimeConfigProvider);
+  final faroCollectorUrl = runtimeConfig.faroCollectorUrl;
   final apiKey = extractTokenFromCollectorUrl(faroCollectorUrl);
   final faro = container.read(faroProvider);
 
@@ -54,6 +53,25 @@ Future<void> startFaro({
       appEnv: appEnv,
       apiKey: apiKey,
       collectorUrl: faroCollectorUrl,
+      // Session sampling rate (0.0–1.0), overridable via debug Config screen.
+      // Decided once per session at init, hence the restart-to-apply semantics.
+      sampling: SamplingRate(runtimeConfig.faroSampleRate),
+      // Alternatively, Faro supports a callback-style sampler for dynamic,
+      // per-session decisions based on the session metadata available at init
+      // (user, app env, custom session attributes, ...). Swap the line above
+      // for something like this:
+      //
+      // sampling: SamplingFunction((context) {
+      //   // Always sample beta users
+      //   if (context.meta.user?.attributes?['role'] == 'beta') {
+      //     return 1.0;
+      //   }
+      //   // Sample only 10% of production sessions
+      //   if (context.meta.app?.environment == 'production') {
+      //     return 0.1;
+      //   }
+      //   return runtimeConfig.faroSampleRate;
+      // }),
       cpuUsageVitals: true,
       memoryUsageVitals: true,
       anrTracking: true,

--- a/Mobiles/flutter/lib/core/o11y/loggers/o11y_logger.dart
+++ b/Mobiles/flutter/lib/core/o11y/loggers/o11y_logger.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'package:faro/faro.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../demo_rum/sdk/demo_rum.dart';
 import '../faro/faro.dart';
 
 final consoleO11yLoggerProvider = Provider((ref) {
@@ -13,11 +14,16 @@ final faroO11yLoggerProvider = Provider((ref) {
   return FaroO11yLogger(faro: ref.watch(faroProvider));
 });
 
+final demoRumO11yLoggerProvider = Provider((ref) {
+  return DemoRumO11yLogger();
+});
+
 final o11yLoggerProvider = Provider<O11yLogger>((ref) {
-  return MultiO11yLogger(
-    loggers: [
+  return CompositeO11yLogger(
+    delegates: [
       ref.watch(consoleO11yLoggerProvider),
       ref.watch(faroO11yLoggerProvider),
+      ref.watch(demoRumO11yLoggerProvider),
     ],
   );
 });
@@ -33,22 +39,23 @@ abstract class O11yLogger {
   });
 }
 
-class MultiO11yLogger implements O11yLogger {
-  MultiO11yLogger({required List<O11yLogger> loggers}) : _loggers = loggers;
+class CompositeO11yLogger implements O11yLogger {
+  CompositeO11yLogger({required List<O11yLogger> delegates})
+    : _delegates = delegates;
 
-  final List<O11yLogger> _loggers;
+  final List<O11yLogger> _delegates;
 
   @override
   void debug(String message, {Map<String, String>? context}) {
-    for (final logger in _loggers) {
-      logger.debug(message, context: context);
+    for (final delegate in _delegates) {
+      delegate.debug(message, context: context);
     }
   }
 
   @override
   void warning(String message, {Map<String, String>? context}) {
-    for (final logger in _loggers) {
-      logger.warning(message, context: context);
+    for (final delegate in _delegates) {
+      delegate.warning(message, context: context);
     }
   }
 
@@ -59,8 +66,8 @@ class MultiO11yLogger implements O11yLogger {
     StackTrace? stackTrace,
     Map<String, String>? context,
   }) {
-    for (final logger in _loggers) {
-      logger.error(
+    for (final delegate in _delegates) {
+      delegate.error(
         message,
         error: error,
         stackTrace: stackTrace,
@@ -148,5 +155,42 @@ class FaroO11yLogger implements O11yLogger {
       allContext = {...allContext, 'stackTrace': stackTrace.toString()};
     }
     _faro.pushLog(message, level: LogLevel.error, context: allContext);
+  }
+}
+
+/// Routes O11y logs into the DemoRum SDK's structured Logs. Context entries
+/// become attributes.
+class DemoRumO11yLogger implements O11yLogger {
+  static Map<String, Object> _attributes(
+    Map<String, String>? context, [
+    Map<String, String>? extra,
+  ]) {
+    final attributes = <String, Object>{};
+    context?.forEach((k, v) => attributes[k] = v);
+    extra?.forEach((k, v) => attributes[k] = v);
+    return attributes;
+  }
+
+  @override
+  void debug(String message, {Map<String, String>? context}) {
+    DemoRum.logger.debug(message, attributes: _attributes(context));
+  }
+
+  @override
+  void warning(String message, {Map<String, String>? context}) {
+    DemoRum.logger.warn(message, attributes: _attributes(context));
+  }
+
+  @override
+  void error(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, String>? context,
+  }) {
+    final extra = <String, String>{};
+    if (error != null) extra['error'] = error.toString();
+    if (stackTrace != null) extra['stackTrace'] = stackTrace.toString();
+    DemoRum.logger.error(message, attributes: _attributes(context, extra));
   }
 }

--- a/Mobiles/flutter/lib/core/o11y/traces/o11y_traces.dart
+++ b/Mobiles/flutter/lib/core/o11y/traces/o11y_traces.dart
@@ -3,27 +3,187 @@ import 'dart:async';
 import 'package:faro/faro.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../demo_rum/sdk/demo_rum.dart';
 import '../faro/faro.dart';
 
-final o11yTracesProvider = Provider<O11yTraces>((ref) {
+final faroO11yTracesProvider = Provider<O11yTraces>((ref) {
   return FaroO11yTraces(faro: ref.watch(faroProvider));
 });
 
+final demoRumO11yTracesProvider = Provider<O11yTraces>((ref) {
+  return DemoRumO11yTraces();
+});
+
+/// Fans span creation out to every configured RUM SDK (Faro + DemoRum) so a
+/// single instrumented operation is recorded as a span in both: Faro spans →
+/// Grafana Cloud tracing, DemoRum spans → wherever a real second SDK would
+/// send them (here: nowhere — it's a no-op stand-in).
+///
+/// The two SDKs remain separate trace systems (independent trace/span IDs) —
+/// we mirror the same logical span into each, we don't share a trace context
+/// between them.
+final o11yTracesProvider = Provider<O11yTraces>((ref) {
+  return CompositeO11yTraces(
+    delegates: [
+      ref.watch(faroO11yTracesProvider),
+      ref.watch(demoRumO11yTracesProvider),
+    ],
+  );
+});
+
+/// App-owned span handle. Returned by [O11yTraces] so call sites never depend
+/// on a Faro (`Span`) or DemoRum (`DemoRumSpan`) type directly — the composite
+/// fans each call out to whichever underlying spans exist.
+abstract class O11ySpan {
+  /// Sets a single attribute on the span.
+  void setAttribute(String key, Object value);
+
+  /// Marks the span as failed and records what went wrong. Both SDKs set the
+  /// span status to error and remember the failure so a later [end] call with
+  /// the default `ok: true` won't silently downgrade it back to OK. Faro also
+  /// records the exception natively; DemoRum surfaces `exception.*` attributes
+  /// (type, message, and stacktrace when provided). Does not end the span.
+  void recordException(Object exception, {StackTrace? stackTrace});
+
+  /// Finishes the span. [ok] maps to the span status; [message] is an optional
+  /// status description (used by Faro).
+  void end({bool ok = true, String? message});
+}
+
+/// Manual + auto span creation, abstracted over the underlying RUM SDK(s).
+///
+/// For Faro, parenting is automatic: any span started inside a [startSpan]
+/// callback auto-parents to it (via Faro's zone context). Pass [parentSpan] —
+/// an [O11ySpan] previously returned by *this same tracer* — to parent
+/// explicitly instead, which is what you need when stitching spans across
+/// async/zone boundaries.
 abstract class O11yTraces {
+  /// Runs [body] inside a span named [name] and ends it automatically. If
+  /// [body] throws, the exception is recorded, the span is marked failed, and
+  /// the error rethrows.
+  ///
+  /// For Faro the span establishes zone context, so work performed inside
+  /// [body] (nested spans, auto-instrumented HTTP) auto-parents to it.
   FutureOr<T> startSpan<T>(
     String name,
-    FutureOr<T> Function(Span) body, {
-    Map<String, String> attributes = const {},
-    Span? parentSpan,
+    FutureOr<T> Function(O11ySpan span) body, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
   });
 
-  Span startSpanManual(
+  /// Starts a span whose lifecycle the caller owns — you MUST call
+  /// [O11ySpan.end] yourself (typically in a `finally`).
+  O11ySpan startSpanManual(
     String name, {
-    Map<String, String> attributes = const {},
-    Span? parentSpan,
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
   });
+}
 
-  Span? getActiveSpan();
+class CompositeO11yTraces implements O11yTraces {
+  CompositeO11yTraces({required List<O11yTraces> delegates})
+    : _delegates = delegates;
+
+  final List<O11yTraces> _delegates;
+
+  /// Nests each delegate's native [startSpan] so every SDK establishes its own
+  /// context around [body]:
+  /// `delegate[0].startSpan(() => delegate[1].startSpan(() => ... => body))`.
+  ///
+  /// Faro (delegate 0, outermost) then auto-parents its nested/HTTP spans under
+  /// the span it created. Each delegate's `startSpan` also owns its span's
+  /// lifecycle + error status, so a thrown error propagates up through every
+  /// layer and marks each SDK's span failed.
+  @override
+  FutureOr<T> startSpan<T>(
+    String name,
+    FutureOr<T> Function(O11ySpan span) body, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
+  }) {
+    return _startNested(0, name, body, attributes, parentSpan, const []);
+  }
+
+  FutureOr<T> _startNested<T>(
+    int index,
+    String name,
+    FutureOr<T> Function(O11ySpan span) body,
+    Map<String, Object> attributes,
+    O11ySpan? parentSpan,
+    List<O11ySpan> openSpans,
+  ) {
+    if (index == _delegates.length) {
+      return body(CompositeO11ySpan(openSpans));
+    }
+    return _delegates[index].startSpan(
+      name,
+      (span) => _startNested(index + 1, name, body, attributes, parentSpan, [
+        ...openSpans,
+        span,
+      ]),
+      attributes: attributes,
+      parentSpan: _parentForDelegate(parentSpan, index),
+    );
+  }
+
+  @override
+  O11ySpan startSpanManual(
+    String name, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
+  }) {
+    return CompositeO11ySpan([
+      for (var i = 0; i < _delegates.length; i++)
+        _delegates[i].startSpanManual(
+          name,
+          attributes: attributes,
+          parentSpan: _parentForDelegate(parentSpan, i),
+        ),
+    ]);
+  }
+
+  /// Picks the delegate-specific parent out of a composite parent span. A
+  /// [CompositeO11ySpan]'s inner spans are index-aligned with [_delegates]
+  /// (both built in the same order), so delegate `i` gets sub-span `i`.
+  ///
+  /// Only spans created by *this same composite* compose correctly; any other
+  /// [O11ySpan] yields no explicit parent, so the delegate falls back to its
+  /// ambient zone parent.
+  O11ySpan? _parentForDelegate(O11ySpan? parentSpan, int index) {
+    return parentSpan is CompositeO11ySpan ? parentSpan.spanAt(index) : null;
+  }
+}
+
+class CompositeO11ySpan implements O11ySpan {
+  CompositeO11ySpan(this._spans);
+
+  final List<O11ySpan> _spans;
+
+  /// The underlying span for delegate [index], or null if out of range. Used by
+  /// [CompositeO11yTraces] to hand each delegate its own parent span.
+  O11ySpan? spanAt(int index) =>
+      index >= 0 && index < _spans.length ? _spans[index] : null;
+
+  @override
+  void setAttribute(String key, Object value) {
+    for (final span in _spans) {
+      span.setAttribute(key, value);
+    }
+  }
+
+  @override
+  void recordException(Object exception, {StackTrace? stackTrace}) {
+    for (final span in _spans) {
+      span.recordException(exception, stackTrace: stackTrace);
+    }
+  }
+
+  @override
+  void end({bool ok = true, String? message}) {
+    for (final span in _spans) {
+      span.end(ok: ok, message: message);
+    }
+  }
 }
 
 class FaroO11yTraces implements O11yTraces {
@@ -31,36 +191,154 @@ class FaroO11yTraces implements O11yTraces {
 
   final Faro _faro;
 
+  /// Uses Faro's native [Faro.startSpan] so the body runs inside Faro's zone
+  /// context: the span is registered as active, so nested spans and Faro's HTTP
+  /// auto-instrumentation auto-parent to it, and it's auto-ended (status/
+  /// exception handled by Faro).
   @override
   FutureOr<T> startSpan<T>(
     String name,
-    FutureOr<T> Function(Span) body, {
-    Map<String, String> attributes = const {},
-    Span? parentSpan,
-  }) async {
+    FutureOr<T> Function(O11ySpan span) body, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
+  }) {
     return _faro.startSpan(
       name,
-      body,
+      (faroSpan) => body(FaroO11ySpan(faroSpan)),
       attributes: attributes,
-      parentSpan: parentSpan,
+      parentSpan: _faroParent(parentSpan),
     );
   }
 
   @override
-  Span startSpanManual(
+  O11ySpan startSpanManual(
     String name, {
-    Map<String, String> attributes = const {},
-    Span? parentSpan,
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
   }) {
-    return _faro.startSpanManual(
+    return FaroO11ySpan(
+      _faro.startSpanManual(
+        name,
+        attributes: attributes,
+        parentSpan: _faroParent(parentSpan),
+      ),
+    );
+  }
+
+  /// Faro resolves `parentSpan ?? getActiveSpan()`, so returning null for a
+  /// missing/foreign parent correctly falls back to the ambient zone span.
+  Span? _faroParent(O11ySpan? parentSpan) =>
+      parentSpan is FaroO11ySpan ? parentSpan.span : null;
+}
+
+class FaroO11ySpan implements O11ySpan {
+  FaroO11ySpan(this._span);
+
+  final Span _span;
+
+  /// Set once [recordException] runs so [end] preserves the failure even when
+  /// called with the default `ok: true`.
+  bool _failed = false;
+
+  /// The wrapped Faro span, so [FaroO11yTraces] can use it as an explicit
+  /// parent for a child span.
+  Span get span => _span;
+
+  @override
+  void setAttribute(String key, Object value) =>
+      _span.setAttribute(key, value);
+
+  @override
+  void recordException(Object exception, {StackTrace? stackTrace}) {
+    _failed = true;
+    _span.recordException(exception, stackTrace: stackTrace);
+    // Faro auto-sets error status only in its startSpan(callback) flow when the
+    // body throws (via SpanExceptionOptions). Faro's Span.recordException() —
+    // the method we call on _span above — only records the exception event and
+    // leaves status untouched, so set it explicitly to cover manual spans and
+    // record-without-throw cases.
+    _span.setStatus(SpanStatusCode.error, message: exception.toString());
+  }
+
+  @override
+  void end({bool ok = true, String? message}) {
+    final isError = _failed || !ok;
+    _span.setStatus(
+      isError ? SpanStatusCode.error : SpanStatusCode.ok,
+      message: message,
+    );
+    _span.end();
+  }
+}
+
+class DemoRumO11yTraces implements O11yTraces {
+  @override
+  FutureOr<T> startSpan<T>(
+    String name,
+    FutureOr<T> Function(O11ySpan span) body, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
+  }) {
+    return DemoRum.startSpan<T>(
       name,
+      (span) => body(DemoRumO11ySpan(span)),
       attributes: attributes,
-      parentSpan: parentSpan,
+      parentSpan: _demoRumParent(parentSpan),
     );
   }
 
   @override
-  Span? getActiveSpan() {
-    return _faro.getActiveSpan();
+  O11ySpan startSpanManual(
+    String name, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
+  }) {
+    return DemoRumO11ySpan(
+      DemoRum.startInactiveSpan(
+        name,
+        attributes: attributes,
+        parentSpan: _demoRumParent(parentSpan),
+      ),
+    );
+  }
+
+  DemoRumSpan? _demoRumParent(O11ySpan? parentSpan) =>
+      parentSpan is DemoRumO11ySpan ? parentSpan.span : null;
+}
+
+class DemoRumO11ySpan implements O11ySpan {
+  DemoRumO11ySpan(this._span);
+
+  final DemoRumSpan _span;
+
+  /// Set once [recordException] runs so [end] preserves the failure even when
+  /// called with the default `ok: true`.
+  bool _failed = false;
+
+  /// The wrapped DemoRum span, so [DemoRumO11yTraces] can use it as an explicit
+  /// parent for a child span.
+  DemoRumSpan get span => _span;
+
+  @override
+  void setAttribute(String key, Object value) =>
+      _span.setAttribute(key, value);
+
+  @override
+  void recordException(Object exception, {StackTrace? stackTrace}) {
+    _failed = true;
+    _span.status = DemoRumSpanStatus.error;
+    _span.setAttribute('exception.type', exception.runtimeType.toString());
+    _span.setAttribute('exception.message', exception.toString());
+    if (stackTrace != null) {
+      _span.setAttribute('exception.stacktrace', stackTrace.toString());
+    }
+  }
+
+  @override
+  void end({bool ok = true, String? message}) {
+    _span.status = (_failed || !ok)
+        ? DemoRumSpanStatus.error
+        : DemoRumSpanStatus.ok;
+    _span.end();
   }
 }

--- a/Mobiles/flutter/lib/core/router/app_router.dart
+++ b/Mobiles/flutter/lib/core/router/app_router.dart
@@ -10,6 +10,7 @@ import '../../features/debug/presentation/debug_screen.dart';
 import '../../features/pizza/presentation/home_screen.dart';
 import '../../features/profile/presentation/profile_screen.dart';
 import '../../features/shell/presentation/main_shell.dart';
+import '../o11y/demo_rum/sdk/demo_rum.dart';
 
 /// Route paths as constants for type-safe navigation
 abstract class AppRoutes {
@@ -32,7 +33,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     navigatorKey: _rootNavigatorKey,
     initialLocation: AppRoutes.home,
-    observers: [FaroNavigationObserver()],
+    // Both RUM SDKs derive screen names from `route.settings.name`. The
+    // pageBuilder routes below set an explicit `name:` so Faro view meta and
+    // DemoRum screen views are both populated (builder routes get their name
+    // from go_router automatically).
+    observers: [FaroNavigationObserver(), DemoRumNavigatorObserver()],
     routes: [
       // ShellRoute wraps the bottom navigation bar
       ShellRoute(
@@ -43,15 +48,24 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         routes: [
           GoRoute(
             path: AppRoutes.home,
-            pageBuilder: (_, _) => const NoTransitionPage(child: HomeScreen()),
+            pageBuilder: (_, _) => const NoTransitionPage(
+              name: AppRoutes.home,
+              child: HomeScreen(),
+            ),
           ),
           GoRoute(
             path: AppRoutes.about,
-            pageBuilder: (_, _) => const NoTransitionPage(child: AboutScreen()),
+            pageBuilder: (_, _) => const NoTransitionPage(
+              name: AppRoutes.about,
+              child: AboutScreen(),
+            ),
           ),
           GoRoute(
             path: AppRoutes.debug,
-            pageBuilder: (_, _) => const NoTransitionPage(child: DebugScreen()),
+            pageBuilder: (_, _) => const NoTransitionPage(
+              name: AppRoutes.debug,
+              child: DebugScreen(),
+            ),
           ),
         ],
       ),

--- a/Mobiles/flutter/lib/features/debug/presentation/config_screen.dart
+++ b/Mobiles/flutter/lib/features/debug/presentation/config_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/o11y/faro/faro_data_collection_provider.dart';
 import 'config_screen_view_model.dart';
 import 'restart_required_banner.dart';
 
@@ -18,12 +20,14 @@ class ConfigScreen extends ConsumerStatefulWidget {
 class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   final _backendController = TextEditingController();
   final _faroController = TextEditingController();
+  final _sampleRateController = TextEditingController();
   bool _controllersSeeded = false;
 
   @override
   void dispose() {
     _backendController.dispose();
     _faroController.dispose();
+    _sampleRateController.dispose();
     super.dispose();
   }
 
@@ -33,6 +37,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     if (_controllersSeeded) return;
     _backendController.text = uiState.savedBackendOverride ?? '';
     _faroController.text = uiState.savedFaroCollectorOverride ?? '';
+    _sampleRateController.text =
+        uiState.savedFaroSampleRateOverride?.toString() ?? '';
     _controllersSeeded = true;
   }
 
@@ -55,10 +61,12 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         padding: const EdgeInsets.all(16),
         children: [
           const RestartRequiredBanner(),
+          const _FaroDataCollectionCard(),
+          const SizedBox(height: 24),
           Text(
-            'Override the URLs used by this app. Changes only take effect '
-            'after you kill and restart the app — this keeps traces, logs '
-            'and metrics correlated within a single session.',
+            'Override the values used by this app. Changes here only take '
+            'effect after you kill and restart the app — this keeps traces, '
+            'logs and metrics correlated within a single session.',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
@@ -81,6 +89,18 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             defaultDisplay: uiState.defaultFaroCollectorDisplay,
             hintText: 'https://faro-collector.../collect/<api-key>',
           ),
+          const SizedBox(height: 24),
+          _UrlField(
+            label: 'Faro session sample rate',
+            controller: _sampleRateController,
+            inUseValue: uiState.faroSampleRateInUse.toString(),
+            defaultValue: uiState.defaultFaroSampleRate.toString(),
+            hintText: 'e.g. 0.25 — fraction of sessions sampled (0.0–1.0)',
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+            ],
+          ),
           const SizedBox(height: 32),
           SizedBox(
             width: double.infinity,
@@ -90,6 +110,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
                   : () => actions.save(
                       backendUrl: _backendController.text,
                       faroCollectorUrl: _faroController.text,
+                      faroSampleRateText: _sampleRateController.text,
                     ),
               icon: uiState.saving
                   ? const SizedBox(
@@ -111,6 +132,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
                       await actions.clear();
                       _backendController.clear();
                       _faroController.clear();
+                      _sampleRateController.clear();
                     },
               icon: const Icon(Icons.restart_alt),
               label: const Text('Use defaults (clear overrides)'),
@@ -144,6 +166,38 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   }
 }
 
+/// Live switch for Faro's global data-collection flag. Unlike the override
+/// fields below, this takes effect immediately (no restart) and Faro persists
+/// the value across app launches on its own.
+class _FaroDataCollectionCard extends ConsumerWidget {
+  const _FaroDataCollectionCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final enabled = ref.watch(faroDataCollectionProvider);
+
+    return Card(
+      child: SwitchListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        title: const Text('Faro data collection'),
+        subtitle: Text(
+          enabled
+              ? 'Faro is collecting and sending telemetry. Applies immediately.'
+              : 'Faro telemetry is paused — nothing is sent. Applies '
+                    'immediately.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        value: enabled,
+        onChanged: (value) =>
+            ref.read(faroDataCollectionProvider.notifier).setEnabled(value),
+      ),
+    );
+  }
+}
+
 class _UrlField extends StatelessWidget {
   const _UrlField({
     required this.label,
@@ -153,6 +207,8 @@ class _UrlField extends StatelessWidget {
     required this.hintText,
     this.inUseDisplay,
     this.defaultDisplay,
+    this.keyboardType = TextInputType.url,
+    this.inputFormatters,
   });
 
   final String label;
@@ -162,6 +218,8 @@ class _UrlField extends StatelessWidget {
   final String hintText;
   final String? inUseDisplay;
   final String? defaultDisplay;
+  final TextInputType keyboardType;
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   Widget build(BuildContext context) {
@@ -198,7 +256,8 @@ class _UrlField extends StatelessWidget {
                 labelText: 'Override (empty = use default)',
                 border: const OutlineInputBorder(),
               ),
-              keyboardType: TextInputType.url,
+              keyboardType: keyboardType,
+              inputFormatters: inputFormatters,
               autocorrect: false,
               enableSuggestions: false,
             ),

--- a/Mobiles/flutter/lib/features/debug/presentation/config_screen_view_model.dart
+++ b/Mobiles/flutter/lib/features/debug/presentation/config_screen_view_model.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/config/config_service.dart';
 import '../../../core/config/debug_settings.dart';
+import '../../../core/config/faro_sample_rate_service.dart';
 import '../../../core/config/runtime_config.dart';
 import '../../../core/utils/faro_utils.dart';
 
@@ -16,11 +17,14 @@ class ConfigScreenUiState extends Equatable {
     required this.backendInUse,
     required this.faroCollectorInUse,
     required this.faroCollectorInUseDisplay,
+    required this.faroSampleRateInUse,
     required this.defaultBackend,
     required this.defaultFaroCollector,
     required this.defaultFaroCollectorDisplay,
+    required this.defaultFaroSampleRate,
     required this.savedBackendOverride,
     required this.savedFaroCollectorOverride,
+    required this.savedFaroSampleRateOverride,
     required this.saving,
     required this.statusMessage,
   });
@@ -34,6 +38,9 @@ class ConfigScreenUiState extends Equatable {
   /// Faro collector URL with the API key partially masked, safe to render.
   final String faroCollectorInUseDisplay;
 
+  /// Faro session sampling rate Faro initialized with this session (0.0–1.0).
+  final double faroSampleRateInUse;
+
   /// Build-time default backend URL.
   final String defaultBackend;
 
@@ -43,9 +50,15 @@ class ConfigScreenUiState extends Equatable {
   /// Masked build-time default, safe to render (null if not configured).
   final String? defaultFaroCollectorDisplay;
 
+  /// Default Faro sampling rate when no override is saved.
+  final double defaultFaroSampleRate;
+
   /// Saved override in SharedPreferences — empty string means "no override".
   final String? savedBackendOverride;
   final String? savedFaroCollectorOverride;
+
+  /// Saved sampling-rate override — `null` means "no override".
+  final double? savedFaroSampleRateOverride;
 
   /// Whether a save/clear is in-flight.
   final bool saving;
@@ -61,11 +74,14 @@ class ConfigScreenUiState extends Equatable {
       backendInUse: backendInUse,
       faroCollectorInUse: faroCollectorInUse,
       faroCollectorInUseDisplay: faroCollectorInUseDisplay,
+      faroSampleRateInUse: faroSampleRateInUse,
       defaultBackend: defaultBackend,
       defaultFaroCollector: defaultFaroCollector,
       defaultFaroCollectorDisplay: defaultFaroCollectorDisplay,
+      defaultFaroSampleRate: defaultFaroSampleRate,
       savedBackendOverride: savedBackendOverride,
       savedFaroCollectorOverride: savedFaroCollectorOverride,
+      savedFaroSampleRateOverride: savedFaroSampleRateOverride,
       saving: saving ?? this.saving,
       statusMessage: statusMessage != null
           ? statusMessage()
@@ -78,11 +94,14 @@ class ConfigScreenUiState extends Equatable {
     backendInUse,
     faroCollectorInUse,
     faroCollectorInUseDisplay,
+    faroSampleRateInUse,
     defaultBackend,
     defaultFaroCollector,
     defaultFaroCollectorDisplay,
+    defaultFaroSampleRate,
     savedBackendOverride,
     savedFaroCollectorOverride,
+    savedFaroSampleRateOverride,
     saving,
     statusMessage,
   ];
@@ -94,11 +113,14 @@ class ConfigScreenUiState extends Equatable {
 
 /// Defines the actions available on the Config screen.
 abstract interface class ConfigScreenActions {
-  /// Persist all overrides atomically. Empty/whitespace values clear
-  /// the corresponding override.
+  /// Persist all overrides atomically. Empty/whitespace URL values clear the
+  /// corresponding override; an empty [faroSampleRateText] clears the rate
+  /// override. Returns silently after setting an error status if the sample
+  /// rate is present but invalid.
   Future<void> save({
     required String? backendUrl,
     required String? faroCollectorUrl,
+    required String? faroSampleRateText,
   });
 
   /// Clear all overrides and fall back to build-time defaults on the
@@ -124,13 +146,16 @@ class _ConfigScreenViewModel extends Notifier<ConfigScreenUiState>
       backendInUse: runtime.backendBaseUrl,
       faroCollectorInUse: runtime.faroCollectorUrl,
       faroCollectorInUseDisplay: maskCollectorUrl(runtime.faroCollectorUrl),
+      faroSampleRateInUse: runtime.faroSampleRate,
       defaultBackend: configService.baseUrl,
       defaultFaroCollector: defaultFaroCollector,
       defaultFaroCollectorDisplay: defaultFaroCollector == null
           ? null
           : maskCollectorUrl(defaultFaroCollector),
+      defaultFaroSampleRate: kDefaultFaroSampleRate,
       savedBackendOverride: settings.backendUrlOverride,
       savedFaroCollectorOverride: settings.faroCollectorUrlOverride,
+      savedFaroSampleRateOverride: settings.faroSampleRateOverride,
       saving: false,
       statusMessage: null,
     );
@@ -140,11 +165,22 @@ class _ConfigScreenViewModel extends Notifier<ConfigScreenUiState>
   Future<void> save({
     required String? backendUrl,
     required String? faroCollectorUrl,
+    required String? faroSampleRateText,
   }) async {
+    final (sampleRate, sampleRateError) = _parseSampleRate(faroSampleRateText);
+    if (sampleRateError != null) {
+      state = state.copyWith(statusMessage: () => sampleRateError);
+      return;
+    }
+
     state = state.copyWith(saving: true, statusMessage: () => null);
     await ref
         .read(debugSettingsProvider.notifier)
-        .saveUrls(backendUrl: backendUrl, faroCollectorUrl: faroCollectorUrl);
+        .saveConfigOverrides(
+          backendUrl: backendUrl,
+          faroCollectorUrl: faroCollectorUrl,
+          faroSampleRate: sampleRate,
+        );
     // State is re-derived automatically via ref.watch(debugSettingsProvider)
     // in build(), so we only need to update the transient fields here.
     state = state.copyWith(
@@ -159,12 +195,30 @@ class _ConfigScreenViewModel extends Notifier<ConfigScreenUiState>
     state = state.copyWith(saving: true, statusMessage: () => null);
     await ref
         .read(debugSettingsProvider.notifier)
-        .saveUrls(backendUrl: null, faroCollectorUrl: null);
+        .saveConfigOverrides(
+          backendUrl: null,
+          faroCollectorUrl: null,
+          faroSampleRate: null,
+        );
     state = state.copyWith(
       saving: false,
       statusMessage: () =>
           'Overrides cleared. Kill and relaunch to use defaults.',
     );
+  }
+
+  /// Parses the sample-rate text field. Returns `(rate, error)`:
+  /// - empty → `(null, null)` (clear the override)
+  /// - a number in [0.0, 1.0] → `(value, null)`
+  /// - anything else → `(null, <message>)`
+  (double?, String?) _parseSampleRate(String? text) {
+    final trimmed = text?.trim() ?? '';
+    if (trimmed.isEmpty) return (null, null);
+    final value = double.tryParse(trimmed);
+    if (value == null || value < 0.0 || value > 1.0) {
+      return (null, 'Faro sample rate must be a number between 0.0 and 1.0.');
+    }
+    return (value, null);
   }
 
   /// [ConfigService.faroCollectorUrl] throws if `FARO_COLLECTOR_URL` isn't

--- a/Mobiles/flutter/lib/features/debug/presentation/config_screen_view_model.dart
+++ b/Mobiles/flutter/lib/features/debug/presentation/config_screen_view_model.dart
@@ -94,14 +94,14 @@ class ConfigScreenUiState extends Equatable {
 
 /// Defines the actions available on the Config screen.
 abstract interface class ConfigScreenActions {
-  /// Persist both URL overrides atomically. Empty/whitespace values clear
+  /// Persist all overrides atomically. Empty/whitespace values clear
   /// the corresponding override.
   Future<void> save({
     required String? backendUrl,
     required String? faroCollectorUrl,
   });
 
-  /// Clear both URL overrides and fall back to build-time defaults on the
+  /// Clear all overrides and fall back to build-time defaults on the
   /// next app launch.
   Future<void> clear();
 }
@@ -115,7 +115,7 @@ class _ConfigScreenViewModel extends Notifier<ConfigScreenUiState>
   @override
   ConfigScreenUiState build() {
     final settings = ref.watch(debugSettingsProvider);
-    final runtime = ref.watch(runtimeConfigProvider).requireValue;
+    final runtime = ref.watch(runtimeConfigProvider);
     final configService = ref.watch(configServiceProvider);
 
     final defaultFaroCollector = _safeDefaultFaroCollectorUrl();

--- a/Mobiles/flutter/lib/features/debug/presentation/debug_screen.dart
+++ b/Mobiles/flutter/lib/features/debug/presentation/debug_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/config/debug_settings.dart';
+import '../../../core/o11y/demo_rum/sdk/demo_rum.dart';
 import '../../../core/o11y/errors/o11y_errors.dart';
 import '../../../core/o11y/events/o11y_events.dart';
 import '../../../core/o11y/loggers/o11y_logger.dart';
@@ -150,8 +151,9 @@ class _DebugScreenState extends ConsumerState<DebugScreen> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    'Emit one-off Faro signals (logs and custom events) to '
-                    'verify the SDK pipeline end-to-end.',
+                    'Emit one-off signals (logs and custom events) to both '
+                    'Faro and the DemoRum SDK to verify the pipelines '
+                    'end-to-end.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
@@ -201,7 +203,8 @@ class _DebugScreenState extends ConsumerState<DebugScreen> {
                   const SizedBox(height: 4),
                   Text(
                     'Throws an exception inside a try/catch and reports it '
-                    'via the Faro error API. Tests the manual reporting path.',
+                    'via the O11y error API, which fans out to both Faro and '
+                    'the DemoRum SDK. Tests the manual reporting path.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
@@ -232,9 +235,10 @@ class _DebugScreenState extends ConsumerState<DebugScreen> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    'Throws a Dart exception outside any try/catch. Faro\'s '
-                    'global error handler (installed by faro.runApp) captures '
-                    'it and reports it. The app keeps running.',
+                    'Throws a Dart exception outside any try/catch. The '
+                    'chained global error handlers installed by both Faro and '
+                    'the DemoRum SDK both see it (Faro chains to DemoRum, which '
+                    'echoes it to the console). The app keeps running.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
@@ -246,6 +250,40 @@ class _DebugScreenState extends ConsumerState<DebugScreen> {
                       onPressed: _throwUnhandledException,
                       icon: const Icon(Icons.bolt),
                       label: const Text('Throw Unhandled Exception'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Verify DemoRum',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Captures a handled exception directly through the DemoRum '
+                    'SDK only (bypassing the shared O11y layer). Use this to '
+                    'confirm the DemoRum pipeline in isolation from Faro — '
+                    'watch for the "[DemoRum]" console echo.',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.tonalIcon(
+                      onPressed: _captureDemoRumTestException,
+                      icon: const Icon(Icons.verified_outlined),
+                      label: const Text('Capture DemoRum Test Exception'),
                     ),
                   ),
                 ],
@@ -409,6 +447,19 @@ class _DebugScreenState extends ConsumerState<DebugScreen> {
           );
     }
     _showAction('Sent handled exception');
+  }
+
+  void _captureDemoRumTestException() {
+    try {
+      throw StateError('DemoRum verification exception from Debug tab');
+    } catch (e, stackTrace) {
+      DemoRum.captureException(
+        e,
+        stackTrace: stackTrace,
+        withScope: (scope) => scope.setContexts('o11y', _debugTabContext),
+      );
+    }
+    _showAction('Captured DemoRum test exception');
   }
 
   /// Throws synchronously inside a setState callback so it escapes the

--- a/Mobiles/flutter/lib/features/debug/presentation/restart_required_banner.dart
+++ b/Mobiles/flutter/lib/features/debug/presentation/restart_required_banner.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/config/config_service.dart';
 import '../../../core/config/debug_settings.dart';
+import '../../../core/config/faro_sample_rate_service.dart';
 import '../../../core/config/runtime_config.dart';
 
 // =============================================================================
@@ -46,13 +47,16 @@ final restartBannerUiStateProvider = Provider<RestartBannerUiState>((ref) {
   final savedBackend = settings.backendUrlOverride ?? configService.baseUrl;
   final savedFaroCollector =
       settings.faroCollectorUrlOverride ?? _safeDefaultFaroCollectorUrl();
+  final savedSampleRate =
+      settings.faroSampleRateOverride ?? kDefaultFaroSampleRate;
 
   final backendChanged = savedBackend != runtime.backendBaseUrl;
   final faroCollectorChanged =
       savedFaroCollector != null &&
       savedFaroCollector != runtime.faroCollectorUrl;
+  final sampleRateChanged = savedSampleRate != runtime.faroSampleRate;
 
-  if (!backendChanged && !faroCollectorChanged) {
+  if (!backendChanged && !faroCollectorChanged && !sampleRateChanged) {
     return const RestartBannerUiState.hidden();
   }
 
@@ -61,6 +65,7 @@ final restartBannerUiStateProvider = Provider<RestartBannerUiState>((ref) {
     changedLabel: [
       if (backendChanged) 'Backend URL',
       if (faroCollectorChanged) 'Faro collector URL',
+      if (sampleRateChanged) 'Faro sample rate',
     ].join(' and '),
   );
 });
@@ -80,8 +85,8 @@ String? _safeDefaultFaroCollectorUrl() {
 // =============================================================================
 
 /// Shown at the top of the Debug and Config screens whenever a saved override
-/// (backend URL or Faro collector URL) differs from the value currently-in-use
-/// in the session.
+/// (backend URL, Faro collector URL, or Faro sample rate) differs from the
+/// value currently-in-use in the session.
 ///
 /// Returns a zero-size widget when no restart is needed.
 class RestartRequiredBanner extends ConsumerWidget {

--- a/Mobiles/flutter/lib/features/debug/presentation/restart_required_banner.dart
+++ b/Mobiles/flutter/lib/features/debug/presentation/restart_required_banner.dart
@@ -40,7 +40,7 @@ class RestartBannerUiState extends Equatable {
 /// is the right tool here; a [Notifier] would be ceremony.
 final restartBannerUiStateProvider = Provider<RestartBannerUiState>((ref) {
   final settings = ref.watch(debugSettingsProvider);
-  final runtime = ref.watch(runtimeConfigProvider).requireValue;
+  final runtime = ref.watch(runtimeConfigProvider);
   final configService = ref.watch(configServiceProvider);
 
   final savedBackend = settings.backendUrlOverride ?? configService.baseUrl;
@@ -79,8 +79,9 @@ String? _safeDefaultFaroCollectorUrl() {
 // Widget
 // =============================================================================
 
-/// Shown at the top of the Debug and Config screens whenever the saved
-/// URL overrides differ from the URLs currently-in-use in the session.
+/// Shown at the top of the Debug and Config screens whenever a saved override
+/// (backend URL or Faro collector URL) differs from the value currently-in-use
+/// in the session.
 ///
 /// Returns a zero-size widget when no restart is needed.
 class RestartRequiredBanner extends ConsumerWidget {

--- a/Mobiles/flutter/lib/features/pizza/domain/pizza_provider.dart
+++ b/Mobiles/flutter/lib/features/pizza/domain/pizza_provider.dart
@@ -5,6 +5,7 @@ import '../../../core/o11y/actions/o11y_actions.dart';
 import '../../../core/o11y/events/o11y_events.dart';
 import '../../../core/o11y/loggers/o11y_logger.dart';
 import '../../../core/o11y/metrics/o11y_metrics.dart';
+import '../../../core/o11y/traces/o11y_traces.dart';
 import '../../auth/domain/auth_provider.dart';
 import '../models/pizza.dart';
 import '../models/restrictions.dart';
@@ -60,6 +61,7 @@ class PizzaStateNotifier extends Notifier<PizzaState> {
   late O11yEvents _o11yEvents;
   late O11yLogger _o11yLogger;
   late O11yMetrics _o11yMetrics;
+  late O11yTraces _o11yTraces;
 
   @override
   PizzaState build() {
@@ -68,6 +70,7 @@ class PizzaStateNotifier extends Notifier<PizzaState> {
     _o11yEvents = ref.watch(o11yEventsProvider);
     _o11yLogger = ref.watch(o11yLoggerProvider);
     _o11yMetrics = ref.watch(o11yMetricsProvider);
+    _o11yTraces = ref.watch(o11yTracesProvider);
 
     // Reset pizza state when user logs out, clear error when user logs in
     ref.listen(isLoggedInProvider, (prev, next) {
@@ -97,31 +100,49 @@ class PizzaStateNotifier extends Notifier<PizzaState> {
     state = state.copyWith(isLoading: true, errorMessage: null);
 
     try {
-      final pizza = await _pizzaRepository.getPizzaRecommendation(restrictions);
+      // startSpan (callback form) runs the fetch *inside* the span's context,
+      // so Faro's HTTP auto-instrumentation nests the request under this span.
+      // The span is mirrored into the DemoRum SDK too (see O11yTraces).
+      await _o11yTraces.startSpan(
+        'pizza.get_recommendation',
+        (span) async {
+          final pizza = await _pizzaRepository.getPizzaRecommendation(
+            restrictions,
+          );
 
-      if (pizza != null) {
-        _o11yEvents.trackEvent(
-          'pizza_received',
-          context: {
-            'pizza_id': pizza.pizza.id.toString(),
-            'pizza_name': pizza.pizza.name,
-          },
-        );
-        _o11yMetrics.addMeasurement('pizza.recommendation', {
-          'pizza_id': pizza.pizza.id,
-          'calories': pizza.calories ?? 0,
-          'vegetarian': pizza.vegetarian == true ? 1 : 0,
-        });
-        state = state.copyWith(pizza: pizza, isLoading: false);
-      } else {
-        _o11yLogger.warning('Pizza recommendation returned null');
-        state = state.copyWith(
-          isLoading: false,
-          errorMessage:
-              'Failed to get pizza recommendation. Please log in and try again.',
-        );
-      }
+          if (pizza != null) {
+            span.setAttribute('pizza.found', true);
+            span.setAttribute('pizza.id', pizza.pizza.id);
+            span.setAttribute('pizza.name', pizza.pizza.name);
+            _o11yEvents.trackEvent(
+              'pizza_received',
+              context: {
+                'pizza_id': pizza.pizza.id.toString(),
+                'pizza_name': pizza.pizza.name,
+              },
+            );
+            _o11yMetrics.addMeasurement('pizza.recommendation', {
+              'pizza_id': pizza.pizza.id,
+              'calories': pizza.calories ?? 0,
+              'vegetarian': pizza.vegetarian == true ? 1 : 0,
+            });
+            state = state.copyWith(pizza: pizza, isLoading: false);
+          } else {
+            // Not an error — the repo returns null for expected non-success
+            // (mainly 401 "needs login"). Mark it and let the span finish OK.
+            span.setAttribute('pizza.found', false);
+            _o11yLogger.warning('Pizza recommendation returned null');
+            state = state.copyWith(
+              isLoading: false,
+              errorMessage:
+                  'Failed to get pizza recommendation. Please log in and try again.',
+            );
+          }
+        },
+        attributes: {'vegetarian': restrictions.mustBeVegetarian},
+      );
     } catch (error, stackTrace) {
+      // startSpan already recorded the exception + marked the span failed.
       _o11yLogger.error(
         'Failed to get pizza recommendation',
         error: error,

--- a/Mobiles/flutter/test/core/http_overrides_timing_test.dart
+++ b/Mobiles/flutter/test/core/http_overrides_timing_test.dart
@@ -1,0 +1,54 @@
+// Verifies the ordering constraint behind `installFaroHttpOverrides()`:
+// an `http.Client()` (IOClient) captures its `HttpClient` AT CONSTRUCTION via
+// `HttpOverrides.current`, so a client built BEFORE the override is installed
+// is never routed through it — while one built AFTER is. This is the exact
+// mechanism that makes bootstrap install the Faro overrides before anything
+// (e.g. session restore) constructs the cached ApiClient's http.Client.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+class _CountingHttpOverrides extends HttpOverrides {
+  int createCount = 0;
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    createCount++;
+    return super.createHttpClient(context);
+  }
+}
+
+void main() {
+  test(
+    'http.Client() is only routed through HttpOverrides installed BEFORE it',
+    () {
+      final saved = HttpOverrides.current;
+      addTearDown(() => HttpOverrides.global = saved);
+
+      final overrides = _CountingHttpOverrides();
+
+      // Build a client with NO custom override installed.
+      HttpOverrides.global = null;
+      final before = http.Client();
+      expect(
+        overrides.createCount,
+        0,
+        reason: 'client constructed before install must not use the override',
+      );
+
+      // Install the override, then build another client.
+      HttpOverrides.global = overrides;
+      final after = http.Client();
+      expect(
+        overrides.createCount,
+        1,
+        reason: 'only the post-install client should go through the override',
+      );
+
+      before.close();
+      after.close();
+    },
+  );
+}

--- a/Mobiles/flutter/test/core/o11y/o11y_traces_test.dart
+++ b/Mobiles/flutter/test/core/o11y/o11y_traces_test.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:flutter_mobile_o11y_demo/core/o11y/traces/o11y_traces.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Records the parent it was handed so we can assert the composite distributes
+/// each delegate its own sub-span.
+class _RecordedCall {
+  _RecordedCall(this.name, this.parent);
+  final String name;
+  final O11ySpan? parent;
+}
+
+class _FakeSpan implements O11ySpan {
+  _FakeSpan(this.name);
+  final String name;
+  bool ended = false;
+
+  @override
+  void setAttribute(String key, Object value) {}
+
+  @override
+  void recordException(Object exception, {StackTrace? stackTrace}) {}
+
+  @override
+  void end({bool ok = true, String? message}) => ended = true;
+}
+
+class _FakeTraces implements O11yTraces {
+  final List<_RecordedCall> manualCalls = [];
+  final List<_RecordedCall> spanCalls = [];
+
+  @override
+  FutureOr<T> startSpan<T>(
+    String name,
+    FutureOr<T> Function(O11ySpan span) body, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
+  }) async {
+    spanCalls.add(_RecordedCall(name, parentSpan));
+    final span = _FakeSpan(name);
+    try {
+      return await body(span);
+    } finally {
+      span.end();
+    }
+  }
+
+  @override
+  O11ySpan startSpanManual(
+    String name, {
+    Map<String, Object> attributes = const {},
+    O11ySpan? parentSpan,
+  }) {
+    manualCalls.add(_RecordedCall(name, parentSpan));
+    return _FakeSpan(name);
+  }
+}
+
+void main() {
+  group('CompositeO11yTraces parent distribution', () {
+    late _FakeTraces faro;
+    late _FakeTraces demoRum;
+    late CompositeO11yTraces composite;
+
+    setUp(() {
+      faro = _FakeTraces();
+      demoRum = _FakeTraces();
+      composite = CompositeO11yTraces(delegates: [faro, demoRum]);
+    });
+
+    test('startSpanManual with no parent passes null to every delegate', () {
+      composite.startSpanManual('root');
+
+      expect(faro.manualCalls.single.parent, isNull);
+      expect(demoRum.manualCalls.single.parent, isNull);
+    });
+
+    test('startSpanManual hands each delegate its own sub-span of the '
+        'composite parent', () {
+      final parent = composite.startSpanManual('parent') as CompositeO11ySpan;
+
+      composite.startSpanManual('child', parentSpan: parent);
+
+      // Child call is the 2nd manual call on each delegate.
+      expect(faro.manualCalls[1].parent, same(parent.spanAt(0)));
+      expect(demoRum.manualCalls[1].parent, same(parent.spanAt(1)));
+    });
+
+    test('startSpan hands each delegate its own sub-span of the composite '
+        'parent', () async {
+      final parent = composite.startSpanManual('parent') as CompositeO11ySpan;
+
+      await composite.startSpan('child', (_) async {}, parentSpan: parent);
+
+      expect(faro.spanCalls.single.parent, same(parent.spanAt(0)));
+      expect(demoRum.spanCalls.single.parent, same(parent.spanAt(1)));
+    });
+
+    test('a foreign (non-composite) parent yields no explicit parent', () {
+      composite.startSpanManual('child', parentSpan: _FakeSpan('foreign'));
+
+      expect(faro.manualCalls.single.parent, isNull);
+      expect(demoRum.manualCalls.single.parent, isNull);
+    });
+  });
+}

--- a/Mobiles/flutter/test/widget_test.dart
+++ b/Mobiles/flutter/test/widget_test.dart
@@ -30,6 +30,7 @@ void main() {
           const RuntimeConfig(
             backendBaseUrl: 'http://localhost:3333',
             faroCollectorUrl: '',
+            faroSampleRate: 1.0,
           ),
         ),
       ],

--- a/Mobiles/flutter/test/widget_test.dart
+++ b/Mobiles/flutter/test/widget_test.dart
@@ -4,24 +4,30 @@
 // full provider tree (auth, pizza, Faro, network), which is out of scope
 // for a demo app of this size.
 //
-// We override `runtimeConfigProvider` and warm it before pumping because
-// bootstrap normally awaits its future before running the app; tests
-// don't go through bootstrap, so without warming the provider stays in
-// AsyncLoading and downstream consumers call `.requireValue` on it.
+// We override `sharedPreferencesProvider` (with mock prefs) and
+// `runtimeConfigProvider` because tests don't go through bootstrap, which
+// normally resolves both. Config + debug providers read prefs synchronously,
+// so the override must be a resolved instance.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:flutter_mobile_o11y_demo/bootstrap.dart';
 import 'package:flutter_mobile_o11y_demo/core/config/runtime_config.dart';
+import 'package:flutter_mobile_o11y_demo/core/config/shared_preferences_provider.dart';
 
 void main() {
   testWidgets('QuickPizzaApp mounts', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
     final container = ProviderContainer(
       overrides: [
-        runtimeConfigProvider.overrideWith(
-          (ref) async => const RuntimeConfig(
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        runtimeConfigProvider.overrideWithValue(
+          const RuntimeConfig(
             backendBaseUrl: 'http://localhost:3333',
             faroCollectorUrl: '',
           ),
@@ -29,9 +35,6 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-
-    // Warm the FutureProvider so `.requireValue` is safe on first frame.
-    await container.read(runtimeConfigProvider.future);
 
     await tester.pumpWidget(
       UncontrolledProviderScope(

--- a/Mobiles/react-native/ios/Podfile.lock
+++ b/Mobiles/react-native/ios/Podfile.lock
@@ -2182,7 +2182,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FaroReactNative: 8129c56d724e57c6e375b675b92e0d66d12d88d8
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: 40d9c07f06e5cfb14add9a995c44cd9260eb8403
+  hermes-engine: af26a2fc195f459f1524c41bc6da855e0eafa8ae
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
@@ -2192,7 +2192,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: af87338af8fe3fdf3058328c8001eb9a6c35f2ac
+  React-Core-prebuilt: 8d637a909b2f1ea893ccd5f60707c5db195e57e9
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2255,7 +2255,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: 378c47f88c1f15c3e7af23cf2a6ba1b142da8cef
+  ReactNativeDependencies: c380a964bdefa6cb8a75c47f1d645646b947eb74
   RNCAsyncStorage: 7a5a6094f9f6b9158e72f1855cd86e769413d851
   RNDeviceInfo: 900bd20e1fd3bfd894e7384cc4a83880c0341bd3
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707

--- a/Mobiles/react-native/ios/Podfile.lock
+++ b/Mobiles/react-native/ios/Podfile.lock
@@ -2182,7 +2182,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FaroReactNative: 8129c56d724e57c6e375b675b92e0d66d12d88d8
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: af26a2fc195f459f1524c41bc6da855e0eafa8ae
+  hermes-engine: 40d9c07f06e5cfb14add9a995c44cd9260eb8403
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
@@ -2192,7 +2192,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: 8d637a909b2f1ea893ccd5f60707c5db195e57e9
+  React-Core-prebuilt: af87338af8fe3fdf3058328c8001eb9a6c35f2ac
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2255,7 +2255,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: c380a964bdefa6cb8a75c47f1d645646b947eb74
+  ReactNativeDependencies: 378c47f88c1f15c3e7af23cf2a6ba1b142da8cef
   RNCAsyncStorage: 7a5a6094f9f6b9158e72f1855cd86e769413d851
   RNDeviceInfo: 900bd20e1fd3bfd894e7384cc4a83880c0341bd3
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707


### PR DESCRIPTION
## Summary
- Demonstrates two mobile RUM SDKs coexisting in one Flutter app: Grafana Faro (the real, primary instrumentation) alongside **DemoRum** — a small, made-up, no-op RUM SDK defined locally in the app.
- No third-party RUM SDK or service is bundled. DemoRum sends nothing; it echoes to the console (`[DemoRum]` logs) so you can *see* it receive the same telemetry as Faro. Swap its types for a real vendor SDK to make it live.
- Adds debug controls for Faro session sampling and live data collection.

## What's included
- **DemoRum SDK** (`core/o11y/demo_rum/sdk/demo_rum.dart`): API shaped like a typical mobile RUM SDK — init + options, root widget, navigation observer, HTTP client wrapper, exception capture, structured logs, scope/user, spans.
- **Honest where it matters:** chained `FlutterError` / `PlatformDispatcher` error handlers (save + call the previous), HTTP client forwards requests (Faro's `HttpOverrides` still captures), spans run their callbacks.
- **Unified O11y layer:** the shared `core/o11y/` composite (errors/events/logs/traces + app-owned `O11ySpan`) fans out to both Faro and DemoRum. `bootstrap` nests `wrapWithDemoRum(wrapWithFaro(app))`.
- **Faro sampling controls:** configure a persisted session sample-rate override from 0.0–1.0, with restart-to-apply behavior and validation.
- **Faro data collection:** pause or resume Faro telemetry immediately through the SDK’s persisted collection policy.
- **Docs:** Flutter README + CLAUDE.md explain the dual-SDK pattern.

## Notes
- The original dual-SDK branch history was squashed to a single commit; this sampling update is a follow-up commit.

## Test plan
- `flutter analyze` — no issues.
- `flutter test` — all 12 tests pass.
- Debug → Config: change the Faro sample rate, restart, and confirm the effective rate.
- Debug → Config: disable and re-enable Faro data collection and confirm it applies immediately.
- Debug tab → logs / events / handled + unhandled exceptions reach Faro and echo through DemoRum.