### PR TITLE
feat(rn): add debug toggles for frozen frames and memory stress

### DIFF
--- a/Mobiles/react-native/App.tsx
+++ b/Mobiles/react-native/App.tsx
@@ -22,6 +22,8 @@ import { AppNavigator } from './src/navigation/AppNavigator';
 import { useAdminStore } from './src/features/admin/domain/adminStore';
 import { useAuthStore } from './src/features/auth/domain/authStore';
 import { useDebugSettingsStore } from './src/features/debug/domain/debugSettingsStore';
+import { MemoryStressEffect } from './src/features/debug/domain/memoryStress';
+import { RandomFrozenFramesEffect } from './src/features/debug/domain/randomFrozenFrames';
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
@@ -60,6 +62,8 @@ function App() {
     >
       <SafeAreaProvider>
         <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
+        <RandomFrozenFramesEffect />
+        <MemoryStressEffect />
         <AppNavigator />
       </SafeAreaProvider>
     </O11yErrorBoundary>

--- a/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaDebugModule.kt
+++ b/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaDebugModule.kt
@@ -1,0 +1,37 @@
+package com.quickpizza
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+/**
+ * Demo-only helpers for Debug tab fault injection.
+ * [blockMainThread] stalls the UI looper so Faro Choreographer frame monitoring
+ * records real slow/frozen frames (unlike JS-thread busy loops).
+ */
+class QuickPizzaDebugModule(
+  reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+
+  override fun getName(): String = "QuickPizzaDebug"
+
+  @ReactMethod
+  fun blockMainThread(durationMs: Double, promise: Promise) {
+    val blockForMs = durationMs.toLong().coerceIn(1, MAX_BLOCK_MS)
+    Handler(Looper.getMainLooper()).post {
+      val deadline = SystemClock.uptimeMillis() + blockForMs
+      while (SystemClock.uptimeMillis() < deadline) {
+        Thread.yield()
+      }
+      promise.resolve(null)
+    }
+  }
+
+  companion object {
+    private const val MAX_BLOCK_MS = 10_000L
+  }
+}

--- a/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaPackage.kt
+++ b/Mobiles/react-native/android/app/src/main/java/com/quickpizza/QuickPizzaPackage.kt
@@ -12,6 +12,7 @@ class QuickPizzaPackage : ReactPackage {
     listOf(
       QuickPizzaCrashModule(reactContext),
       QuickPizzaNdkCrashModule(reactContext),
+      QuickPizzaDebugModule(reactContext),
     )
 
   override fun createViewManagers(

--- a/Mobiles/react-native/ios/QuickPizza.xcodeproj/project.pbxproj
+++ b/Mobiles/react-native/ios/QuickPizza.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2A4A7D902CA7012300110001 /* QuickPizzaCrashModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A4A7D8E2CA7012300110001 /* QuickPizzaCrashModule.swift */; };
 		2A4A7D912CA7012300110001 /* QuickPizzaCrashModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A4A7D8F2CA7012300110001 /* QuickPizzaCrashModule.m */; };
+		2B5B8EA12DB8123400220001 /* QuickPizzaDebugModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5B8EA32DB8123400220001 /* QuickPizzaDebugModule.swift */; };
+		2B5B8EA22DB8123400220001 /* QuickPizzaDebugModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B5B8EA42DB8123400220001 /* QuickPizzaDebugModule.m */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		943088C196BDD68EC79CB1DB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
@@ -23,6 +25,8 @@
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = QuickPizza/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2A4A7D8E2CA7012300110001 /* QuickPizzaCrashModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = QuickPizzaCrashModule.swift; path = QuickPizza/QuickPizzaCrashModule.swift; sourceTree = "<group>"; };
 		2A4A7D8F2CA7012300110001 /* QuickPizzaCrashModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = QuickPizzaCrashModule.m; path = QuickPizza/QuickPizzaCrashModule.m; sourceTree = "<group>"; };
+		2B5B8EA32DB8123400220001 /* QuickPizzaDebugModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = QuickPizzaDebugModule.swift; path = QuickPizza/QuickPizzaDebugModule.swift; sourceTree = "<group>"; };
+		2B5B8EA42DB8123400220001 /* QuickPizzaDebugModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = QuickPizzaDebugModule.m; path = QuickPizza/QuickPizzaDebugModule.m; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-QuickPizza.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickPizza.debug.xcconfig"; path = "Target Support Files/Pods-QuickPizza/Pods-QuickPizza.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-QuickPizza.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickPizza.release.xcconfig"; path = "Target Support Files/Pods-QuickPizza/Pods-QuickPizza.release.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-QuickPizza.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-QuickPizza.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -50,6 +54,8 @@
 				761780EC2CA45674006654EE /* AppDelegate.swift */,
 				2A4A7D8E2CA7012300110001 /* QuickPizzaCrashModule.swift */,
 				2A4A7D8F2CA7012300110001 /* QuickPizzaCrashModule.m */,
