### PR TITLE
feat(flutter): add real telemetry replay harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ logs.txt
 /Mobiles/android/.gradle
 /Mobiles/android/app/src/main/res/raw/config.json
 /Mobiles/android/local.properties
+/Mobiles/flutter/benchmark/.captures/
+/Mobiles/flutter/benchmark/.runtime/

--- a/Mobiles/flutter/benchmark/README.md
+++ b/Mobiles/flutter/benchmark/README.md
@@ -1,0 +1,93 @@
+# Flutter QuickPizza telemetry replay
+
+This local-only harness captures real Faro payloads from the Flutter QuickPizza app, keeps the raw request bodies unchanged, creates a sanitized copy, and replays the same telemetry mix with fresh timestamps and correlated IDs.
+
+It intentionally does not send data to Grafana Cloud or any shared development stack.
+
+## Prerequisites
+
+- Flutter
+- Go
+- Node.js 22 or newer
+- Grafana Alloy with `faro.receiver`
+- Loki
+- An iOS simulator or Android emulator
+
+## Capture one session
+
+Start the local telemetry stack:
+
+```bash
+cd Mobiles/flutter/benchmark
+node local-stack.mjs
+```
+
+In another terminal, start the byte-preserving proxy. Use a new capture directory for every scenario:
+
+```bash
+node capture-proxy.mjs \
+  --output .captures/flutter-session-001 \
+  --scenario launch-request-rate-background-foreground
+```
+
+Run the QuickPizza backend from the repository root:
+
+```bash
+make build-go
+./bin/quickpizza
+```
+
+Run the Flutter app with the proxy as its collector:
+
+```bash
+cd Mobiles/flutter
+flutter run \
+  --dart-define=FARO_COLLECTOR_URL=http://127.0.0.1:12348/collect/local-benchmark-key \
+  --dart-define=BASE_URL=http://127.0.0.1:3333 \
+  --dart-define=PORT=3333
+```
+
+Complete the named scenario once, allow the Faro batch to flush, then stop the app and proxy. Files under `.captures/<capture>/raw` are the exact HTTP request bodies and must not be edited.
+
+Captured payloads can contain user or device identifiers. The entire `.captures` directory is ignored by Git. Only sanitized summaries should be committed.
+
+## Sanitize and prepare replay
+
+```bash
+node prepare-replay.mjs \
+  --capture .captures/flutter-session-001 \
+  --run flutter-session-001-replay
+```
+
+The command:
+
+- preserves the raw capture and records its SHA-256 hashes;
+- replaces user and installation identifiers in a separate sanitized copy;
+- rejects remaining obvious credentials or email addresses;
+- shifts timestamps while preserving their relative spacing;
+- remaps session, page, action, trace, and span IDs consistently;
+- adds `benchmark_run_id` as a session attribute;
+- fails if source and replay item counts differ.
+
+## Replay and validate Sessions
+
+```bash
+node replay.mjs \
+  --input .captures/flutter-session-001/replay/flutter-session-001-replay
+
+node validate-loki.mjs --run flutter-session-001-replay
+```
+
+The validation runs the same lifecycle-event shape used by Mobile O11y Sessions and requires at least one parsed `session_id`.
+
+## Recorded validations
+
+Sanitized capture and replay summaries live under [`results`](results). Raw payloads remain local and are not committed.
+
+## Tests
+
+```bash
+node --test lib/telemetry.test.mjs
+alloy validate config/alloy.local.alloy
+loki -config.file=config/loki.local.yaml -verify-config
+```

--- a/Mobiles/flutter/benchmark/README.md
+++ b/Mobiles/flutter/benchmark/README.md
@@ -37,13 +37,23 @@ make build-go
 ./bin/quickpizza
 ```
 
-Run the Flutter app with the proxy as its collector:
+Run the Flutter app with the proxy as its collector. For an iOS simulator, use the host loopback address:
 
 ```bash
 cd Mobiles/flutter
 flutter run \
   --dart-define=FARO_COLLECTOR_URL=http://127.0.0.1:12348/collect/local-benchmark-key \
   --dart-define=BASE_URL=http://127.0.0.1:3333 \
+  --dart-define=PORT=3333
+```
+
+For an Android emulator, use its `10.0.2.2` alias for the host machine:
+
+```bash
+cd Mobiles/flutter
+flutter run \
+  --dart-define=FARO_COLLECTOR_URL=http://10.0.2.2:12348/collect/local-benchmark-key \
+  --dart-define=BASE_URL=http://10.0.2.2:3333 \
   --dart-define=PORT=3333
 ```
 
@@ -75,10 +85,12 @@ The command:
 node replay.mjs \
   --input .captures/flutter-session-001/replay/flutter-session-001-replay
 
-node validate-loki.mjs --run flutter-session-001-replay
+node validate-loki.mjs \
+  --run flutter-session-001-replay \
+  --manifest .captures/flutter-session-001/replay/flutter-session-001-replay/replay-manifest.json
 ```
 
-The validation runs the same lifecycle-event shape used by Mobile O11y Sessions and requires at least one parsed `session_id`.
+The validation runs the same lifecycle-event shape used by Mobile O11y Sessions, requires at least one parsed `session_id`, and checks that Loki received the expected event, measurement, log, and exception counts from the replay manifest. Trace counts are checked when preparing the replay but are not included in the Loki comparison because this local stack does not route traces to Loki.
 
 ## Recorded validations
 

--- a/Mobiles/flutter/benchmark/README.md
+++ b/Mobiles/flutter/benchmark/README.md
@@ -87,7 +87,7 @@ Sanitized capture and replay summaries live under [`results`](results). Raw payl
 ## Tests
 
 ```bash
-node --test lib/telemetry.test.mjs
+node --test lib/*.test.mjs
 alloy validate config/alloy.local.alloy
 loki -config.file=config/loki.local.yaml -verify-config
 ```

