### PR TITLE
fix(flutter): report ShellRoute view names

### DIFF
--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -109,13 +109,17 @@ is code we wrote in `core/o11y/` or in the feature repositories.
 
 ### Flutter (Faro)
 
-- **SDK:** `faro-mobile-flutter` 0.14.0
+- **SDK:** `faro-mobile-flutter` 0.17.0-beta.1
 - **Init:** `Mobiles/flutter/lib/bootstrap.dart` → `Faro` from
   `package:faro`
 - **Faro app:** registry name `QuickPizza_Flutter`, id `69`. The SDK is
   configured in `Mobiles/flutter/lib/bootstrap.dart` to send
   `app_name=QuickPizza_Flutter`, matching the React Native app
   (`QuickPizza_ReactNative`).
+- **View names:** go_router paths such as `/`, `/about`, `/debug`, and
+  `/debug/config`. The root and shell navigators each register Faro's
+  navigation observer so bottom navigation tabs and full-screen routes use the
+  same path-based naming convention.
 
 | Signal kind | Examples | Source |
 | --- | --- | --- |

--- a/Mobiles/flutter/lib/core/router/app_router.dart
+++ b/Mobiles/flutter/lib/core/router/app_router.dart
@@ -22,49 +22,67 @@ abstract class AppRoutes {
   static const profile = '/profile';
 }
 