+				2B5B8EA32DB8123400220001 /* QuickPizzaDebugModule.swift */,
+				2B5B8EA42DB8123400220001 /* QuickPizzaDebugModule.m */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
@@ -266,6 +272,8 @@
 				761780ED2CA45674006654EE /* AppDelegate.swift in Sources */,
 				2A4A7D902CA7012300110001 /* QuickPizzaCrashModule.swift in Sources */,
 				2A4A7D912CA7012300110001 /* QuickPizzaCrashModule.m in Sources */,
+				2B5B8EA12DB8123400220001 /* QuickPizzaDebugModule.swift in Sources */,
+				2B5B8EA22DB8123400220001 /* QuickPizzaDebugModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mobiles/react-native/ios/QuickPizza/QuickPizzaDebugModule.m
+++ b/Mobiles/react-native/ios/QuickPizza/QuickPizzaDebugModule.m
@@ -1,0 +1,9 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(QuickPizzaDebug, NSObject)
+
+RCT_EXTERN_METHOD(blockMainThread:(nonnull NSNumber *)durationMs
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/Mobiles/react-native/ios/QuickPizza/QuickPizzaDebugModule.swift
+++ b/Mobiles/react-native/ios/QuickPizza/QuickPizzaDebugModule.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import React
 
@@ -19,7 +20,7 @@ class QuickPizzaDebug: NSObject {
     DispatchQueue.main.async {
       let deadline = Date().addingTimeInterval(clampedMs / 1000.0)
       while Date() < deadline {
-        Thread.yield()
+        sched_yield()
       }
       resolve(nil)
     }

--- a/Mobiles/react-native/ios/QuickPizza/QuickPizzaDebugModule.swift
+++ b/Mobiles/react-native/ios/QuickPizza/QuickPizzaDebugModule.swift
@@ -1,0 +1,27 @@
+import Foundation
+import React
+
+@objc(QuickPizzaDebug)
+class QuickPizzaDebug: NSObject {
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    false
+  }
+
+  /// Blocks the main run loop for demo frozen-frame injection (Faro CADisplayLink).
+  @objc(blockMainThread:resolver:rejecter:)
+  func blockMainThread(
+    _ durationMs: NSNumber,
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
+    let clampedMs = min(max(durationMs.doubleValue, 1), 10_000)
+    DispatchQueue.main.async {
+      let deadline = Date().addingTimeInterval(clampedMs / 1000.0)
+      while Date() < deadline {
+        Thread.yield()
+      }
+      resolve(nil)
+    }
+  }
+}

--- a/Mobiles/react-native/src/features/debug/domain/debugSettingsStore.ts
+++ b/Mobiles/react-native/src/features/debug/domain/debugSettingsStore.ts
@@ -12,7 +12,7 @@ export interface DebugSettings {
   backendErrorIngredients: boolean;
   clientFaultyPizzaJson: boolean;
   clientSkipAuthDependency: boolean;
-  /** Demo-only: randomly block the JS thread to induce slow/frozen frames. */
+  /** Demo-only: randomly block the UI thread to induce slow/frozen frames. */
   clientRandomFrozenFrames: boolean;
   /** Demo-only: retain growing buffers to stress process memory. */
   clientMemoryStress: boolean;