--- a/Mobiles/flutter/benchmark/capture-proxy.mjs
+++ b/Mobiles/flutter/benchmark/capture-proxy.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { createServer } from 'node:http';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { sha256 } from './lib/telemetry.mjs';
+
+const { values } = parseArgs({
+  options: {
+    output: { type: 'string', short: 'o' },
+    forward: { type: 'string', default: 'http://127.0.0.1:12347/collect' },
+    port: { type: 'string', default: '12348' },
+    scenario: { type: 'string', default: 'launch-request-rate-background-foreground' },
+  },
+});
+
+if (!values.output) {
+  throw new Error('--output is required');
+}
+
+const outputDir = resolve(values.output);
+const rawDir = join(outputDir, 'raw');
+const manifestPath = join(outputDir, 'capture-manifest.json');
+const port = Number(values.port);
+await mkdir(rawDir, { recursive: true });
+
+const manifest = {
+  format: 1,
+  capturedAt: new Date().toISOString(),
+  scenario: values.scenario,
+  forwardTarget: 'local-faro-receiver',
+  requests: [],
+};
+
+let requestNumber = 0;
+let manifestWrite = Promise.resolve();
+let stopping = false;
+
+const server = createServer(async (request, response) => {
+  try {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const body = Buffer.concat(chunks);
+    requestNumber += 1;
+    const filename = `request-${String(requestNumber).padStart(4, '0')}.json`;
+    await writeFile(join(rawDir, filename), body, { flag: 'wx' });
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(request.headers)) {
+      if (value != null && !['host', 'content-length'].includes(key.toLowerCase())) {
+        headers.set(key, Array.isArray(value) ? value.join(', ') : value);
+      }
+    }
+
+    const forwarded = await fetch(values.forward, {
+      method: request.method,
+      headers,
+      body,
+    });
+    const forwardedBody = Buffer.from(await forwarded.arrayBuffer());
+
+    manifest.requests.push({
+      filename,
+      capturedAt: new Date().toISOString(),
+      bytes: body.length,
+      sha256: sha256(body),
+      contentType: request.headers['content-type'] ?? null,
+      forwardedStatus: forwarded.status,
+    });
+    await queueManifestWrite();
+
+    response.writeHead(forwarded.status, Object.fromEntries(forwarded.headers.entries()));
+    response.end(forwardedBody);
+    process.stdout.write(`Captured ${filename} (${body.length} bytes)\n`);
+  } catch (error) {
+    response.writeHead(502, { 'content-type': 'text/plain' });
+    response.end('Local capture proxy failed');
+    process.stderr.write(`${error.stack ?? error}\n`);
+  }
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`Capture proxy listening on http://127.0.0.1:${port}\n`);
+  process.stdout.write(`Raw payloads: ${rawDir}\n`);
+});
+
+async function writeManifest() {
+  const temporaryPath = `${manifestPath}.${process.pid}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await rename(temporaryPath, manifestPath);
+}
+
+function queueManifestWrite() {
+  manifestWrite = manifestWrite.then(writeManifest);
+  return manifestWrite;
+}
+
+async function shutdown() {
+  if (stopping) {
+    return;
+  }
+  stopping = true;
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  await queueManifestWrite();
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/Mobiles/flutter/benchmark/capture-proxy.mjs
+++ b/Mobiles/flutter/benchmark/capture-proxy.mjs
@@ -5,6 +5,7 @@ import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
+import { isCollectorRequest } from './lib/http.mjs';
 import { sha256 } from './lib/telemetry.mjs';
 
 const { values } = parseArgs({
@@ -43,6 +44,12 @@ let stopping = false;
 
 const server = createServer(async (request, response) => {
   try {
+    if (!isCollectorRequest(request.method, request.url)) {
+      response.writeHead(404, { 'content-type': 'text/plain' });
+      response.end('Not found');
+      return;
+    }
+
     const chunks = [];
     for await (const chunk of request) {
       chunks.push(chunk);

--- a/Mobiles/flutter/benchmark/capture-proxy.mjs
+++ b/Mobiles/flutter/benchmark/capture-proxy.mjs
@@ -24,6 +24,9 @@ const outputDir = resolve(values.output);
 const rawDir = join(outputDir, 'raw');
 const manifestPath = join(outputDir, 'capture-manifest.json');
 const port = Number(values.port);
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new Error(`--port must be an integer between 1 and 65535: ${values.port}`);
+}
 await mkdir(rawDir, { recursive: true });
 
 const manifest = {
@@ -95,8 +98,9 @@ async function writeManifest() {
 }
 
 function queueManifestWrite() {
-  manifestWrite = manifestWrite.then(writeManifest);
-  return manifestWrite;
+  const nextWrite = manifestWrite.catch(() => {}).then(writeManifest);
+  manifestWrite = nextWrite.catch(() => {});
+  return nextWrite;
 }
 
 async function shutdown() {

--- a/Mobiles/flutter/benchmark/config/alloy.local.alloy
+++ b/Mobiles/flutter/benchmark/config/alloy.local.alloy
@@ -1,0 +1,38 @@
+loki.write "local" {
+	endpoint {
+		url = "http://127.0.0.1:3100/loki/api/v1/push"
+	}
+}
+
+loki.process "mobile_o11y_labels" {
+	stage.logfmt {
+		mapping = {
+			kind = "kind",
+		}
+	}
+
+	stage.labels {
+		values = {
+			kind = "kind",
+		}
+	}
+
+	forward_to = [loki.write.local.receiver]
+}
+
+faro.receiver "quickpizza_flutter" {
+	extra_log_labels = {
+		app_id           = "quickpizza-flutter-local",
+		benchmark_source = "quickpizza-flutter",
+	}
+
+	server {
+		listen_address       = "127.0.0.1"
+		listen_port          = 12347
+		cors_allowed_origins = ["*"]
+	}
+
+	output {
+		logs = [loki.process.mobile_o11y_labels.receiver]
+	}
+}

--- a/Mobiles/flutter/benchmark/config/loki.local.yaml
+++ b/Mobiles/flutter/benchmark/config/loki.local.yaml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_address: 127.0.0.1
+  http_listen_port: 3100
+
+common:
+  path_prefix: .runtime/loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: .runtime/loki/chunks
+      rules_directory: .runtime/loki/rules
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: .runtime/loki/compactor

--- a/Mobiles/flutter/benchmark/lib/http.mjs
+++ b/Mobiles/flutter/benchmark/lib/http.mjs
@@ -1,0 +1,8 @@
+export function isCollectorRequest(method, requestUrl) {
+  if (method !== 'POST') {
+    return false;
+  }
+
+  const pathname = new URL(requestUrl ?? '/', 'http://localhost').pathname;
+  return pathname === '/collect' || pathname.startsWith('/collect/');
+}

--- a/Mobiles/flutter/benchmark/lib/http.test.mjs
+++ b/Mobiles/flutter/benchmark/lib/http.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isCollectorRequest } from './http.mjs';
+
+test('accepts Faro collector POST requests', () => {
+  assert.equal(isCollectorRequest('POST', '/collect'), true);
+  assert.equal(isCollectorRequest('POST', '/collect/local-benchmark-key'), true);
+  assert.equal(isCollectorRequest('POST', '/collect/local-benchmark-key?source=test'), true);
+});
+
+test('rejects unrelated paths and methods', () => {
+  assert.equal(isCollectorRequest('GET', '/collect/local-benchmark-key'), false);
+  assert.equal(isCollectorRequest('POST', '/health'), false);
+  assert.equal(isCollectorRequest('POST', '/collector'), false);
+});

--- a/Mobiles/flutter/benchmark/lib/logql.mjs
+++ b/Mobiles/flutter/benchmark/lib/logql.mjs
@@ -1,0 +1,3 @@
+export function quoteLogQLString(value) {
+  return JSON.stringify(String(value));
+}

--- a/Mobiles/flutter/benchmark/lib/logql.test.mjs
+++ b/Mobiles/flutter/benchmark/lib/logql.test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { quoteLogQLString } from './logql.mjs';
+
+test('quotes strings for LogQL selectors and filters', () => {
+  assert.equal(quoteLogQLString('run-"one"\\next\nline'), '"run-\\"one\\"\\\\next\\nline"');
+});

--- a/Mobiles/flutter/benchmark/lib/telemetry.mjs
+++ b/Mobiles/flutter/benchmark/lib/telemetry.mjs
@@ -1,0 +1,423 @@
+import { createHash } from 'node:crypto';
+
+export const PAYLOAD_ITEM_KEYS = [
+  'events',
+  'measurements',
+  'logs',
+  'exceptions',
+];
+
+export function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function countPayloadItems(payload) {
+  const counts = Object.fromEntries(
+    PAYLOAD_ITEM_KEYS.map((key) => [
+      key,
+      Array.isArray(payload[key]) ? payload[key].length : 0,
+    ]),
+  );
+  counts.traces = countSpans(payload.traces);
+  counts.total = Object.values(counts).reduce((sum, value) => sum + value, 0);
+  return counts;
+}
+
+export function addCounts(total, next) {
+  const result = { ...total };
+  for (const [key, value] of Object.entries(next)) {
+    result[key] = (result[key] ?? 0) + value;
+  }
+  return result;
+}
+
+export function sanitizePayload(payload) {
+  return sanitizeValue(structuredClone(payload), []);
+}
+
+export function findSensitiveValues(payload) {
+  const findings = [];
+  inspectSensitiveValue(payload, [], findings);
+  return findings;
+}
+
+export function prepareReplayPayloads(payloads, { runId, startTime }) {
+  if (!runId) {
+    throw new Error('runId is required');
+  }
+
+  const cloned = structuredClone(payloads);
+  const earliestTimestamp = findEarliestTimestamp(cloned);
+  const targetTimestamp = startTime ? Date.parse(startTime) : Date.now();
+  if (Number.isNaN(targetTimestamp)) {
+    throw new Error(`Invalid start time: ${startTime}`);
+  }
+
+  const offsetMs = earliestTimestamp == null ? 0 : targetTimestamp - earliestTimestamp;
+  const idMaps = new Map();
+
+  for (const payload of cloned) {
+    transformValue(payload, [], { runId, offsetMs, idMaps });
+    if (!payload.meta?.session) {
+      throw new Error('A Faro session is required for benchmark replay');
+    }
+    payload.meta.session.attributes ??= {};
+    payload.meta.session.attributes.benchmark_run_id = runId;
+  }
+
+  return {
+    payloads: cloned,
+    offsetMs,
+    remappedIds: Object.fromEntries(
+      [...idMaps.entries()].map(([kind, values]) => [kind, values.size]),
+    ),
+  };
+}
+
+function countSpans(value, key = '') {
+  if (value == null || typeof value !== 'object') {
+    return 0;
+  }
+  if (Array.isArray(value)) {
+    const current = key === 'spans' ? value.length : 0;
+    return current + value.reduce((sum, item) => sum + countSpans(item), 0);
+  }
+  return Object.entries(value).reduce(
+    (sum, [childKey, child]) => sum + countSpans(child, childKey),
+    0,
+  );
+}
+
+function sanitizeValue(value, path) {
+  if (Array.isArray(value)) {
+    return value.map((item, index) => sanitizeValue(item, [...path, index]));
+  }
+  if (value == null || typeof value !== 'object') {
+    return sanitizeScalar(value, path);
+  }
+
+  const otelAttribute = getOtelStringAttribute(value);
+  if (otelAttribute) {
+    otelAttribute.value.stringValue = sanitizeOtelAttribute(
+      otelAttribute.key,
+      otelAttribute.value.stringValue,
+    );
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = [...path, key];
+    const normalizedPath = childPath.join('.').toLowerCase();
+    if (normalizedPath === 'meta.user.id') {
+      value[key] = 'benchmark-source-user';
+    } else if (normalizedPath === 'meta.user.username') {
+      value[key] = 'quickpizza-benchmark';
+    } else if (normalizedPath === 'meta.user.email') {
+      value[key] = 'benchmark@example.invalid';
+    } else if (normalizedPath.startsWith('meta.user.attributes.')) {
+      value[key] = 'redacted';
+    } else if (normalizedPath === 'meta.app.installationid') {
+      value[key] = 'benchmark-source-installation';
+    } else if (normalizedPath === 'meta.session.attributes.device_id') {
+      value[key] = 'benchmark-source-device';
+    } else if (isSensitiveKey(key)) {
+      value[key] = '[redacted]';
+    } else {
+      value[key] = sanitizeValue(child, childPath);
+    }
+  }
+  return value;
+}
+
+function sanitizeScalar(value, path) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (looksLikeEmail(value) && path.join('.').toLowerCase() !== 'meta.user.email') {
+    return 'benchmark@example.invalid';
+  }
+  return value;
+}
+
+function inspectSensitiveValue(value, path, findings) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => inspectSensitiveValue(item, [...path, index], findings));
+    return;
+  }
+  if (value == null || typeof value !== 'object') {
+    const key = String(path.at(-1) ?? '');
+    const normalizedPath = path.join('.').toLowerCase();
+    if (
+      typeof value === 'string' &&
+      isSensitiveIdentityPath(normalizedPath) &&
+      !isSanitizedIdentifier(value)
+    ) {
+      findings.push(path.join('.'));
+    } else if (typeof value === 'string' && value !== '[redacted]' && isSensitiveKey(key)) {
+      findings.push(path.join('.'));
+    } else if (
+      typeof value === 'string' &&
+      looksLikeEmail(value) &&
+      value !== 'benchmark@example.invalid'
+    ) {
+      findings.push(path.join('.'));
+    }
+    return;
+  }
+  const otelAttribute = getOtelStringAttribute(value);
+  if (
+    otelAttribute &&
+    ((isSensitiveAttributeKey(otelAttribute.key) &&
+      !isSanitizedIdentifier(otelAttribute.value.stringValue)) ||
+      (looksLikeEmail(otelAttribute.value.stringValue) &&
+        otelAttribute.value.stringValue !== 'benchmark@example.invalid'))
+  ) {
+    findings.push([...path, 'value', 'stringValue'].join('.'));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    inspectSensitiveValue(child, [...path, key], findings);
+  }
+}
+
+function isSensitiveKey(key) {
+  return /^(authorization|api[_-]?key|password|passwd|cookie|secret|access[_-]?token|refresh[_-]?token)$/i.test(
+    key,
+  );
+}
+
+function looksLikeEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function findEarliestTimestamp(payloads) {
+  let earliest = null;
+
+  visit(payloads, [], (value, path) => {
+    const key = normalizeKey(path.at(-1));
+    let timestamp = null;
+    if (typeof value === 'string' && key === 'timestamp') {
+      const parsed = Date.parse(value);
+      timestamp = Number.isNaN(parsed) ? null : parsed;
+    } else if (typeof value === 'string' && key.endsWith('timeunixnano')) {
+      try {
+        timestamp = Number(BigInt(value) / 1_000_000n);
+      } catch {
+        timestamp = null;
+      }
+    }
+    if (timestamp != null && (earliest == null || timestamp < earliest)) {
+      earliest = timestamp;
+    }
+  });
+
+  return earliest;
+}
+
+function transformValue(value, path, context) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => transformValue(item, [...path, index], context));
+    return;
+  }
+  if (value == null || typeof value !== 'object') {
+    return;
+  }
+
+  const otelAttribute = getOtelStringAttribute(value);
+  const otelIdKind = otelAttribute ? attributeIdKind(otelAttribute.key) : null;
+  if (otelAttribute && otelIdKind && otelAttribute.value.stringValue !== '') {
+    otelAttribute.value.stringValue = remapId(
+      otelAttribute.value.stringValue,
+      otelIdKind,
+      context,
+    );
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = [...path, key];
+    if (typeof child === 'string') {
+      const normalizedKey = normalizeKey(key);
+      if (normalizedKey === 'timestamp') {
+        const parsed = Date.parse(child);
+        if (!Number.isNaN(parsed)) {
+          value[key] = new Date(parsed + context.offsetMs).toISOString();
+          continue;
+        }
+      }
+      if (normalizedKey.endsWith('timeunixnano')) {
+        try {
+          value[key] = (BigInt(child) + BigInt(context.offsetMs) * 1_000_000n).toString();
+          continue;
+        } catch {
+          // Keep malformed trace timestamps unchanged.
+        }
+      }
+
+      const idKind = correlatedIdKind(childPath);
+      if (idKind != null && child !== '') {
+        value[key] = remapId(child, idKind, context);
+        continue;
+      }
+    }
+    transformValue(child, childPath, context);
+  }
+}
+
+function correlatedIdKind(path) {
+  const key = normalizeKey(path.at(-1));
+  const parent = normalizeKey(path.at(-2));
+  const directKinds = {
+    sessionid: 'session',
+    pageid: 'page',
+    viewid: 'view',
+    traceid: 'trace',
+    spanid: 'span',
+    parentspanid: 'span',
+    actionid: 'action',
+    actionparentid: 'action',
+    installationid: 'installation',
+    deviceid: 'device',
+    userid: 'user',
+  };
+  if (directKinds[key]) {
+    return directKinds[key];
+  }
+  if (key === 'parentid' && parent === 'action') {
+    return 'action';
+  }
+  if (key === 'id' && ['session', 'page', 'view', 'action', 'user'].includes(parent)) {
+    return parent;
+  }
+  return null;
+}
+
+function attributeIdKind(key) {
+  const normalizedKey = normalizeKey(key);
+  const kinds = {
+    actionid: 'action',
+    appinstallationid: 'installation',
+    deviceid: 'device',
+    faroactionuserid: 'action',
+    faroactionuserparentid: 'action',
+    installationid: 'installation',
+    pageid: 'page',
+    parentspanid: 'span',
+    sessionid: 'session',
+    spanid: 'span',
+    traceid: 'trace',
+    userid: 'user',
+    viewid: 'view',
+  };
+  return kinds[normalizedKey] ?? null;
+}
+
+function getOtelStringAttribute(value) {
+  if (
+    typeof value?.key === 'string' &&
+    value.value != null &&
+    typeof value.value === 'object' &&
+    typeof value.value.stringValue === 'string'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function sanitizeOtelAttribute(key, value) {
+  const normalizedKey = normalizeKey(key);
+  if (normalizedKey === 'userid') {
+    return 'benchmark-source-user';
+  }
+  if (['useremail', 'email'].includes(normalizedKey)) {
+    return 'benchmark@example.invalid';
+  }
+  if (['username', 'userusername'].includes(normalizedKey)) {
+    return 'quickpizza-benchmark';
+  }
+  if (normalizedKey === 'deviceid') {
+    return 'benchmark-source-device';
+  }
+  if (['appinstallationid', 'installationid'].includes(normalizedKey)) {
+    return 'benchmark-source-installation';
+  }
+  if (isSensitiveAttributeKey(key)) {
+    return '[redacted]';
+  }
+  return looksLikeEmail(value) ? 'benchmark@example.invalid' : value;
+}
+
+function isSensitiveAttributeKey(key) {
+  if (
+    [
+      'appinstallationid',
+      'deviceid',
+      'email',
+      'installationid',
+      'useremail',
+      'userid',
+      'username',
+      'userusername',
+    ].includes(normalizeKey(key))
+  ) {
+    return true;
+  }
+  const finalSegment = String(key).split(/[._-]/).at(-1) ?? '';
+  return isSensitiveKey(finalSegment);
+}
+
+function isSensitiveIdentityPath(path) {
+  return [
+    'meta.app.installationid',
+    'meta.session.attributes.device_id',
+    'meta.user.email',
+    'meta.user.id',
+    'meta.user.username',
+  ].includes(path);
+}
+
+function isSanitizedIdentifier(value) {
+  return [
+    '[redacted]',
+    'benchmark-source-device',
+    'benchmark-source-installation',
+    'benchmark-source-user',
+    'benchmark@example.invalid',
+    'quickpizza-benchmark',
+    'redacted',
+  ].includes(value);
+}
+
+function remapId(value, kind, context) {
+  let values = context.idMaps.get(kind);
+  if (!values) {
+    values = new Map();
+    context.idMaps.set(kind, values);
+  }
+  if (!values.has(value)) {
+    const digest = sha256(`${context.runId}:${kind}:${value}`);
+    const replacement = /^[0-9a-f]+$/i.test(value)
+      ? digest.slice(0, value.length)
+      : `${kind}-${digest.slice(0, 16)}`;
+    values.set(value, replacement);
+  }
+  return values.get(value);
+}
+
+function normalizeKey(value) {
+  return String(value ?? '')
+    .replaceAll(/[._-]/g, '')
+    .toLowerCase();
+}
+
+function visit(value, path, visitor) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => visit(item, [...path, index], visitor));
+    return;
+  }
+  if (value == null || typeof value !== 'object') {
+    visitor(value, path);
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    visit(child, [...path, key], visitor);
+  }
+}

--- a/Mobiles/flutter/benchmark/lib/telemetry.test.mjs
+++ b/Mobiles/flutter/benchmark/lib/telemetry.test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  countPayloadItems,
+  findSensitiveValues,
+  prepareReplayPayloads,
+  sanitizePayload,
+} from './telemetry.mjs';
+
+function fixture() {
+  return {
+    meta: {
+      app: { version: '1.1.1', installationId: 'install-original' },
+      sdk: { version: '0.17.0-beta.1' },
+      session: {
+        id: 'session-original',
+        attributes: { device_id: 'device-original', device_model: 'iPhone' },
+      },
+      user: { id: 'user-original', username: 'default', email: 'person@example.com' },
+    },
+    events: [
+      {
+        name: 'session_start',
+        timestamp: '2026-07-14T12:00:00.000Z',
+        trace: { traceId: '0123456789abcdef0123456789abcdef', spanId: '0123456789abcdef' },
+      },
+      {
+        name: 'faro.user.action',
+        timestamp: '2026-07-14T12:00:05.000Z',
+        action: { id: 'action-original', name: 'request pizza' },
+      },
+    ],
+    measurements: [],
+    logs: [],
+    exceptions: [],
+    traces: {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: 'device_id', value: { stringValue: 'device-original' } },
+            ],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: '0123456789abcdef0123456789abcdef',
+                  spanId: '0123456789abcdef',
+                  attributes: [
+                    { key: 'session.id', value: { stringValue: 'session-original' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+test('sanitizes identifying user and installation fields', () => {
+  const sanitized = sanitizePayload(fixture());
+  assert.equal(sanitized.meta.user.id, 'benchmark-source-user');
+  assert.equal(sanitized.meta.user.email, 'benchmark@example.invalid');
+  assert.equal(sanitized.meta.app.installationId, 'benchmark-source-installation');
+  assert.equal(sanitized.meta.session.attributes.device_id, 'benchmark-source-device');
+  assert.equal(
+    sanitized.traces.resourceSpans[0].resource.attributes[0].value.stringValue,
+    'benchmark-source-device',
+  );
+  assert.deepEqual(findSensitiveValues(sanitized), []);
+});
+
+test('preserves item counts and relative time while remapping correlated IDs', () => {
+  const source = sanitizePayload(fixture());
+  const sourceCounts = countPayloadItems(source);
+  const prepared = prepareReplayPayloads([source], {
+    runId: 'run-20260714-1',
+    startTime: '2026-07-14T13:00:00.000Z',
+  });
+  const replay = prepared.payloads[0];
+
+  assert.deepEqual(countPayloadItems(replay), sourceCounts);
+  assert.equal(replay.events[0].timestamp, '2026-07-14T13:00:00.000Z');
+  assert.equal(replay.events[1].timestamp, '2026-07-14T13:00:05.000Z');
+  assert.notEqual(replay.meta.session.id, source.meta.session.id);
+  assert.notEqual(
+    replay.meta.session.attributes.device_id,
+    source.meta.session.attributes.device_id,
+  );
+  assert.notEqual(replay.events[0].trace.traceId, source.events[0].trace.traceId);
+  assert.equal(replay.events[0].trace.traceId.length, 32);
+  assert.equal(replay.meta.session.attributes.benchmark_run_id, 'run-20260714-1');
+  assert.equal(replay.meta.app.version, source.meta.app.version);
+  assert.equal(replay.meta.sdk.version, source.meta.sdk.version);
+  assert.equal(
+    replay.traces.resourceSpans[0].scopeSpans[0].spans[0].attributes[0].value.stringValue,
+    replay.meta.session.id,
+  );
+  assert.equal(
+    replay.traces.resourceSpans[0].resource.attributes[0].value.stringValue,
+    replay.meta.session.attributes.device_id,
+  );
+});
+
+test('uses one mapping for repeated correlated IDs', () => {
+  const source = sanitizePayload(fixture());
+  source.events[1].attributes = { session_id: source.meta.session.id };
+  const { payloads } = prepareReplayPayloads([source], { runId: 'run-consistent' });
+  assert.equal(payloads[0].meta.session.id, payloads[0].events[1].attributes.session_id);
+});

--- a/Mobiles/flutter/benchmark/local-stack.mjs
+++ b/Mobiles/flutter/benchmark/local-stack.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { closeSync, openSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const benchmarkDir = dirname(fileURLToPath(import.meta.url));
+const runtimeDir = join(benchmarkDir, '.runtime');
+await mkdir(runtimeDir, { recursive: true });
+
+const children = [];
+const logDescriptors = [];
+children.push(await start('loki', ['-config.file=config/loki.local.yaml'], 'loki.log'));
+await waitFor('http://127.0.0.1:3100/ready');
+children.push(
+  await start(
+    'alloy',
+    [
+      'run',
+      '--disable-reporting',
+      '--server.http.listen-addr=127.0.0.1:12346',
+      '--storage.path=.runtime/alloy',
+      'config/alloy.local.alloy',
+    ],
+    'alloy.log',
+  ),
+);
+await waitFor('http://127.0.0.1:12346/-/ready');
+
+process.stdout.write('Local Loki and Faro receiver are ready\n');
+process.stdout.write('Faro receiver: http://127.0.0.1:12347/collect\n');
+process.stdout.write('Press Ctrl-C to stop\n');
+
+process.on('SIGINT', () => shutdown());
+process.on('SIGTERM', () => shutdown());
+
+await new Promise(() => {});
+
+async function start(command, args, logName) {
+  const logDescriptor = openSync(join(runtimeDir, logName), 'w');
+  logDescriptors.push(logDescriptor);
+  const child = spawn(command, args, {
+    cwd: benchmarkDir,
+    stdio: ['ignore', logDescriptor, logDescriptor],
+  });
+  child.on('exit', (code) => {
+    if (code !== 0 && code != null) {
+      process.stderr.write(`${command} exited with code ${code}; see ${logName}\n`);
+      shutdown(1);
+    }
+  });
+  return child;
+}
+
+async function waitFor(url) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Service is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+function shutdown(code = 0) {
+  for (const child of children) {
+    child.kill('SIGTERM');
+  }
+  setTimeout(() => {
+    for (const descriptor of logDescriptors) {
+      closeSync(descriptor);
+    }
+    process.exit(code);
+  }, 250);
+}

--- a/Mobiles/flutter/benchmark/local-stack.mjs
+++ b/Mobiles/flutter/benchmark/local-stack.mjs
@@ -12,6 +12,7 @@ await mkdir(runtimeDir, { recursive: true });
 
 const children = [];
 const logDescriptors = [];
+let stopping = false;
 children.push(await start('loki', ['-config.file=config/loki.local.yaml'], 'loki.log'));
 await waitFor('http://127.0.0.1:3100/ready');
 children.push(
@@ -45,6 +46,12 @@ async function start(command, args, logName) {
     cwd: benchmarkDir,
     stdio: ['ignore', logDescriptor, logDescriptor],
   });
+  child.on('error', (error) => {
+    process.stderr.write(
+      `Failed to start ${command}: ${error.message}. Is it installed and available on PATH?\n`,
+    );
+    shutdown(1);
+  });
   child.on('exit', (code) => {
     if (code !== 0 && code != null) {
       process.stderr.write(`${command} exited with code ${code}; see ${logName}\n`);
@@ -71,6 +78,10 @@ async function waitFor(url) {
 }
 
 function shutdown(code = 0) {
+  if (stopping) {
+    return;
+  }
+  stopping = true;
   for (const child of children) {
     child.kill('SIGTERM');
   }

--- a/Mobiles/flutter/benchmark/prepare-replay.mjs
+++ b/Mobiles/flutter/benchmark/prepare-replay.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import {
+  addCounts,
+  countPayloadItems,
+  findSensitiveValues,
+  prepareReplayPayloads,
+  sanitizePayload,
+  sha256,
+} from './lib/telemetry.mjs';
+
+const { values } = parseArgs({
+  options: {
+    capture: { type: 'string', short: 'c' },
+    run: { type: 'string', short: 'r' },
+    start: { type: 'string' },
+  },
+});
+
+if (!values.capture || !values.run) {
+  throw new Error('--capture and --run are required');
+}
+
+const captureDir = resolve(values.capture);
+const rawDir = join(captureDir, 'raw');
+const sanitizedDir = join(captureDir, 'sanitized-source');
+const replayDir = join(captureDir, 'replay', values.run);
+const filenames = (await readdir(rawDir)).filter((name) => name.endsWith('.json')).sort();
+if (filenames.length === 0) {
+  throw new Error(`No captured payloads found in ${rawDir}`);
+}
+
+await mkdir(sanitizedDir, { recursive: true });
+await mkdir(replayDir, { recursive: true });
+
+const rawBuffers = await Promise.all(filenames.map((name) => readFile(join(rawDir, name))));
+const rawPayloads = rawBuffers.map((body, index) => {
+  try {
+    return JSON.parse(body.toString('utf8'));
+  } catch (error) {
+    throw new Error(`${filenames[index]} is not valid JSON: ${error.message}`);
+  }
+});
+const sanitizedPayloads = rawPayloads.map(sanitizePayload);
+const sensitiveFindings = sanitizedPayloads.flatMap((payload, index) =>
+  findSensitiveValues(payload).map((path) => `${filenames[index]}:${path}`),
+);
+if (sensitiveFindings.length > 0) {
+  throw new Error(`Sensitive values remain after sanitization:\n${sensitiveFindings.join('\n')}`);
+}
+
+const prepared = prepareReplayPayloads(sanitizedPayloads, {
+  runId: values.run,
+  startTime: values.start,
+});
+
+let sourceCounts = {};
+let replayCounts = {};
+const files = [];
+for (let index = 0; index < filenames.length; index += 1) {
+  const filename = filenames[index];
+  const raw = rawBuffers[index];
+  const sanitized = `${JSON.stringify(sanitizedPayloads[index], null, 2)}\n`;
+  const replay = `${JSON.stringify(prepared.payloads[index], null, 2)}\n`;
+  await writeFile(join(sanitizedDir, filename), sanitized);
+  await writeFile(join(replayDir, filename), replay);
+
+  const currentSourceCounts = countPayloadItems(sanitizedPayloads[index]);
+  const currentReplayCounts = countPayloadItems(prepared.payloads[index]);
+  sourceCounts = addCounts(sourceCounts, currentSourceCounts);
+  replayCounts = addCounts(replayCounts, currentReplayCounts);
+  files.push({
+    filename,
+    rawSha256: sha256(raw),
+    sanitizedSha256: sha256(sanitized),
+    replaySha256: sha256(replay),
+    sourceCounts: currentSourceCounts,
+    replayCounts: currentReplayCounts,
+  });
+}
+
+if (JSON.stringify(sourceCounts) !== JSON.stringify(replayCounts)) {
+  throw new Error('Source and replay item counts differ');
+}
+
+const firstMeta = sanitizedPayloads.find((payload) => payload.meta)?.meta ?? {};
+const manifest = {
+  format: 1,
+  createdAt: new Date().toISOString(),
+  benchmarkRunId: values.run,
+  app: firstMeta.app ?? null,
+  sdk: firstMeta.sdk ?? null,
+  requestCount: filenames.length,
+  sourceCounts,
+  replayCounts,
+  timestampOffsetMs: prepared.offsetMs,
+  remappedIds: prepared.remappedIds,
+  sensitiveFindings: [],
+  rawCapturePreserved: true,
+  files,
+};
+await writeFile(join(replayDir, 'replay-manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+
+process.stdout.write(`Prepared ${filenames.length} payloads in ${replayDir}\n`);
+process.stdout.write(`Counts: ${JSON.stringify(sourceCounts)}\n`);
+process.stdout.write(`App: ${firstMeta.app?.version ?? 'unknown'}\n`);
+process.stdout.write(`SDK: ${firstMeta.sdk?.version ?? 'unknown'}\n`);
+process.stdout.write(`Manifest: ${basename(replayDir)}/replay-manifest.json\n`);

--- a/Mobiles/flutter/benchmark/replay.mjs
+++ b/Mobiles/flutter/benchmark/replay.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { readFile, readdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    input: { type: 'string', short: 'i' },
+    endpoint: { type: 'string', default: 'http://127.0.0.1:12347/collect' },
+  },
+});
+
+if (!values.input) {
+  throw new Error('--input is required');
+}
+
+const inputDir = resolve(values.input);
+const filenames = (await readdir(inputDir))
+  .filter((name) => name.startsWith('request-') && name.endsWith('.json'))
+  .sort();
+if (filenames.length === 0) {
+  throw new Error(`No replay payloads found in ${inputDir}`);
+}
+
+for (const filename of filenames) {
+  const body = await readFile(join(inputDir, filename));
+  const response = await fetch(values.endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(`${filename} failed with HTTP ${response.status}: ${await response.text()}`);
+  }
+  process.stdout.write(`Replayed ${filename}\n`);
+}
+
+process.stdout.write(`Replayed ${filenames.length} payloads to local Faro receiver\n`);

--- a/Mobiles/flutter/benchmark/results/2026-07-14-quickpizza-flutter-session.md
+++ b/Mobiles/flutter/benchmark/results/2026-07-14-quickpizza-flutter-session.md
@@ -1,0 +1,28 @@
+# QuickPizza Flutter local replay validation
+
+## Source
+
+- App: `QuickPizza_Flutter` `1.1.1`
+- SDK: `faro-mobile-flutter` `0.17.0-beta.1`
+- Scenario: launch, request one pizza, rate it, background the app, and resume it
+- Destination: local Alloy and Loki only
+- Capture: 19 HTTP batches containing one session
+
+The byte-for-byte source payloads remain in the ignored local `.captures` directory. The replay manifest records their SHA-256 hashes. The derived data removes the source user, installation, and device identifiers, and the sanitization check found no remaining obvious credentials or email addresses.
+
+## Counts
+
+| Signal | Source | Replay |
+| --- | ---: | ---: |
+| Events | 19 | 19 |
+| Measurements | 28 | 28 |
+| Logs | 8 | 8 |
+| Exceptions | 0 | 0 |
+| Trace spans | 5 | 5 |
+| Total | 60 | 60 |
+
+The replay changed timestamps and correlated identifiers, added `benchmark_run_id`, and preserved the source signal mix and item counts. None of the 15 source identifiers found across Faro and OTLP fields remained in the replayed payloads.
+
+## Sessions validation
+
+The Mobile O11y Sessions lifecycle query returned one lifecycle row for one remapped session after replay into local Loki.

--- a/Mobiles/flutter/benchmark/validate-loki.mjs
+++ b/Mobiles/flutter/benchmark/validate-loki.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    run: { type: 'string', short: 'r' },
+    loki: { type: 'string', default: 'http://127.0.0.1:3100' },
+    app: { type: 'string', default: 'quickpizza-flutter-local' },
+    since: { type: 'string', default: '30m' },
+  },
+});
+
+if (!values.run) {
+  throw new Error('--run is required');
+}
+
+const durationMs = parseDuration(values.since);
+const end = Date.now() * 1_000_000;
+const start = (Date.now() - durationMs) * 1_000_000;
+const query = `{app_id="${values.app}", kind="event"} |= "${values.run}" |~ "session_start|session_extend|session_resume" | logfmt | event_name=~"session_start|session_extend|session_resume"`;
+const url = new URL('/loki/api/v1/query_range', values.loki);
+url.searchParams.set('query', query);
+url.searchParams.set('start', String(start));
+url.searchParams.set('end', String(end));
+url.searchParams.set('limit', '5000');
+url.searchParams.set('direction', 'forward');
+
+const response = await fetch(url);
+if (!response.ok) {
+  throw new Error(`Loki query failed with HTTP ${response.status}: ${await response.text()}`);
+}
+const body = await response.json();
+const lines = body.data.result.flatMap((stream) => stream.values.map((value) => value[1]));
+const sessions = new Set(
+  lines
+    .map((line) => /(?:^|\s)session_id=(?:"([^"]+)"|([^\s]+))/.exec(line))
+    .filter(Boolean)
+    .map((match) => match[1] ?? match[2]),
+);
+
+if (lines.length === 0 || sessions.size === 0) {
+  throw new Error(`Sessions validation failed for benchmark run ${values.run}`);
+}
+
+process.stdout.write(`Sessions validation passed\n`);
+process.stdout.write(`Lifecycle rows: ${lines.length}\n`);
+process.stdout.write(`Unique sessions: ${sessions.size}\n`);
+process.stdout.write(`Session IDs: ${[...sessions].join(', ')}\n`);
+
+function parseDuration(value) {
+  const match = /^(\d+)(s|m|h)$/.exec(value);
+  if (!match) {
+    throw new Error(`Invalid duration: ${value}`);
+  }
+  const multiplier = { s: 1_000, m: 60_000, h: 3_600_000 }[match[2]];
+  return Number(match[1]) * multiplier;
+}

--- a/Mobiles/flutter/benchmark/validate-loki.mjs
+++ b/Mobiles/flutter/benchmark/validate-loki.mjs
@@ -2,6 +2,8 @@
 
 import { parseArgs } from 'node:util';
 
+import { quoteLogQLString } from './lib/logql.mjs';
+
 const { values } = parseArgs({
   options: {
     run: { type: 'string', short: 'r' },
@@ -16,9 +18,10 @@ if (!values.run) {
 }
 
 const durationMs = parseDuration(values.since);
-const end = Date.now() * 1_000_000;
-const start = (Date.now() - durationMs) * 1_000_000;
-const query = `{app_id="${values.app}", kind="event"} |= "${values.run}" |~ "session_start|session_extend|session_resume" | logfmt | event_name=~"session_start|session_extend|session_resume"`;
+const now = Date.now();
+const end = now * 1_000_000;
+const start = (now - durationMs) * 1_000_000;
+const query = `{app_id=${quoteLogQLString(values.app)}, kind="event"} |~ "session_start|session_extend|session_resume" | logfmt | session_attr_benchmark_run_id=${quoteLogQLString(values.run)} | event_name=~"session_start|session_extend|session_resume"`;
 const url = new URL('/loki/api/v1/query_range', values.loki);
 url.searchParams.set('query', query);
 url.searchParams.set('start', String(start));

--- a/Mobiles/flutter/benchmark/validate-loki.mjs
+++ b/Mobiles/flutter/benchmark/validate-loki.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
 import { quoteLogQLString } from './lib/logql.mjs';
@@ -10,6 +12,7 @@ const { values } = parseArgs({
     loki: { type: 'string', default: 'http://127.0.0.1:3100' },
     app: { type: 'string', default: 'quickpizza-flutter-local' },
     since: { type: 'string', default: '30m' },
+    manifest: { type: 'string' },
   },
 });
 
@@ -21,20 +24,9 @@ const durationMs = parseDuration(values.since);
 const now = Date.now();
 const end = now * 1_000_000;
 const start = (now - durationMs) * 1_000_000;
-const query = `{app_id=${quoteLogQLString(values.app)}, kind="event"} |~ "session_start|session_extend|session_resume" | logfmt | session_attr_benchmark_run_id=${quoteLogQLString(values.run)} | event_name=~"session_start|session_extend|session_resume"`;
-const url = new URL('/loki/api/v1/query_range', values.loki);
-url.searchParams.set('query', query);
-url.searchParams.set('start', String(start));
-url.searchParams.set('end', String(end));
-url.searchParams.set('limit', '5000');
-url.searchParams.set('direction', 'forward');
-
-const response = await fetch(url);
-if (!response.ok) {
-  throw new Error(`Loki query failed with HTTP ${response.status}: ${await response.text()}`);
-}
-const body = await response.json();
-const lines = body.data.result.flatMap((stream) => stream.values.map((value) => value[1]));
+const lifecycleQuery = `{app_id=${quoteLogQLString(values.app)}, kind="event"} |~ "session_start|session_extend|session_resume" | logfmt | session_attr_benchmark_run_id=${quoteLogQLString(values.run)} | event_name=~"session_start|session_extend|session_resume"`;
+const lifecycleResult = await queryLoki(lifecycleQuery);
+const lines = lifecycleResult.flatMap((stream) => stream.values.map((value) => value[1]));
 const sessions = new Set(
   lines
     .map((line) => /(?:^|\s)session_id=(?:"([^"]+)"|([^\s]+))/.exec(line))
@@ -50,6 +42,72 @@ process.stdout.write(`Sessions validation passed\n`);
 process.stdout.write(`Lifecycle rows: ${lines.length}\n`);
 process.stdout.write(`Unique sessions: ${sessions.size}\n`);
 process.stdout.write(`Session IDs: ${[...sessions].join(', ')}\n`);
+
+if (values.manifest) {
+  await validateReplayCounts(values.manifest);
+}
+
+async function validateReplayCounts(manifestPath) {
+  const manifest = JSON.parse(await readFile(resolve(manifestPath), 'utf8'));
+  if (manifest.benchmarkRunId !== values.run) {
+    throw new Error(
+      `Manifest run ${manifest.benchmarkRunId} does not match requested run ${values.run}`,
+    );
+  }
+  if (!countsMatch(manifest.sourceCounts, manifest.replayCounts)) {
+    throw new Error('Source and replay item counts differ in the replay manifest');
+  }
+
+  const expectedCounts = {
+    event: manifest.replayCounts.events ?? 0,
+    measurement: manifest.replayCounts.measurements ?? 0,
+    log: manifest.replayCounts.logs ?? 0,
+    exception: manifest.replayCounts.exceptions ?? 0,
+  };
+  const replayQuery = `{app_id=${quoteLogQLString(values.app)}} | logfmt | session_attr_benchmark_run_id=${quoteLogQLString(values.run)}`;
+  const replayResult = await queryLoki(replayQuery);
+  const actualCounts = Object.fromEntries(Object.keys(expectedCounts).map((kind) => [kind, 0]));
+  let actualTotal = 0;
+  for (const stream of replayResult) {
+    const count = stream.values.length;
+    actualTotal += count;
+    const kind = stream.stream.kind;
+    if (Object.hasOwn(actualCounts, kind)) {
+      actualCounts[kind] += count;
+    }
+  }
+
+  const expectedTotal = Object.values(expectedCounts).reduce((sum, count) => sum + count, 0);
+  if (actualTotal !== expectedTotal || !countsMatch(expectedCounts, actualCounts)) {
+    throw new Error(
+      `Loki replay counts differ: expected ${JSON.stringify(expectedCounts)}, received ${JSON.stringify(actualCounts)}`,
+    );
+  }
+
+  process.stdout.write('Replay count validation passed\n');
+  process.stdout.write(`Loki rows: ${actualTotal}\n`);
+}
+
+async function queryLoki(query) {
+  const url = new URL('/loki/api/v1/query_range', values.loki);
+  url.searchParams.set('query', query);
+  url.searchParams.set('start', String(start));
+  url.searchParams.set('end', String(end));
+  url.searchParams.set('limit', '5000');
+  url.searchParams.set('direction', 'forward');
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Loki query failed with HTTP ${response.status}: ${await response.text()}`);
+  }
+  const body = await response.json();
+  return body.data.result;
+}
+
+function countsMatch(expected, actual) {
+  const keys = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+  return [...keys].every((key) => expected[key] === actual[key]);
+}
 
 function parseDuration(value) {
   const match = /^(\d+)(s|m|h)$/.exec(value);


### PR DESCRIPTION
## Summary

- capture real Faro payloads from the Flutter QuickPizza app through a local byte-preserving proxy
- sanitize identifying values and create replay copies with fresh timestamps, correlated IDs, and `benchmark_run_id`
- replay through local Alloy into local Loki and validate the Mobile O11y Sessions lifecycle query
- document the verified QuickPizza scenario and matching source/replay counts

Raw captures and runtime data remain local and are ignored by Git. This does not send telemetry to Grafana Cloud or another shared stack.

Related to grafana/app-o11y-kwl#3756