-/// Navigator key for the root navigator
-final _rootNavigatorKey = GlobalKey<NavigatorState>();
-
-/// Navigator key for the shell (bottom nav) navigator
-final _shellNavigatorKey = GlobalKey<NavigatorState>();
-
 /// Provider for the GoRouter instance
 final appRouterProvider = Provider<GoRouter>((ref) {
+  return createAppRouter();
+});
+
+/// Creates the app router with separate observers for its two navigators.
+///
+/// A NavigatorObserver can only be attached to one Navigator, so the root and
+/// shell navigators need distinct Faro and DemoRum observer instances.
+GoRouter createAppRouter({
+  List<NavigatorObserver>? rootObservers,
+  List<NavigatorObserver>? shellObservers,
+}) {
+  final rootNavigatorKey = GlobalKey<NavigatorState>();
+  final shellNavigatorKey = GlobalKey<NavigatorState>();
+
   return GoRouter(
-    navigatorKey: _rootNavigatorKey,
+    navigatorKey: rootNavigatorKey,
     initialLocation: AppRoutes.home,
-    // Both RUM SDKs derive screen names from `route.settings.name`. The
-    // pageBuilder routes below set an explicit `name:` so Faro view meta and
-    // DemoRum screen views are both populated (builder routes get their name
-    // from go_router automatically).
-    observers: [FaroNavigationObserver(), DemoRumNavigatorObserver()],
+    // Builder routes get their path as the RouteSettings name from go_router.
+    // Custom pages below set the same path explicitly for consistent RUM view
+    // names across both navigators.
+    observers: rootObservers ?? _createNavigationObservers(),
     routes: [
       // ShellRoute wraps the bottom navigation bar
       ShellRoute(
-        navigatorKey: _shellNavigatorKey,
-        builder: (_, _, child) {
-          return MainShell(child: child);
-        },
+        navigatorKey: shellNavigatorKey,
+        // Avoid forwarding the root observers in addition to the dedicated
+        // shell observers, which would report every shell navigation twice.
+        notifyRootObserver: false,
+        observers: shellObservers ?? _createNavigationObservers(),
+        pageBuilder: (_, state, child) => MaterialPage<void>(
+          key: state.pageKey,
+          // Keep the wrapper route aligned with its visible child. This also
+          // gives root-level pushes and pops a non-null previous route name.
+          name: state.uri.path,
+          child: MainShell(child: child),
+        ),
         routes: [
           GoRoute(
             path: AppRoutes.home,
-            pageBuilder: (_, _) => const NoTransitionPage(
+            pageBuilder: (_, state) => NoTransitionPage<void>(
+              key: state.pageKey,
               name: AppRoutes.home,
-              child: HomeScreen(),
+              child: const HomeScreen(),
             ),
           ),
           GoRoute(
             path: AppRoutes.about,
-            pageBuilder: (_, _) => const NoTransitionPage(
+            pageBuilder: (_, state) => NoTransitionPage<void>(
+              key: state.pageKey,
               name: AppRoutes.about,
-              child: AboutScreen(),
+              child: const AboutScreen(),
             ),
           ),
           GoRoute(
             path: AppRoutes.debug,
-            pageBuilder: (_, _) => const NoTransitionPage(
+            pageBuilder: (_, state) => NoTransitionPage<void>(
+              key: state.pageKey,
               name: AppRoutes.debug,
-              child: DebugScreen(),
+              child: const DebugScreen(),
             ),
           ),
         ],
@@ -72,20 +90,25 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       // /debug/config is pushed on top of the shell (hides bottom nav)
       GoRoute(
         path: AppRoutes.debugConfig,
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (_, _) => const ConfigScreen(),
       ),
       // Routes outside the shell (full-screen, no bottom nav)
       GoRoute(
         path: AppRoutes.login,
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (_, _) => const LoginScreen(),
       ),
       GoRoute(
         path: AppRoutes.profile,
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (_, _) => const ProfileScreen(),
       ),
     ],
   );
-});
+}
+
+List<NavigatorObserver> _createNavigationObservers() => [
+  FaroNavigationObserver(),
+  DemoRumNavigatorObserver(),
+];

--- a/Mobiles/flutter/test/core/router/app_router_test.dart
+++ b/Mobiles/flutter/test/core/router/app_router_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_mobile_o11y_demo/bootstrap.dart';
+import 'package:flutter_mobile_o11y_demo/core/config/runtime_config.dart';
+import 'package:flutter_mobile_o11y_demo/core/config/shared_preferences_provider.dart';
+import 'package:flutter_mobile_o11y_demo/core/router/app_router.dart';
+
+class _NavigationChange {
+  const _NavigationChange(this.kind, this.from, this.to);
+
+  final String kind;
+  final String? from;
+  final String? to;
+}
+
+class _RecordingObserver extends NavigatorObserver {
+  final List<_NavigationChange> changes = [];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    changes.add(
+      _NavigationChange(
+        'push',
+        previousRoute?.settings.name,
+        route.settings.name,
+      ),
+    );
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    changes.add(
+      _NavigationChange(
+        'pop',
+        route.settings.name,
+        previousRoute?.settings.name,
+      ),
+    );
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    changes.add(
+      _NavigationChange(
+        'replace',
+        oldRoute?.settings.name,
+        newRoute?.settings.name,
+      ),
+    );
+  }
+}
+
+void main() {
+  testWidgets('reports named shell and root navigation changes', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final rootObserver = _RecordingObserver();
+    final shellObserver = _RecordingObserver();
+    final router = createAppRouter(
+      rootObservers: [rootObserver],
+      shellObservers: [shellObserver],
+    );
+    addTearDown(router.dispose);
+
+    final container = ProviderContainer(
+      overrides: [
+        appRouterProvider.overrideWithValue(router),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        runtimeConfigProvider.overrideWithValue(
+          const RuntimeConfig(
+            backendBaseUrl: 'http://localhost:3333',
+            faroCollectorUrl: '',
+            faroSampleRate: 1.0,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const QuickPizzaApp(),
+      ),
+    );
+    await tester.pump();
+
+    rootObserver.changes.clear();
+    shellObserver.changes.clear();
+
+    router.go(AppRoutes.about);
+    await tester.pumpAndSettle();
+    expect(shellObserver.changes, hasLength(1));
+    expect(shellObserver.changes.single.kind, 'push');
+    expect(shellObserver.changes.single.from, AppRoutes.home);
+    expect(shellObserver.changes.single.to, AppRoutes.about);
+    expect(rootObserver.changes, isEmpty);
+
+    shellObserver.changes.clear();
+    router.go(AppRoutes.debug);
+    await tester.pumpAndSettle();
+    expect(shellObserver.changes, hasLength(1));
+    expect(shellObserver.changes.single.kind, 'push');
+    expect(shellObserver.changes.single.from, AppRoutes.about);
+    expect(shellObserver.changes.single.to, AppRoutes.debug);
+
+    rootObserver.changes.clear();
+    router.push(AppRoutes.debugConfig);
+    await tester.pumpAndSettle();
+    expect(rootObserver.changes, hasLength(1));
+    expect(rootObserver.changes.single.kind, 'push');
+    expect(rootObserver.changes.single.from, AppRoutes.debug);
+    expect(rootObserver.changes.single.to, AppRoutes.debugConfig);
+
+    rootObserver.changes.clear();
+    router.pop();
+    await tester.pumpAndSettle();
+    expect(rootObserver.changes, hasLength(1));
+    expect(rootObserver.changes.single.kind, 'pop');
+    expect(rootObserver.changes.single.from, AppRoutes.debugConfig);
+    expect(rootObserver.changes.single.to, AppRoutes.debug);
+  });
+}


### PR DESCRIPTION
## Summary

- attach separate Faro and DemoRum observers to the shell navigator without duplicating root notifications
- give shell pages stable keys and path-based route names so Home, About, and Debug navigation emits view changes
- keep the shell wrapper name aligned with the visible child so Debug Config push and pop preserve the current view
- document the Flutter view naming convention and current Faro SDK version

## Testing

- `flutter test test/core/router/app_router_test.dart`
- `flutter test`
- `flutter analyze`
- `dart format lib/core/router/app_router.dart test/core/router/app_router_test.dart`
- `flutter build apk --debug --dart-define-from-file=config.json`

Fixes #97