--- a/Mobiles/react-native/src/features/debug/domain/debugSettingsStore.ts
+++ b/Mobiles/react-native/src/features/debug/domain/debugSettingsStore.ts
@@ -12,6 +12,10 @@ export interface DebugSettings {
   backendErrorIngredients: boolean;
   clientFaultyPizzaJson: boolean;
   clientSkipAuthDependency: boolean;
+  /** Demo-only: randomly block the JS thread to induce slow/frozen frames. */
+  clientRandomFrozenFrames: boolean;
+  /** Demo-only: retain growing buffers to stress process memory. */
+  clientMemoryStress: boolean;
 }
 
 export const DEFAULT_DEBUG_SETTINGS: DebugSettings = {
@@ -23,6 +27,8 @@ export const DEFAULT_DEBUG_SETTINGS: DebugSettings = {
   backendErrorIngredients: false,
   clientFaultyPizzaJson: false,
   clientSkipAuthDependency: false,
+  clientRandomFrozenFrames: false,
+  clientMemoryStress: false,
 };
 
 interface DebugSettingsStore {
@@ -48,6 +54,8 @@ function sanitizeSettings(value: unknown): DebugSettings {
     backendErrorIngredients: raw.backendErrorIngredients === true,
     clientFaultyPizzaJson: raw.clientFaultyPizzaJson === true,
     clientSkipAuthDependency: raw.clientSkipAuthDependency === true,
+    clientRandomFrozenFrames: raw.clientRandomFrozenFrames === true,
+    clientMemoryStress: raw.clientMemoryStress === true,
   };
 }
 

--- a/Mobiles/react-native/src/features/debug/domain/memoryStress.ts
+++ b/Mobiles/react-native/src/features/debug/domain/memoryStress.ts
@@ -7,9 +7,9 @@ import { useEffect } from 'react';
 
 import { useDebugSettingsStore } from './debugSettingsStore';
 
-const CHUNK_BYTES = 24 * 1024 * 1024; // 24 MiB
+const CHUNK_BYTES = 24 * 1024 * 1024; // 24 MiB ArrayBuffer per chunk
 const INTERVAL_MS = 400;
-/** ~720 MiB cap — painful on a small AVD; turn off to free. */
+/** Up to 30 chunks (~24 MiB buffer + ~1 MiB string each); turn off to free. */
 const MAX_CHUNKS = 30;
 const BURST_ON_ENABLE = 4;
 

--- a/Mobiles/react-native/src/features/debug/domain/memoryStress.ts
+++ b/Mobiles/react-native/src/features/debug/domain/memoryStress.ts
@@ -1,0 +1,71 @@
+/**
+ * Demo-only: retain growing buffers while a Debug switch is on to stress
+ * process memory hard enough to feel on a 1 GB AVD. Releases when disabled.
+ */
+
+import { useEffect } from 'react';
+
+import { useDebugSettingsStore } from './debugSettingsStore';
+
+const CHUNK_BYTES = 24 * 1024 * 1024; // 24 MiB
+const INTERVAL_MS = 400;
+/** ~720 MiB cap — painful on a small AVD; turn off to free. */
+const MAX_CHUNKS = 30;
+const BURST_ON_ENABLE = 4;
+
+const retainedChunks: Uint8Array[] = [];
+const retainedStrings: string[] = [];
+
+function allocateChunk(): void {
+  if (retainedChunks.length >= MAX_CHUNKS) {
+    return;
+  }
+  const chunk = new Uint8Array(CHUNK_BYTES);
+  // Touch every page + write a large string so Hermes/heap also grows.
+  for (let i = 0; i < chunk.length; i += 4096) {
+    chunk[i] = (i + retainedChunks.length) & 0xff;
+  }
+  // Fill a slice densely so allocation itself is expensive / janky.
+  for (let i = 0; i < Math.min(chunk.length, 2 * 1024 * 1024); i++) {
+    chunk[i] = i & 0xff;
+  }
+  retainedChunks.push(chunk);
+  retainedStrings.push('x'.repeat(1024 * 1024)); // +1 MiB string
+}
+
+function releaseChunks(): void {
+  retainedChunks.length = 0;
+  retainedStrings.length = 0;
+}
+
+/**
+ * When `clientMemoryStress` is enabled, grows retained buffers quickly.
+ * Renders nothing.
+ */
+export function MemoryStressEffect(): null {
+  const enabled = useDebugSettingsStore(
+    (state) => state.settings.clientMemoryStress,
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      releaseChunks();
+      return undefined;
+    }
+
+    for (let i = 0; i < BURST_ON_ENABLE; i++) {
+      allocateChunk();
+    }
+
+    const intervalId = setInterval(() => {
+      allocateChunk();
+    }, INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+      releaseChunks();
+    };
+  }, [enabled]);
+
+  return null;
+}

