### PR TITLE
chore(ios): bump OpenTelemetry Swift to 2.5.0 and configure session lifecycle

### DIFF
--- a/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
+++ b/Mobiles/ios/QuickPizzaIos.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.4.1;
+				minimumVersion = 2.5.0;
 			};
 		};
 		62EFEF4C2F360BAE00E72D9F /* XCRemoteSwiftPackageReference "opentelemetry-swift-core" */ = {
@@ -440,7 +440,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift-core.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.4.1;
+				minimumVersion = 2.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Mobiles/ios/QuickPizzaIos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mobiles/ios/QuickPizzaIos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
       "state" : {
-        "revision" : "21374ac2439aee4e206721ef91a7e8bf4c0579d6",
-        "version" : "2.4.1"
+        "revision" : "9a6d6a8aed22c415bb1673206e337824635f818b",
+        "version" : "2.5.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift-core.git",
       "state" : {
-        "revision" : "84b9e341cbb7b4dd62cd1b89cd9e008995084132",
-        "version" : "2.4.1"
+        "revision" : "06f8a460a66f813758d22f09025d85df45450a63",
+        "version" : "2.5.1"
       }
     },
     {
@@ -101,6 +101,15 @@
       }
     },
     {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "swift-http-structured-headers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
@@ -123,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
-        "version" : "1.12.1"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -195,8 +204,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
-        "version" : "1.38.0"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Mobiles/ios/QuickPizzaIos/Core/O11y/OTelService.swift
+++ b/Mobiles/ios/QuickPizzaIos/Core/O11y/OTelService.swift
@@ -44,7 +44,11 @@ final class OTelService {
     // MARK: - Sessions
 
     private func setupSessions() {
-        let sessionConfig = SessionConfig(sessionTimeout: 15 * 60) // 15 min, matching Faro inactivity rule
+        let sessionConfig = SessionConfig(
+            sessionTimeout: 15 * 60, // 15 min, matching Faro inactivity rule
+            maxLifetime: 4 * 60 * 60, // 4 hours, matching Faro max lifetime rule
+            restorePersistedSession: false // new session on each cold start, matching Faro session rule
+        )
         SessionManagerProvider.register(sessionManager: SessionManager(configuration: sessionConfig))
         SessionEventInstrumentation.install()
     }


### PR DESCRIPTION
## Summary
- Bump iOS QuickPizza OTel deps: `opentelemetry-swift` 2.4.1 → 2.5.0, `opentelemetry-swift-core` 2.4.1 → 2.5.1.
- Adopt the configurable session lifecycle rules introduced in `opentelemetry-swift` 2.5.0 in `OTelService.setupSessions()`, aligning iOS with the Faro / mobile-o11y session rules:
  - `sessionTimeout` 15 min (inactivity)
  - `maxLifetime` 4 hours
  - `restorePersistedSession: false` (new session on each cold start)

## Notes
- `opentelemetry-swift` 2.5.0 upgrades the SDK to Swift 6.0 and pulls in two new transitive deps (`swift-distributed-tracing`, `swift-service-context`) from the new Distributed Tracing bridge; `swift-log` and `swift-protobuf` get minor bumps. All reflected in `Package.resolved`.
- Unlike Faro RN's volatile `persistent: false` sessions, the OTel `restorePersistedSession: false` path still links the prior session as `session.previous_id` across cold starts.

## Test plan
- [x] Build in Xcode (watch for Swift 6 concurrency warnings/errors).
- [x] Run on simulator: verify a new `session.id` on cold start with `session.previous_id` linkage.
- [x] Confirm spans/logs still export to Grafana Cloud (Tempo/Loki) and land on the OTel RUM dashboard.

Made with [Cursor](https://cursor.com)