--- a/Mobiles/react-native/src/features/debug/domain/randomFrozenFrames.ts
+++ b/Mobiles/react-native/src/features/debug/domain/randomFrozenFrames.ts
@@ -1,0 +1,82 @@
+/**
+ * Demo-only: aggressively blocks the JS thread to induce obvious UI freezes
+ * and Faro slow/frozen frame measurements. Stays under ~3s per stall to avoid ANR.
+ */
+
+import { useEffect } from 'react';
+
+import { useDebugSettingsStore } from './debugSettingsStore';
+
+const MIN_INTERVAL_MS = 300;
+const MAX_INTERVAL_MS = 900;
+const MIN_BLOCK_MS = 700;
+const MAX_BLOCK_MS = 2800;
+
+function randomBetween(min: number, max: number): number {
+  return Math.floor(min + Math.random() * (max - min + 1));
+}
+
+function blockJsThread(durationMs: number): void {
+  const end = Date.now() + durationMs;
+  // Extra arithmetic so Hermes can't optimize the loop away.
+  let sink = 0;
+  while (Date.now() < end) {
+    sink = (sink + 1) * 31;
+  }
+  if (sink === Number.MIN_SAFE_INTEGER) {
+    console.debug('randomFrozenFrames sink', sink);
+  }
+}
+
+/**
+ * When `clientRandomFrozenFrames` is enabled, schedules frequent main-thread
+ * stalls. Renders nothing.
+ */
+export function RandomFrozenFramesEffect(): null {
+  const enabled = useDebugSettingsStore(
+    (state) => state.settings.clientRandomFrozenFrames,
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const scheduleNext = () => {
+      if (cancelled) {
+        return;
+      }
+      const delay = randomBetween(MIN_INTERVAL_MS, MAX_INTERVAL_MS);
+      timeoutId = setTimeout(() => {
+        if (cancelled) {
+          return;
+        }
+        // Burst of 1–3 stalls so freezes feel continuous.
+        const bursts = randomBetween(1, 3);
+        for (let i = 0; i < bursts; i++) {
+          if (cancelled) {
+            break;
+          }
+          blockJsThread(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
+        }
+        scheduleNext();
+      }, delay);
+    };
+
+    // Immediate hit so the toggle feels on right away.
+    blockJsThread(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
+    scheduleNext();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [enabled]);
+
+  return null;
+}

--- a/Mobiles/react-native/src/features/debug/domain/randomFrozenFrames.ts
+++ b/Mobiles/react-native/src/features/debug/domain/randomFrozenFrames.ts
@@ -1,48 +1,60 @@
 /**
- * Demo-only: aggressively blocks the JS thread to induce obvious UI freezes
- * and Faro slow/frozen frame measurements. Each scheduled burst stays under
- * MAX_BLOCK_MS total to avoid ANR.
+ * Demo-only: blocks the native UI thread to induce real Faro slow/frozen frame
+ * measurements (Choreographer / CADisplayLink). Runs in episodes: short bursts
+ * of stalls, then ~30 seconds quiet, repeat.
  */
 
+import { NativeModules, Platform } from 'react-native';
 import { useEffect } from 'react';
 
 import { useDebugSettingsStore } from './debugSettingsStore';
 
-const MIN_INTERVAL_MS = 300;
-const MAX_INTERVAL_MS = 900;
-const MIN_BLOCK_MS = 700;
+const MIN_STALL_GAP_MS = 300;
+const MAX_STALL_GAP_MS = 900;
+/** Must exceed Faro frozenFrameThresholdMs (700) so each stall counts as app_frozen_frame. */
+const MIN_BLOCK_MS = 750;
 const MAX_BLOCK_MS = 2800;
+const MIN_ACTIVE_EPISODE_MS = 10_000;
+const MAX_ACTIVE_EPISODE_MS = 15_000;
+const QUIET_PERIOD_MS = 30_000;
+
+type QuickPizzaDebugNative = {
+  blockMainThread: (durationMs: number) => Promise<void>;
+};
+
+const QuickPizzaDebug = NativeModules.QuickPizzaDebug as
+  | QuickPizzaDebugNative
+  | undefined;
 
 function randomBetween(min: number, max: number): number {
   return Math.floor(min + Math.random() * (max - min + 1));
 }
 
-function blockJsThread(durationMs: number): void {
-  const end = Date.now() + durationMs;
-  // Extra arithmetic so Hermes can't optimize the loop away.
-  let sink = 0;
-  while (Date.now() < end) {
-    sink = (sink + 1) * 31;
-  }
-  if (sink === Number.MIN_SAFE_INTEGER) {
-    console.debug('randomFrozenFrames sink', sink);
-  }
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
-/** Split totalBudgetMs into 1–3 back-to-back stalls (sum never exceeds budget). */
-function blockJsThreadBurst(totalBudgetMs: number): void {
-  const bursts = randomBetween(1, 3);
-  const baseDuration = Math.floor(totalBudgetMs / bursts);
-  const remainder = totalBudgetMs % bursts;
-
-  for (let i = 0; i < bursts; i++) {
-    blockJsThread(baseDuration + (i < remainder ? 1 : 0));
+/** Stall the UI thread via native main-looper block (Android/iOS). */
+async function blockUiThread(durationMs: number): Promise<void> {
+  if (!QuickPizzaDebug?.blockMainThread) {
+    console.warn(
+      `[randomFrozenFrames] QuickPizzaDebug.blockMainThread unavailable on ${Platform.OS}`,
+    );
+    return;
   }
+  await QuickPizzaDebug.blockMainThread(durationMs);
+}
+
+/** One UI-thread stall per burst — splitting would drop below the 700ms frozen threshold. */
+async function blockUiThreadBurst(): Promise<void> {
+  await blockUiThread(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
 }
 
 /**
- * When `clientRandomFrozenFrames` is enabled, schedules frequent main-thread
- * stalls. Renders nothing.
+ * When `clientRandomFrozenFrames` is enabled, alternates active stall episodes
+ * (~10–15s) with quiet periods (~30s). Renders nothing.
  */
 export function RandomFrozenFramesEffect(): null {
   const enabled = useDebugSettingsStore(
@@ -55,31 +67,40 @@ export function RandomFrozenFramesEffect(): null {
     }
 
     let cancelled = false;
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-    const scheduleNext = () => {
-      if (cancelled) {
-        return;
+    const runActiveEpisode = async (): Promise<void> => {
+      console.log(
+        `[randomFrozenFrames] ACTIVE episode start (${new Date().toISOString()})`,
+      );
+      const episodeEnd =
+        Date.now() + randomBetween(MIN_ACTIVE_EPISODE_MS, MAX_ACTIVE_EPISODE_MS);
+
+      while (!cancelled && Date.now() < episodeEnd) {
+        await blockUiThreadBurst();
+        if (cancelled || Date.now() >= episodeEnd) {
+          return;
+        }
+        await delay(randomBetween(MIN_STALL_GAP_MS, MAX_STALL_GAP_MS));
       }
-      const delay = randomBetween(MIN_INTERVAL_MS, MAX_INTERVAL_MS);
-      timeoutId = setTimeout(() => {
+    };
+
+    const runCycle = async (): Promise<void> => {
+      while (!cancelled) {
+        await runActiveEpisode();
         if (cancelled) {
           return;
         }
-        blockJsThreadBurst(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
-        scheduleNext();
-      }, delay);
+        console.log(
+          `[randomFrozenFrames] QUIET period start — ${QUIET_PERIOD_MS / 1000}s (${new Date().toISOString()})`,
+        );
+        await delay(QUIET_PERIOD_MS);
+      }
     };
 
-    // Immediate hit so the toggle feels on right away.
-    blockJsThreadBurst(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
-    scheduleNext();
+    void runCycle();
 
     return () => {
       cancelled = true;
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
     };
   }, [enabled]);
 

--- a/Mobiles/react-native/src/features/debug/domain/randomFrozenFrames.ts
+++ b/Mobiles/react-native/src/features/debug/domain/randomFrozenFrames.ts
@@ -1,6 +1,7 @@
 /**
  * Demo-only: aggressively blocks the JS thread to induce obvious UI freezes
- * and Faro slow/frozen frame measurements. Stays under ~3s per stall to avoid ANR.
+ * and Faro slow/frozen frame measurements. Each scheduled burst stays under
+ * MAX_BLOCK_MS total to avoid ANR.
  */
 
 import { useEffect } from 'react';
@@ -25,6 +26,17 @@ function blockJsThread(durationMs: number): void {
   }
   if (sink === Number.MIN_SAFE_INTEGER) {
     console.debug('randomFrozenFrames sink', sink);
+  }
+}
+
+/** Split totalBudgetMs into 1–3 back-to-back stalls (sum never exceeds budget). */
+function blockJsThreadBurst(totalBudgetMs: number): void {
+  const bursts = randomBetween(1, 3);
+  const baseDuration = Math.floor(totalBudgetMs / bursts);
+  const remainder = totalBudgetMs % bursts;
+
+  for (let i = 0; i < bursts; i++) {
+    blockJsThread(baseDuration + (i < remainder ? 1 : 0));
   }
 }
 
@@ -54,20 +66,13 @@ export function RandomFrozenFramesEffect(): null {
         if (cancelled) {
           return;
         }
-        // Burst of 1–3 stalls so freezes feel continuous.
-        const bursts = randomBetween(1, 3);
-        for (let i = 0; i < bursts; i++) {
-          if (cancelled) {
-            break;
-          }
-          blockJsThread(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
-        }
+        blockJsThreadBurst(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
         scheduleNext();
       }, delay);
     };
 
     // Immediate hit so the toggle feels on right away.
-    blockJsThread(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
+    blockJsThreadBurst(randomBetween(MIN_BLOCK_MS, MAX_BLOCK_MS));
     scheduleNext();
 
     return () => {

--- a/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
+++ b/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
@@ -283,6 +283,22 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
               updateSetting({ clientSkipAuthDependency: value })
             }
           />
+          <SettingSwitch
+            title="Random frozen frames"
+            subtitle="Frequent JS stalls (~0.7–2.8s bursts) — UI should visibly freeze"
+            value={settings.clientRandomFrozenFrames}
+            onValueChange={(value) =>
+              updateSetting({ clientRandomFrozenFrames: value })
+            }
+          />
+          <SettingSwitch
+            title="Memory stress"
+            subtitle="Aggressive: ~24 MiB every 0.4s (burst on enable, cap ~720 MiB)"
+            value={settings.clientMemoryStress}
+            onValueChange={(value) =>
+              updateSetting({ clientMemoryStress: value })
+            }
+          />
         </View>
 
         <View style={styles.section}>

--- a/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
+++ b/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
@@ -293,7 +293,7 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
           />
           <SettingSwitch
             title="Memory stress"
-            subtitle="Aggressive: ~24 MiB every 0.4s (burst on enable, cap ~720 MiB)"
+            subtitle="Aggressive: ~25 MiB/chunk every 0.4s (buffer + string, up to 30 chunks)"
             value={settings.clientMemoryStress}
             onValueChange={(value) =>
               updateSetting({ clientMemoryStress: value })

--- a/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
+++ b/Mobiles/react-native/src/features/debug/presentation/DebugScreen.tsx
@@ -285,7 +285,7 @@ export function DebugScreen({ onNavigateToConfig }: DebugScreenProps) {
           />
           <SettingSwitch
             title="Random frozen frames"
-            subtitle="Frequent JS stalls (~0.7–2.8s bursts) — UI should visibly freeze"
+            subtitle="UI-thread stall episodes (~10–15s), then ~30s quiet, repeat"
             value={settings.clientRandomFrozenFrames}
             onValueChange={(value) =>
               updateSetting({ clientRandomFrozenFrames: value })

--- a/Mobiles/react-native/src/features/debug/presentation/debugConfigHelpers.ts
+++ b/Mobiles/react-native/src/features/debug/presentation/debugConfigHelpers.ts
@@ -36,6 +36,8 @@ export function hasActiveDebugSettings(settings: DebugSettings): boolean {
     settings.backendSlowIngredients ||
     settings.backendErrorIngredients ||
     settings.clientFaultyPizzaJson ||
-    settings.clientSkipAuthDependency
+    settings.clientSkipAuthDependency ||
+    settings.clientRandomFrozenFrames ||
+    settings.clientMemoryStress
   );
 }


### PR DESCRIPTION
## Summary
- Add two demo-only Debug tab switches in the React Native app: **Random frozen frames** and **Memory stress**.
- Wire background effects at the app root so toggling them induces JS thread stalls and retained heap growth for local Faro testing.
- Persist settings in the existing debug settings store and count them as active debug configuration.

## Screenshots
<img width="359" height="802" alt="Screenshot 2026-07-27 at 11 51 06" src="https://github.com/user-attachments/assets/0b0d2e9e-5afa-4fd6-8504-623d50a3240e" />

## Test plan
- [ ] Run the React Native app (`yarn android` or `yarn ios`) and open the Debug tab.
- [ ] Enable **Random frozen frames** — UI should visibly freeze in ~0.7–2.8s bursts; confirm Faro slow/frozen frame measurements in Frontend Observability.
- [ ] Enable **Memory stress** — memory should climb aggressively (~24 MiB every 0.4s, cap ~720 MiB); confirm memory-related Faro signals; disable to verify buffers are released.
- [ ] Restart the app with toggles off and confirm defaults remain disabled.
