### PR TITLE
feat(mobile): send native OTel telemetry to the Faro collector

### DIFF
--- a/.github/workflows/mobile_demo_telemetry.yaml
+++ b/.github/workflows/mobile_demo_telemetry.yaml
@@ -103,9 +103,8 @@ jobs:
           repo_secrets: |
             FARO_COLLECTOR_URL=faro_collector_url:value
             FARO_COLLECTOR_URL_RN=faro_collector_url_rn:value
-            OTLP_ENDPOINT=otlp_endpoint_android_native:value
-            OTLP_INSTANCE_ID=otlp_instance_id_android_native:value
-            OTLP_API_KEY=otlp_api_key_android_native:value
+            FARO_OTLP_URL_ANDROID=faro_otlp_url_android:value
+            FARO_OTLP_URL_IOS=faro_otlp_url_ios:value
             GRAFANA_CLOUD_STACK=grafana_cloud_stack:value
             GRAFANA_CLOUD_TOKEN=grafana_cloud_token:value
             OPENAI_API_KEY=openai_api_key:value
@@ -224,20 +223,20 @@ jobs:
       - name: Create Android Native config.json for CI
         working-directory: Mobiles/android
         env:
-          OTLP_ENDPOINT: ${{ env.OTLP_ENDPOINT }}
-          OTLP_INSTANCE_ID: ${{ env.OTLP_INSTANCE_ID }}
-          OTLP_API_KEY: ${{ env.OTLP_API_KEY }}
+          OTLP_ENDPOINT: ${{ env.FARO_OTLP_URL_ANDROID }}
         run: |
+          # The Faro OTLP ingest URL carries the app key in its path, so the
+          # instance ID and token stay empty and no auth header is sent.
           mkdir -p app/src/main/res/raw
           cat > app/src/main/res/raw/config.json << EOF
           {
             "OTLP_ENDPOINT": "${OTLP_ENDPOINT}",
-            "OTLP_INSTANCE_ID": "${OTLP_INSTANCE_ID}",
-            "OTLP_API_KEY": "${OTLP_API_KEY}",
+            "OTLP_INSTANCE_ID": "",
+            "OTLP_API_KEY": "",
             "BASE_URL": ""
           }
           EOF
-          echo "Created Android Native config.json (secrets redacted)"
+          echo "Created Android Native config.json (OTLP endpoint redacted)"
 
       - name: Resolve Android Native demo app version
         run: |
@@ -436,9 +435,8 @@ jobs:
           repo_secrets: |
             FARO_COLLECTOR_URL=faro_collector_url:value
             FARO_COLLECTOR_URL_RN=faro_collector_url_rn:value
-            OTLP_ENDPOINT=otlp_endpoint_android_native:value
-            OTLP_INSTANCE_ID=otlp_instance_id_android_native:value
-            OTLP_API_KEY=otlp_api_key_android_native:value
+            FARO_OTLP_URL_ANDROID=faro_otlp_url_android:value
+            FARO_OTLP_URL_IOS=faro_otlp_url_ios:value
             GRAFANA_CLOUD_STACK=grafana_cloud_stack:value
             GRAFANA_CLOUD_TOKEN=grafana_cloud_token:value
             OPENAI_API_KEY=openai_api_key:value
@@ -456,21 +454,21 @@ jobs:
       - name: Create Config.xcconfig for CI
         working-directory: Mobiles/ios
         env:
-          OTLP_ENDPOINT: ${{ env.OTLP_ENDPOINT }}
-          OTLP_INSTANCE_ID: ${{ env.OTLP_INSTANCE_ID }}
-          OTLP_API_KEY: ${{ env.OTLP_API_KEY }}
+          OTLP_ENDPOINT: ${{ env.FARO_OTLP_URL_IOS }}
         run: |
           # BASE_URL points at localhost on the host running the simulator,
           # which is the same machine as the runner. xcconfig URLs require
           # /$()/ to escape the :// since semicolons split values.
+          # The Faro OTLP ingest URL carries the app key in its path, so the
+          # instance ID and token stay empty and no auth header is sent.
           cat > Config.xcconfig <<EOF
           BASE_URL = http:/\$()/localhost:3333
           PORT = 3333
           OTLP_ENDPOINT = ${OTLP_ENDPOINT}
-          OTLP_INSTANCE_ID = ${OTLP_INSTANCE_ID}
-          OTLP_API_KEY = ${OTLP_API_KEY}
+          OTLP_INSTANCE_ID =
+          OTLP_API_KEY =
           EOF
-          echo "Created Config.xcconfig (secrets redacted)"
+          echo "Created Config.xcconfig (OTLP endpoint redacted)"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 - **Stack:** Swift, SwiftUI (iOS 17+), Swift Package Manager, `opentelemetry-swift` 2.3.0.
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto HTTP via `URLSessionInstrumentation`, sessions via the `Sessions` library (15-min inactivity, `session.id` + `session.previous_id` on every signal), MetricKit crash/hang/CPU/disk-write diagnostics via `MetricKitInstrumentation` (delivered as logs + `MXMetricPayload` spans), manual `app.screen.view` events, OSLog + OTel dual logging.
-- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_iOS`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard).
+- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_iOS`, id `202`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard).
 - **Config:** `Config.xcconfig` → auto-generates `BuildConfig.generated.swift` — `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Xcode or `bash Mobiles/ios/Scripts/sim-run.sh`.
 - **Resource attrs:** `service.name=quickpizza-ios`, `service.namespace=quickpizza`, `service.version`, `service.build`, `deployment.environment`, `device.id`, `device.model.identifier`, `os.*`, `session.id`, `session.previous_id`, `telemetry.sdk.{language=swift, version=2.3.0}`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ QuickPizza is a demonstration web application that generates pizza recommendatio
 The repository also contains **four QuickPizza mobile demo apps** under `Mobiles/` that demonstrate mobile observability against the same backend. The four apps share screens and workflows but use different SDKs:
 
 - `Mobiles/flutter/` and `Mobiles/react-native/` use the Grafana **Faro** SDKs and export to Grafana Cloud Frontend Observability.
-- `Mobiles/ios/` and `Mobiles/android/` use **OpenTelemetry** mobile SDKs and export over OTLP/HTTP to the same Faro collector, which translates OTLP to Faro on ingest. They can also target the Grafana Cloud OTLP gateway instead, which lands raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" custom dashboard.
+- `Mobiles/ios/` and `Mobiles/android/` use **OpenTelemetry** mobile SDKs and export over OTLP/HTTP to the same Faro collector, which translates OTLP to Faro on ingest. That `/otlp/<appKey>` route runs on development collectors only for now (production returns 404). A legacy alternative targets the Grafana Cloud OTLP gateway, which keeps the data as raw OTel in Tempo + Loki — not readable by the Frontend Observability plugin, only by the "Android & iOS OTel RUM" custom dashboard.
 
 For a single source of truth on what each app emits, where it lands, and how the SDKs differ, see [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md).
 
@@ -128,7 +128,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 - **Stack:** Swift, SwiftUI (iOS 17+), Swift Package Manager, `opentelemetry-swift`. Version pinned in the Xcode project's `Package.resolved`.
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto HTTP via `URLSessionInstrumentation`, sessions via the `Sessions` library (15-min inactivity, `session.id` + `session.previous_id` on every signal), MetricKit crash/hang/CPU/disk-write diagnostics via `MetricKitInstrumentation` (delivered as logs + `MXMetricPayload` spans), manual `app.screen.view` events, OSLog + OTel dual logging.
-- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_iOS`, id `204`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard).
+- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_iOS`, id `204`); development collectors only for now. Legacy: point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway to land raw OTel in Tempo + Loki — invisible to the plugin, read via the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard).
 - **Config:** `Config.xcconfig` → auto-generates `BuildConfig.generated.swift` — `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Xcode or `bash Mobiles/ios/Scripts/sim-run.sh`.
 - **Resource attrs:** `service.name=quickpizza-ios`, `service.namespace=quickpizza`, `service.version`, `service.build`, `deployment.environment`, `device.id`, `device.model.identifier`, `os.*`, `session.id`, `session.previous_id`, `telemetry.sdk.{language=swift, version}`.
@@ -137,7 +137,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 - **Stack:** Kotlin, Jetpack Compose, Hilt, OkHttp, `opentelemetry-android` (the OTel-Android **RUM agent**, alpha). Version pinned in `Mobiles/android/gradle/libs.versions.toml`.
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto OkHttp HTTP spans, auto lifecycle spans (`AppStart`, `Paused`, `Stopped`), auto `screen.view` / `app.jank` events, auto `device.crash` (next launch) and `device.anr` (runtime) events, 15-min session tracking, OTLP disk buffering for offline resilience (toggleable via Debug screen).
-- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_Android`, id `182`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard.
+- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_Android`, id `182`); development collectors only for now. Legacy: point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway to land raw OTel in Tempo + Loki — invisible to the plugin, read via the "Android & iOS OTel RUM" dashboard.
 - **Config:** `app/src/main/res/raw/config.json` — `BASE_URL` (default `http://10.0.2.2:3333` on emulators), `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Android Studio or `cd Mobiles/android && ./gradlew installDebug`. Use Android Studio's bundled JDK (system JDK is often too old).
 - **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `deployment.environment`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version}`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,16 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 All four apps now expose an in-app **Debug** tab (Compose / SwiftUI / Flutter widgets / RN) for runtime config overrides, backend error/latency injection, client-side fault simulation, and triggering test logs / handled exceptions / native crashes. Code lives at `features/debug/` in each app. Android additionally exposes a `Disable disk buffering` toggle and an ANR card; iOS calls out the MetricKit delivery delay.
 
+### Telemetry CI (`.github/workflows/mobile_demo_telemetry.yaml`)
+
+Runs every 2 h on `main`, on push, and via `workflow_dispatch`. Two jobs — Android (emulator) and iOS (simulator) — each exercise all three apps, so six app×platform combinations per run.
+
+- **The driver is [Arbigent](Mobiles/e2e/), an AI UI agent**, not a scripted tap sequence. Scenarios are natural-language goals with `maxRetry` / `maxStep` budgets, so the run needs `OPENAI_API_KEY`.
+- **Three flows.** The basic pizza flow runs every time. Handled-exception runs every ~6 h (`schedule_bucket % 3`). Crash diagnostics runs every ~20 h (`% 10`), which suppresses the handled-exception flow on that run. `workflow_dispatch` runs the basic flow only, unless you pass `run_diagnostics=true`.
+- **A green run does not prove telemetry arrived.** The exporters are fire-and-forget and the e2e tests pass either way, so a wrong or 404 ingest URL still produces a green run. Confirm by querying the stack for the app.
+- **The `mobile-demo-telemetry` environment uses a branch allow-list.** You can dispatch from a feature branch and still get the Vault secrets, but only if the branch is listed: `gh api repos/grafana/mobile-o11y-demo/environments/mobile-demo-telemetry/deployment-branch-policies`.
+- **Do not restate SDK versions in this file.** Point at the manifest that holds the pin (`pubspec.yaml`, `package.json`, `Package.resolved`, `libs.versions.toml`). All four versions listed here had drifted before they were removed.
+
 ## Development Notes
 
 ### Error Injection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 - **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_Android`, id `182`); development collectors only for now. Legacy: point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway to land raw OTel in Tempo + Loki — invisible to the plugin, read via the "Android & iOS OTel RUM" dashboard.
 - **Config:** `app/src/main/res/raw/config.json` — `BASE_URL` (default `http://10.0.2.2:3333` on emulators), `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Android Studio or `cd Mobiles/android && ./gradlew installDebug`. Use Android Studio's bundled JDK (system JDK is often too old).
-- **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `deployment.environment`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version}`.
+- **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version}`.
 
 ### Shared Debug screen
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ QuickPizza is a demonstration web application that generates pizza recommendatio
 The repository also contains **four QuickPizza mobile demo apps** under `Mobiles/` that demonstrate mobile observability against the same backend. The four apps share screens and workflows but use different SDKs:
 
 - `Mobiles/flutter/` and `Mobiles/react-native/` use the Grafana **Faro** SDKs and export to Grafana Cloud Frontend Observability.
-- `Mobiles/ios/` and `Mobiles/android/` use **OpenTelemetry** mobile SDKs and export over OTLP/HTTP to Grafana Cloud Tempo + Loki (visualised via the "Android & iOS OTel RUM" custom dashboard).
+- `Mobiles/ios/` and `Mobiles/android/` use **OpenTelemetry** mobile SDKs and export over OTLP/HTTP to the same Faro collector, which translates OTLP to Faro on ingest. They can also target the Grafana Cloud OTLP gateway instead, which lands raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" custom dashboard.
 
 For a single source of truth on what each app emits, where it lands, and how the SDKs differ, see [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md).
 
@@ -128,7 +128,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 - **Stack:** Swift, SwiftUI (iOS 17+), Swift Package Manager, `opentelemetry-swift` 2.3.0.
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto HTTP via `URLSessionInstrumentation`, sessions via the `Sessions` library (15-min inactivity, `session.id` + `session.previous_id` on every signal), MetricKit crash/hang/CPU/disk-write diagnostics via `MetricKitInstrumentation` (delivered as logs + `MXMetricPayload` spans), manual `app.screen.view` events, OSLog + OTel dual logging.
-- **Where it lands:** OTLP/HTTP → Grafana Cloud Tempo + Loki, visualised via the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard) on the configured Grafana Cloud stack.
+- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_iOS`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard).
 - **Config:** `Config.xcconfig` → auto-generates `BuildConfig.generated.swift` — `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Xcode or `bash Mobiles/ios/Scripts/sim-run.sh`.
 - **Resource attrs:** `service.name=quickpizza-ios`, `service.namespace=quickpizza`, `service.version`, `service.build`, `deployment.environment`, `device.id`, `device.model.identifier`, `os.*`, `session.id`, `session.previous_id`, `telemetry.sdk.{language=swift, version=2.3.0}`.
@@ -137,7 +137,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 - **Stack:** Kotlin, Jetpack Compose, Hilt, OkHttp, `opentelemetry-android` 1.4.0-alpha (the OTel-Android **RUM agent**).
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto OkHttp HTTP spans, auto lifecycle spans (`AppStart`, `Paused`, `Stopped`), auto `screen.view` / `app.jank` events, auto `device.crash` (next launch) and `device.anr` (runtime) events, 15-min session tracking, OTLP disk buffering for offline resilience (toggleable via Debug screen).
-- **Where it lands:** OTLP/HTTP → Grafana Cloud Tempo + Loki, visualised via the "Android & iOS OTel RUM" dashboard.
+- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_Android`, id `182`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard.
 - **Config:** `app/src/main/res/raw/config.json` — `BASE_URL` (default `http://10.0.2.2:3333` on emulators), `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Android Studio or `cd Mobiles/android && ./gradlew installDebug`. Use Android Studio's bundled JDK (system JDK is often too old).
 - **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `deployment.environment`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version=1.4.0-alpha}`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 ### Flutter (`Mobiles/flutter/`)
 
-- **Stack:** Flutter/Dart, Riverpod, GoRouter, `faro` Dart SDK (`faro-mobile-flutter` 0.14.0).
+- **Stack:** Flutter/Dart, Riverpod, GoRouter, `faro` Dart SDK (`faro-mobile-flutter`). Version pinned in `Mobiles/flutter/pubspec.yaml`.
 - **Observability:** Faro emits `event` / `log` / `measurement` / `exception` signals; auto HTTP via `faro.tracing.fetch`; auto perf measurements (`app_memory`, `app_cpu_usage`, frame rates, `app_startup`); native crashes via custom `MethodChannel`-backed `NativeCrashService`.
 - **Where it lands:** Frontend Observability plugin (Faro app `QuickPizza_Flutter`, id `69`). SDK is configured to send `app_name=QuickPizza_Flutter` to match the registry; older telemetry may still carry the legacy `quickpizza-flutter` kebab-case name.
 - **Config:** `config.json` at project root — `BASE_URL`, `FARO_COLLECTOR_URL`.
@@ -118,7 +118,7 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 ### React Native (`Mobiles/react-native/`)
 
-- **Stack:** React Native 0.84.x, `@grafana/faro-react-native` 1.0.0-alpha.1, `faro-react-native` 2.3.1.
+- **Stack:** React Native 0.84.x, `@grafana/faro-react-native` + `@grafana/faro-react-native-tracing`. Versions pinned in `Mobiles/react-native/package.json`.
 - **Observability:** Faro signals as above, plus dual fetch + XMLHttpRequest auto tracing (`faro.tracing.fetch` + `faro.tracing.xml-http-request`), custom business measurements (`pizza.recommendation`, `pizza.rating`), native crash capture via Faro CrashKit (`type=crash`).
 - **Where it lands:** Frontend Observability plugin (Faro app `QuickPizza_ReactNative`, id `123`).
 - **Config:** `config.json` at `Mobiles/react-native/` — `BASE_URL`, `FARO_COLLECTOR_URL`.
@@ -126,21 +126,21 @@ read [`Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./Mobiles/docs/MOBILE_OBS
 
 ### iOS native (`Mobiles/ios/`)
 
-- **Stack:** Swift, SwiftUI (iOS 17+), Swift Package Manager, `opentelemetry-swift` 2.3.0.
+- **Stack:** Swift, SwiftUI (iOS 17+), Swift Package Manager, `opentelemetry-swift`. Version pinned in the Xcode project's `Package.resolved`.
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto HTTP via `URLSessionInstrumentation`, sessions via the `Sessions` library (15-min inactivity, `session.id` + `session.previous_id` on every signal), MetricKit crash/hang/CPU/disk-write diagnostics via `MetricKitInstrumentation` (delivered as logs + `MXMetricPayload` spans), manual `app.screen.view` events, OSLog + OTel dual logging.
-- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_iOS`, id `202`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard).
+- **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_iOS`, id `204`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard (and an iOS-specific dashboard).
 - **Config:** `Config.xcconfig` → auto-generates `BuildConfig.generated.swift` — `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Xcode or `bash Mobiles/ios/Scripts/sim-run.sh`.
-- **Resource attrs:** `service.name=quickpizza-ios`, `service.namespace=quickpizza`, `service.version`, `service.build`, `deployment.environment`, `device.id`, `device.model.identifier`, `os.*`, `session.id`, `session.previous_id`, `telemetry.sdk.{language=swift, version=2.3.0}`.
+- **Resource attrs:** `service.name=quickpizza-ios`, `service.namespace=quickpizza`, `service.version`, `service.build`, `deployment.environment`, `device.id`, `device.model.identifier`, `os.*`, `session.id`, `session.previous_id`, `telemetry.sdk.{language=swift, version}`.
 
 ### Android native (`Mobiles/android/`)
 
-- **Stack:** Kotlin, Jetpack Compose, Hilt, OkHttp, `opentelemetry-android` 1.4.0-alpha (the OTel-Android **RUM agent**).
+- **Stack:** Kotlin, Jetpack Compose, Hilt, OkHttp, `opentelemetry-android` (the OTel-Android **RUM agent**, alpha). Version pinned in `Mobiles/android/gradle/libs.versions.toml`.
 - **Observability:** Manual spans (`pizza.get_recommendation`, `auth.login`, `pizza.rate`), auto OkHttp HTTP spans, auto lifecycle spans (`AppStart`, `Paused`, `Stopped`), auto `screen.view` / `app.jank` events, auto `device.crash` (next launch) and `device.anr` (runtime) events, 15-min session tracking, OTLP disk buffering for offline resilience (toggleable via Debug screen).
 - **Where it lands:** OTLP/HTTP → Faro collector `/otlp/<appKey>` → Frontend Observability plugin (Faro app `QuickPizza_Android`, id `182`). Point `OTLP_ENDPOINT` at the Grafana Cloud OTLP gateway instead to land raw OTel in Tempo + Loki for the "Android & iOS OTel RUM" dashboard.
 - **Config:** `app/src/main/res/raw/config.json` — `BASE_URL` (default `http://10.0.2.2:3333` on emulators), `OTLP_ENDPOINT`, `OTLP_INSTANCE_ID`, `OTLP_API_KEY`. Runtime overrides via in-app Debug → Config.
 - **Build:** Android Studio or `cd Mobiles/android && ./gradlew installDebug`. Use Android Studio's bundled JDK (system JDK is often too old).
-- **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `deployment.environment`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version=1.4.0-alpha}`.
+- **Resource attrs:** `service.name=quickpizza-android`, `service.namespace=quickpizza`, `service.version`, `deployment.environment`, `android.os.api_level`, `device.manufacturer`, `device.model.{identifier,name}`, `network.connection.type`, `app.installation.id`, `nav.{destination, previous_destination, kind}`, `telemetry.sdk.{language=java, version}`.
 
 ### Shared Debug screen
 

--- a/Mobiles/README.md
+++ b/Mobiles/README.md
@@ -28,17 +28,10 @@ Two wire formats, one destination:
   `/otlp/<appKey>` endpoint, which translates OTLP to Faro on ingest.
 
 Both end up in the Grafana Cloud **Frontend Observability** plugin, one app per
-key.
-
-> **The `/otlp/<appKey>` route runs on development collectors only.** A
-> production collector returns `404` on that path today. The demo stack uses a
-> development collector for this reason.
-
-A legacy option remains for the native apps: export to the Grafana Cloud OTLP
-gateway, which lands **raw OTel** in Tempo + Loki. The Frontend Observability
-plugin cannot read that data — it carries no app identity — so you query it with
-the [Mobile OTel RUM dashboard](./docs/MOBILE_OTEL_RUM_DASHBOARD.md) instead. See
-[Connect to Grafana Cloud](./docs/CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway).
+key. Two caveats, both covered in
+[Connect to Grafana Cloud](./docs/CONNECT_GRAFANA_CLOUD.md): the `/otlp/<appKey>`
+route runs on development collectors only for now, and the native apps have a
+legacy OTLP gateway path that the plugin cannot read.
 
 For a side-by-side of what each app actually emits, see
 [`docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./docs/MOBILE_OBSERVABILITY_OVERVIEW.md).

--- a/Mobiles/README.md
+++ b/Mobiles/README.md
@@ -17,15 +17,21 @@ places.
 | --- | --- | --- | --- | --- | --- |
 | **Flutter** (Android + iOS) | Cross-platform | [`flutter/`](./flutter/) | Grafana **Faro** | Frontend Observability | [Flutter README](./flutter/README.md) |
 | **React Native** (Android + iOS) | Cross-platform | [`react-native/`](./react-native/) | Grafana **Faro** | Frontend Observability | [React Native README](./react-native/README.md) |
-| **iOS native** (SwiftUI) | Native | [`ios/`](./ios/) | **OpenTelemetry** Swift | Tempo + Loki | [iOS README](./ios/README.md) |
-| **Android native** (Compose) | Native | [`android/`](./android/) | **OpenTelemetry** Android | Tempo + Loki | [Android README](./android/README.md) |
+| **iOS native** (SwiftUI) | Native | [`ios/`](./ios/) | **OpenTelemetry** Swift | Frontend Observability | [iOS README](./ios/README.md) |
+| **Android native** (Compose) | Native | [`android/`](./android/) | **OpenTelemetry** Android | Frontend Observability | [Android README](./android/README.md) |
 
-Two telemetry stories, one backend:
+Two wire formats, one destination:
 
-- **Faro** (Flutter, React Native) → exports to the Grafana Cloud **Frontend
-  Observability** plugin.
-- **OpenTelemetry** (iOS, Android) → exports OTLP/HTTP to **Tempo + Loki**,
-  visualized with the [Mobile OTel RUM dashboard](./docs/MOBILE_OTEL_RUM_DASHBOARD.md).
+- **Faro** (Flutter, React Native) → posts Faro payloads to the collector's
+  `/collect/<appKey>` endpoint.
+- **OpenTelemetry** (iOS, Android) → posts OTLP/HTTP to the same collector's
+  `/otlp/<appKey>` endpoint, which translates OTLP to Faro on ingest.
+
+Both end up in the Grafana Cloud **Frontend Observability** plugin, one app per
+key. The native apps can target the Grafana Cloud OTLP gateway instead, which
+lands raw OTel in Tempo + Loki for the
+[Mobile OTel RUM dashboard](./docs/MOBILE_OTEL_RUM_DASHBOARD.md) — see
+[Connect to Grafana Cloud](./docs/CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway).
 
 For a side-by-side of what each app actually emits, see
 [`docs/MOBILE_OBSERVABILITY_OVERVIEW.md`](./docs/MOBILE_OBSERVABILITY_OVERVIEW.md).

--- a/Mobiles/README.md
+++ b/Mobiles/README.md
@@ -28,9 +28,16 @@ Two wire formats, one destination:
   `/otlp/<appKey>` endpoint, which translates OTLP to Faro on ingest.
 
 Both end up in the Grafana Cloud **Frontend Observability** plugin, one app per
-key. The native apps can target the Grafana Cloud OTLP gateway instead, which
-lands raw OTel in Tempo + Loki for the
-[Mobile OTel RUM dashboard](./docs/MOBILE_OTEL_RUM_DASHBOARD.md) — see
+key.
+
+> **The `/otlp/<appKey>` route runs on development collectors only.** A
+> production collector returns `404` on that path today. The demo stack uses a
+> development collector for this reason.
+
+A legacy option remains for the native apps: export to the Grafana Cloud OTLP
+gateway, which lands **raw OTel** in Tempo + Loki. The Frontend Observability
+plugin cannot read that data — it carries no app identity — so you query it with
+the [Mobile OTel RUM dashboard](./docs/MOBILE_OTEL_RUM_DASHBOARD.md) instead. See
 [Connect to Grafana Cloud](./docs/CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway).
 
 For a side-by-side of what each app actually emits, see

--- a/Mobiles/README.md
+++ b/Mobiles/README.md
@@ -2,7 +2,7 @@
 
 **Start here.** This directory holds four mobile QuickPizza apps used to demo
 mobile observability with Grafana. They share the same screens and talk to the
-same backend — what differs is the telemetry SDK and where the data lands.
+same backend — what differs is the telemetry SDK and the wire format it sends.
 
 This page is the entry point: it tells you **which platforms are supported**,
 **how to get a demo running**, and **where to go for more detail**. Everything
@@ -13,12 +13,12 @@ places.
 
 ## Supported platforms
 
-| Platform | Type | Location | SDK | Data lands in | Run guide |
-| --- | --- | --- | --- | --- | --- |
-| **Flutter** (Android + iOS) | Cross-platform | [`flutter/`](./flutter/) | Grafana **Faro** | Frontend Observability | [Flutter README](./flutter/README.md) |
-| **React Native** (Android + iOS) | Cross-platform | [`react-native/`](./react-native/) | Grafana **Faro** | Frontend Observability | [React Native README](./react-native/README.md) |
-| **iOS native** (SwiftUI) | Native | [`ios/`](./ios/) | **OpenTelemetry** Swift | Frontend Observability | [iOS README](./ios/README.md) |
-| **Android native** (Compose) | Native | [`android/`](./android/) | **OpenTelemetry** Android | Frontend Observability | [Android README](./android/README.md) |
+| Platform | Type | Location | SDK | Run guide |
+| --- | --- | --- | --- | --- |
+| **Flutter** (Android + iOS) | Cross-platform | [`flutter/`](./flutter/) | Grafana **Faro** | [Flutter README](./flutter/README.md) |
+| **React Native** (Android + iOS) | Cross-platform | [`react-native/`](./react-native/) | Grafana **Faro** | [React Native README](./react-native/README.md) |
+| **iOS native** (SwiftUI) | Native | [`ios/`](./ios/) | **OpenTelemetry** Swift | [iOS README](./ios/README.md) |
+| **Android native** (Compose) | Native | [`android/`](./android/) | **OpenTelemetry** Android | [Android README](./android/README.md) |
 
 Two wire formats, one destination:
 

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -115,11 +115,13 @@ session attributes) is inventoried in
 Where to view the data on the demo stack:
 
 - **Frontend Observability:** open the `QuickPizza_Android` app. The Faro
-  collector translates the OTLP payloads to Faro on ingest.
-- **OTLP gateway path only** (see
+  collector translates the OTLP payloads to Faro on ingest. The `/otlp/<appKey>`
+  route runs on development collectors only for now.
+- **Legacy OTLP gateway path only** (see
   [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway)):
+  the data stays raw OTel and does not appear in Frontend Observability. Query
   the shared [Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md),
-  Tempo (`resource.service.name="quickpizza-android"`), and Loki
+  Tempo (`resource.service.name="quickpizza-android"`), or Loki
   (`service_name="quickpizza-android"`).
 
 ---

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -114,9 +114,13 @@ session attributes) is inventoried in
 
 Where to view the data on the demo stack:
 
-- **Dashboard:** import and configure the shared [Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md)
-- **Explore Tempo:** filter by `resource.service.name="quickpizza-android"`
-- **Explore Loki:** filter by `service_name="quickpizza-android"`
+- **Frontend Observability:** open the `QuickPizza_Android` app. The Faro
+  collector translates the OTLP payloads to Faro on ingest.
+- **OTLP gateway path only** (see
+  [Connect to Grafana Cloud](../docs/CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway)):
+  the shared [Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md),
+  Tempo (`resource.service.name="quickpizza-android"`), and Loki
+  (`service_name="quickpizza-android"`).
 
 ---
 
@@ -126,9 +130,9 @@ Where to view the data on the demo stack:
 
 ```json
 {
-  "OTLP_ENDPOINT": "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp",
-  "OTLP_INSTANCE_ID": "1234567",
-  "OTLP_API_KEY": "glc_xxxxxxxxxxxx",
+  "OTLP_ENDPOINT": "https://faro-collector-<region>.grafana.net/otlp/<appKey>",
+  "OTLP_INSTANCE_ID": "",
+  "OTLP_API_KEY": "",
   "BASE_URL": ""
 }
 ```
@@ -136,8 +140,8 @@ Where to view the data on the demo stack:
 | Field | Description |
 | --- | --- |
 | `OTLP_ENDPOINT` | OTLP/HTTP base URL (without `/v1/traces`). Empty disables export. |
-| `OTLP_INSTANCE_ID` | Numeric Grafana Cloud OTLP gateway instance ID. |
-| `OTLP_API_KEY` | Grafana Cloud access token (combined with the instance ID into `Authorization: Basic`). |
+| `OTLP_INSTANCE_ID` | Numeric Grafana Cloud OTLP gateway instance ID. Leave empty for Faro OTLP ingest. |
+| `OTLP_API_KEY` | Grafana Cloud access token (combined with the instance ID into `Authorization: Basic`). Leave empty for Faro OTLP ingest. |
 | `BASE_URL` | QuickPizza backend URL. Empty auto-resolves to `http://10.0.2.2:3333` on emulators. Set to your machine's LAN IP for physical devices ([details](../README.md#shared-basics)). |
 
 To obtain the OTLP endpoint, instance ID, and token, see

--- a/Mobiles/android/README.md
+++ b/Mobiles/android/README.md
@@ -94,8 +94,9 @@ The app uses [`opentelemetry-android`](https://github.com/open-telemetry/opentel
 | **Logs** | `screen.view` (auto), `app.jank` (auto, slow rendering), `session.start` (auto), `rum.sdk.init.*` (auto SDK self-telemetry), `exception` (manual `logger.exception`), `device.crash` (auto, next launch), `device.anr` (auto, runtime), `debug.test_event` (manual) |
 
 Core resource attributes: `service.name=quickpizza-android`,
-`service.namespace=quickpizza`, `service.version`,
-`deployment.environment=production`. The full set (device, network, nav, and
+`service.namespace=quickpizza`, `service.version`. The app does not set
+`deployment.environment`, so environment filters do not match it (the iOS app
+does). The full set (device, network, nav, and
 session attributes) is inventoried in
 [`MOBILE_OBSERVABILITY_OVERVIEW.md § Android native`](../docs/MOBILE_OBSERVABILITY_OVERVIEW.md#android-native-opentelemetry-android).
 

--- a/Mobiles/android/config.json.example
+++ b/Mobiles/android/config.json.example
@@ -1,11 +1,11 @@
 {
   "_comment": "Copy this file to app/src/main/res/raw/config.json and fill in your values.",
   "OTLP_ENDPOINT": "",
-  "_OTLP_ENDPOINT_comment": "e.g. https://otlp-gateway-prod-eu-west-0.grafana.net/otlp",
+  "_OTLP_ENDPOINT_comment": "Faro OTLP ingest URL, e.g. https://faro-collector-<region>.grafana.net/otlp/<appKey>. The app key in the path identifies the app, so leave OTLP_INSTANCE_ID and OTLP_API_KEY empty. To send to the Grafana Cloud OTLP gateway instead, use https://otlp-gateway-<clusterSlug>.grafana.net/otlp and fill in both credentials.",
   "OTLP_INSTANCE_ID": "",
-  "_OTLP_INSTANCE_ID_comment": "Your Grafana Cloud OTLP Gateway instance ID (numeric).",
+  "_OTLP_INSTANCE_ID_comment": "Grafana Cloud OTLP gateway instance ID (numeric). Leave empty for the Faro OTLP ingest URL.",
   "OTLP_API_KEY": "",
-  "_OTLP_API_KEY_comment": "Your Grafana Cloud access token (e.g. glc_xxxxxxxx). Combined with the instance ID, the app will compute Authorization: Basic <base64(instanceId:apiKey)>.",
+  "_OTLP_API_KEY_comment": "Grafana Cloud access token (e.g. glc_xxxxxxxx). Combined with the instance ID, the app will compute Authorization: Basic <base64(instanceId:apiKey)>. Leave empty for the Faro OTLP ingest URL.",
   "BASE_URL": "",
   "_BASE_URL_comment": "Leave empty for emulator (uses http://10.0.2.2:3333 automatically). For physical devices, set to your machine's IP e.g. http://192.168.1.100:3333"
 }

--- a/Mobiles/android/config.json.example
+++ b/Mobiles/android/config.json.example
@@ -1,7 +1,7 @@
 {
   "_comment": "Copy this file to app/src/main/res/raw/config.json and fill in your values.",
   "OTLP_ENDPOINT": "",
-  "_OTLP_ENDPOINT_comment": "Faro OTLP ingest URL, e.g. https://faro-collector-<region>.grafana.net/otlp/<appKey>. The app key in the path identifies the app, so leave OTLP_INSTANCE_ID and OTLP_API_KEY empty. To send to the Grafana Cloud OTLP gateway instead, use https://otlp-gateway-<clusterSlug>.grafana.net/otlp and fill in both credentials.",
+  "_OTLP_ENDPOINT_comment": "Faro OTLP ingest URL, e.g. https://faro-collector-<region>.grafana.net/otlp/<appKey>. The app key in the path identifies the app, so leave OTLP_INSTANCE_ID and OTLP_API_KEY empty. The app then appears in Frontend Observability. NOTE: this route runs on development collectors only for now; a production collector returns 404. Legacy option: the Grafana Cloud OTLP gateway at https://otlp-gateway-<clusterSlug>.grafana.net/otlp with both credentials filled in — that path keeps the data as raw OTel, so the app does NOT appear in Frontend Observability (query Tempo/Loki or the Mobile OTel RUM dashboard instead).",
   "OTLP_INSTANCE_ID": "",
   "_OTLP_INSTANCE_ID_comment": "Grafana Cloud OTLP gateway instance ID (numeric). Leave empty for the Faro OTLP ingest URL.",
   "OTLP_API_KEY": "",

--- a/Mobiles/docs/ANDROID_NATIVE_SETUP.md
+++ b/Mobiles/docs/ANDROID_NATIVE_SETUP.md
@@ -39,7 +39,9 @@ Edit `config.json`:
 ```
 
 The app key in the path identifies the app, so the instance ID and token stay
-empty. For what each field means, see the
+empty, and the app appears in Frontend Observability. This route runs on
+development collectors only for now — a production collector returns `404`. For
+what each field means, see the
 [config reference in the Android README](../android/README.md#configuration-reference).
 To obtain the OTLP endpoint — or to send to the Grafana Cloud OTLP gateway
 instead — see

--- a/Mobiles/docs/ANDROID_NATIVE_SETUP.md
+++ b/Mobiles/docs/ANDROID_NATIVE_SETUP.md
@@ -31,16 +31,18 @@ Edit `config.json`:
 
 ```json
 {
-  "OTLP_ENDPOINT": "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp",
-  "OTLP_INSTANCE_ID": "1234567",
-  "OTLP_API_KEY": "glc_xxxxxxxxxxxx",
+  "OTLP_ENDPOINT": "https://faro-collector-<region>.grafana.net/otlp/<appKey>",
+  "OTLP_INSTANCE_ID": "",
+  "OTLP_API_KEY": "",
   "BASE_URL": ""
 }
 ```
 
-For what each field means, see the
+The app key in the path identifies the app, so the instance ID and token stay
+empty. For what each field means, see the
 [config reference in the Android README](../android/README.md#configuration-reference).
-To obtain the OTLP endpoint, instance ID, and token, see
+To obtain the OTLP endpoint — or to send to the Grafana Cloud OTLP gateway
+instead — see
 [Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md#opentelemetry-apps-ios-native-android-native).
 For `BASE_URL` emulator/device defaults (and why Android uses `10.0.2.2` rather
 than `localhost`), see [Shared basics](../README.md#shared-basics).

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -14,6 +14,10 @@ Both families reach the same place. The Faro apps post Faro payloads to
 the same collector, which translates OTLP to Faro on the way in. Each app has
 its own key, so each shows up as its own app in the plugin.
 
+> **OTLP ingest is not enabled in production yet.** The `/otlp/<appKey>` route
+> is live on development collectors only. A production collector returns `404`
+> on that path today. Use the OTLP gateway below until the route ships.
+
 The native apps can also send to the Grafana Cloud OTLP gateway instead, which
 lands the data in Tempo and Loki for the
 [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md). That path needs
@@ -88,6 +92,12 @@ URL path, so there is no separate token to manage.
 ```
 https://faro-collector-<region>.grafana.net/otlp/<appKey>
 ```
+
+> **Development collectors only.** This route is not enabled in production yet.
+> A production collector returns `404` on `/otlp/<appKey>`, and the exporter
+> then drops every signal. To confirm a collector serves the route, send a `GET`
+> to `/otlp/probe/v1/traces`: `405` means the route exists, `404` means it does
+> not. The demo apps target a development collector for this reason.
 
 Leave `OTLP_INSTANCE_ID` and `OTLP_API_KEY` empty — the apps send no
 `Authorization` header when either value is blank.

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -7,7 +7,18 @@ families that authenticate differently:
 | Apps | SDK family | What you configure | Where the data lands |
 | --- | --- | --- | --- |
 | Flutter, React Native | Grafana **Faro** | `FARO_COLLECTOR_URL` | Frontend Observability plugin |
-| iOS native, Android native | **OpenTelemetry** | `OTLP_ENDPOINT` + `OTLP_INSTANCE_ID` + `OTLP_API_KEY` | Tempo (traces) + Loki (logs), viewed via the [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) |
+| iOS native, Android native | **OpenTelemetry** | `OTLP_ENDPOINT` | Frontend Observability plugin |
+
+Both families reach the same place. The Faro apps post Faro payloads to
+`/collect/<appKey>`; the native OTel apps post OTLP/HTTP to `/otlp/<appKey>` on
+the same collector, which translates OTLP to Faro on the way in. Each app has
+its own key, so each shows up as its own app in the plugin.
+
+The native apps can also send to the Grafana Cloud OTLP gateway instead, which
+lands the data in Tempo and Loki for the
+[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md). That path needs
+`OTLP_INSTANCE_ID` and `OTLP_API_KEY` as well — see
+[Alternative: the OTLP gateway](#alternative-the-otlp-gateway) below.
 
 > **Faro apps require a collector URL.** The Flutter and React Native apps
 > throw at startup if `FARO_COLLECTOR_URL` is empty, so you must set it (see
@@ -62,28 +73,27 @@ these are registered as `QuickPizza_Flutter` and `QuickPizza_ReactNative`.
 
 ## OpenTelemetry apps (iOS native, Android native)
 
-OTel apps send OTLP/HTTP to the Grafana Cloud OTLP gateway and authenticate
-with an **instance ID + access token**.
+OTel apps send OTLP/HTTP to the **Faro collector**, which translates OTLP to
+Faro and registers the app in Frontend Observability. The app key sits in the
+URL path, so there is no separate token to manage.
 
-### Find your endpoint and credentials
+### Find your endpoint
 
-The OTLP endpoint follows the standard Grafana Cloud pattern:
+1. In Grafana Cloud, open **Frontend Observability**.
+2. Create a new app (or open an existing one).
+3. Copy the app's **Faro collector URL** (looks like
+   `https://faro-collector-<region>.grafana.net/collect/<appKey>`).
+4. Replace `/collect/` with `/otlp/` to get the OTLP ingest URL:
 
 ```
-https://otlp-gateway-<clusterSlug>.grafana.net/otlp
+https://faro-collector-<region>.grafana.net/otlp/<appKey>
 ```
 
-To find `clusterSlug`, the numeric Instance ID, and a token:
+Leave `OTLP_INSTANCE_ID` and `OTLP_API_KEY` empty — the apps send no
+`Authorization` header when either value is blank.
 
-1. Go to your Grafana Cloud org page (`https://grafana.com/orgs/<your-org>`).
-2. Open the stack — the **cluster slug** and **numeric Instance ID** are listed
-   on its details page.
-3. Generate an **Access Policy token** with scopes `metrics:write`,
-   `logs:write`, `traces:write` (the native apps need logs + traces; metrics is
-   harmless to include).
-
-The app computes `Authorization: Basic base64(instanceId:apiKey)` for you — you
-only supply the three raw values.
+On the demo stack these are registered as `QuickPizza_Android` and
+`QuickPizza_iOS`.
 
 ### Where to put them
 
@@ -98,15 +108,38 @@ them itself, and on Android the OpenTelemetry SDK exporter handles them.
 
 ### View the data
 
-Traces appear in **Explore → Tempo** within seconds (filter by
-`resource.service.name="quickpizza-ios"` / `"quickpizza-android"`); logs in
-**Explore → Loki** (`service_name="quickpizza-ios"` / `"quickpizza-android"`).
-For a RUM-style view, import the
-[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md).
+The app appears in the **Frontend Observability** plugin, next to the Flutter
+and React Native apps.
 
 > **Android latency note:** the OTel-Android SDK buffers exports to disk
 > (~30–45 s) for offline resilience. For live demos, flip **Debug →
 > OpenTelemetry SDK → Disable disk buffering** to drop latency to ~1–6 s.
+
+### Alternative: the OTLP gateway
+
+To land the native telemetry in Tempo and Loki instead — which is what the
+[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) reads — point the
+apps at the Grafana Cloud OTLP gateway:
+
+```
+https://otlp-gateway-<clusterSlug>.grafana.net/otlp
+```
+
+This path authenticates with an **instance ID + access token**:
+
+1. Go to your Grafana Cloud org page (`https://grafana.com/orgs/<your-org>`).
+2. Open the stack — the **cluster slug** and **numeric Instance ID** are listed
+   on its details page.
+3. Generate an **Access Policy token** with scopes `metrics:write`,
+   `logs:write`, `traces:write` (the native apps need logs + traces; metrics is
+   harmless to include).
+
+Put all three values in the same config file. The app computes
+`Authorization: Basic base64(instanceId:apiKey)` for you.
+
+Traces then appear in **Explore → Tempo** within seconds (filter by
+`resource.service.name="quickpizza-ios"` / `"quickpizza-android"`); logs in
+**Explore → Loki** (`service_name="quickpizza-ios"` / `"quickpizza-android"`).
 
 ---
 
@@ -118,8 +151,9 @@ For a RUM-style view, import the
   the Debug → Config overrides) and you relaunched the app.
 - Faro: confirm the collector URL is complete (includes the `/collect/<token>`
   path).
-- OTel: confirm the endpoint is OTLP/**HTTP** (not gRPC), has no trailing slash,
-  and the token allows `logs:write` + `traces:write`.
+- OTel: confirm the endpoint is OTLP/**HTTP** (not gRPC) and has no trailing
+  slash. For Faro OTLP ingest, confirm the URL ends with `/otlp/<appKey>`. For
+  the OTLP gateway, confirm the token allows `logs:write` + `traces:write`.
 - Use the in-app **Debug** tab to emit a test log / handled exception and
   confirm it arrives.
 

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -12,12 +12,9 @@ families that authenticate differently:
 Both families reach the same place. The Faro apps post Faro payloads to
 `/collect/<appKey>`; the native OTel apps post OTLP/HTTP to `/otlp/<appKey>` on
 the same collector, which translates OTLP to Faro on the way in. Each app has
-its own key, so each shows up as its own app in the plugin.
-
-> **Faro OTLP ingest runs on development collectors only.** The
-> `/otlp/<appKey>` route is not enabled in production yet — a production
-> collector returns `404` on that path today. The demo stack uses a development
-> collector for this reason.
+its own key, so each shows up as its own app in the plugin. The `/otlp/<appKey>`
+route runs on development collectors only for now — see
+[OpenTelemetry apps](#opentelemetry-apps-ios-native-android-native) below.
 
 A legacy option remains for the native apps: export to the Grafana Cloud OTLP
 gateway. That path lands **raw OTel** in Tempo and Loki, and the Frontend

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -92,6 +92,11 @@ https://faro-collector-<region>.grafana.net/otlp/<appKey>
 Leave `OTLP_INSTANCE_ID` and `OTLP_API_KEY` empty — the apps send no
 `Authorization` header when either value is blank.
 
+> **Every signal needs a `session.id`.** When the collector runs with session
+> management on, it rejects an OTLP request that carries a signal without one:
+> `400 session.id is required on every signal`. Both native apps track sessions
+> and stamp the attribute, so this only bites a hand-rolled OTLP client.
+
 On the demo stack these are registered as `QuickPizza_Android` and
 `QuickPizza_iOS`.
 

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -14,14 +14,16 @@ Both families reach the same place. The Faro apps post Faro payloads to
 the same collector, which translates OTLP to Faro on the way in. Each app has
 its own key, so each shows up as its own app in the plugin.
 
-> **OTLP ingest is not enabled in production yet.** The `/otlp/<appKey>` route
-> is live on development collectors only. A production collector returns `404`
-> on that path today. Use the OTLP gateway below until the route ships.
+> **Faro OTLP ingest runs on development collectors only.** The
+> `/otlp/<appKey>` route is not enabled in production yet — a production
+> collector returns `404` on that path today. The demo stack uses a development
+> collector for this reason.
 
-The native apps can also send to the Grafana Cloud OTLP gateway instead, which
-lands the data in Tempo and Loki for the
-[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md). That path needs
-`OTLP_INSTANCE_ID` and `OTLP_API_KEY` as well — see
+A legacy option remains for the native apps: export to the Grafana Cloud OTLP
+gateway. That path lands **raw OTel** in Tempo and Loki, and the Frontend
+Observability plugin cannot read it, so you query it with the
+[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md). It also needs
+`OTLP_INSTANCE_ID` and `OTLP_API_KEY` — see
 [Alternative: the OTLP gateway](#alternative-the-otlp-gateway) below.
 
 > **Faro apps require a collector URL.** The Flutter and React Native apps
@@ -95,9 +97,8 @@ https://faro-collector-<region>.grafana.net/otlp/<appKey>
 
 > **Development collectors only.** This route is not enabled in production yet.
 > A production collector returns `404` on `/otlp/<appKey>`, and the exporter
-> then drops every signal. To confirm a collector serves the route, send a `GET`
-> to `/otlp/probe/v1/traces`: `405` means the route exists, `404` means it does
-> not. The demo apps target a development collector for this reason.
+> then drops every signal. The demo apps target a development collector for this
+> reason.
 
 Leave `OTLP_INSTANCE_ID` and `OTLP_API_KEY` empty — the apps send no
 `Authorization` header when either value is blank.
@@ -132,9 +133,17 @@ and React Native apps.
 
 ### Alternative: the OTLP gateway
 
-To land the native telemetry in Tempo and Loki instead — which is what the
-[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) reads — point the
-apps at the Grafana Cloud OTLP gateway:
+This is the legacy path. Prefer Faro OTLP ingest above unless you specifically
+need the Mobile OTel RUM dashboard.
+
+The gateway bypasses the collector, so nothing translates the payloads. The data
+stays **raw OTel**: Loki streams carry `service_name` and `service_namespace`
+only, with no `app_id`, `app_key`, or `kind` label. The Frontend Observability
+plugin keys off those labels, so it **cannot read gateway data** — the apps do
+not appear in the plugin at all. The
+[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) exists for this path.
+
+To use it, point the apps at the Grafana Cloud OTLP gateway:
 
 ```
 https://otlp-gateway-<clusterSlug>.grafana.net/otlp

--- a/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
+++ b/Mobiles/docs/CONNECT_GRAFANA_CLOUD.md
@@ -89,7 +89,7 @@ URL path, so there is no separate token to manage.
 2. Create a new app (or open an existing one).
 3. Copy the app's **Faro collector URL** (looks like
    `https://faro-collector-<region>.grafana.net/collect/<appKey>`).
-4. Replace `/collect/` with `/otlp/` to get the OTLP ingest URL:
+4. Replace `/collect/` with `/otlp/` to get the Faro OTLP ingest URL:
 
 ```
 https://faro-collector-<region>.grafana.net/otlp/<appKey>
@@ -133,8 +133,9 @@ and React Native apps.
 
 ### Alternative: the OTLP gateway
 
-This is the legacy path. Prefer Faro OTLP ingest above unless you specifically
-need the Mobile OTel RUM dashboard.
+This is the legacy path. Prefer Faro OTLP ingest above — unless you need the
+Mobile OTel RUM dashboard, or you target a production stack, where the
+`/otlp/<appKey>` route is not enabled yet.
 
 The gateway bypasses the collector, so nothing translates the payloads. The data
 stays **raw OTel**: Loki streams carry `service_name` and `service_namespace`

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -45,7 +45,7 @@ It is intended for two audiences:
 | --- | --- | --- | --- | --- |
 | Flutter (Android + iOS) | `Mobiles/flutter/` | `faro` Dart SDK | `QuickPizza_Flutter` (app_id `69`) | Faro collector → Grafana Cloud Frontend Observability |
 | React Native (Android + iOS) | `Mobiles/react-native/` | `@grafana/faro-react-native` | `QuickPizza_ReactNative` (app_id `123`) | Faro collector → Grafana Cloud Frontend Observability |
-| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` → `QuickPizza_iOS` (app_id `202`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
+| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` → `QuickPizza_iOS` (app_id `204`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
 | Android native (Compose) | `Mobiles/android/` | `opentelemetry-android` (RUM agent) | `quickpizza-android` → `QuickPizza_Android` (app_id `182`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
 
 The native apps set `service.name` to `quickpizza-ios` / `quickpizza-android`,

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -41,12 +41,17 @@ It is intended for two audiences:
 
 ## At a glance
 
-| Platform | App location | SDK | Service / app name in telemetry | Backend |
-| --- | --- | --- | --- | --- |
-| Flutter (Android + iOS) | `Mobiles/flutter/` | `faro` Dart SDK | `QuickPizza_Flutter` (app_id `69`) | Faro collector → Grafana Cloud Frontend Observability |
-| React Native (Android + iOS) | `Mobiles/react-native/` | `@grafana/faro-react-native` | `QuickPizza_ReactNative` (app_id `123`) | Faro collector → Grafana Cloud Frontend Observability |
-| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` → `QuickPizza_iOS` (app_id `204`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
-| Android native (Compose) | `Mobiles/android/` | `opentelemetry-android` (RUM agent) | `quickpizza-android` → `QuickPizza_Android` (app_id `182`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
+| Platform | App location | SDK | Service / app name in telemetry |
+| --- | --- | --- | --- |
+| Flutter (Android + iOS) | `Mobiles/flutter/` | `faro` Dart SDK | `QuickPizza_Flutter` (app_id `69`) |
+| React Native (Android + iOS) | `Mobiles/react-native/` | `@grafana/faro-react-native` | `QuickPizza_ReactNative` (app_id `123`) |
+| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` → `QuickPizza_iOS` (app_id `204`) |
+| Android native (Compose) | `Mobiles/android/` | `opentelemetry-android` (RUM agent) | `quickpizza-android` → `QuickPizza_Android` (app_id `182`) |
+
+All four reach Grafana Cloud Frontend Observability through the Faro collector —
+the Faro apps post to `/collect/<appKey>`, the native apps post OTLP/HTTP to
+`/otlp/<appKey>`. See [§ Where the data lives](#where-the-data-lives) for the
+datasources and the legacy OTLP gateway alternative.
 
 The native apps set `service.name` to `quickpizza-ios` / `quickpizza-android`,
 but the Faro collector replaces it with the registered app name on ingest, so
@@ -81,12 +86,8 @@ Common feature set:
 
 ## Where the data lives
 
-| App | Visualisation |
-| --- | --- |
-| Flutter | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
-| React Native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
-| iOS native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
-| Android native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
+All four apps open in the Frontend Observability plugin at
+`/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack.
 
 Underlying datasources on whichever Grafana Cloud stack you target:
 

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -45,7 +45,7 @@ It is intended for two audiences:
 | --- | --- | --- | --- | --- |
 | Flutter (Android + iOS) | `Mobiles/flutter/` | `faro` Dart SDK | `QuickPizza_Flutter` (app_id `69`) | Faro collector → Grafana Cloud Frontend Observability |
 | React Native (Android + iOS) | `Mobiles/react-native/` | `@grafana/faro-react-native` | `QuickPizza_ReactNative` (app_id `123`) | Faro collector → Grafana Cloud Frontend Observability |
-| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` → `QuickPizza_iOS` | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
+| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` → `QuickPizza_iOS` (app_id `202`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
 | Android native (Compose) | `Mobiles/android/` | `opentelemetry-android` (RUM agent) | `quickpizza-android` → `QuickPizza_Android` (app_id `182`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
 
 The native apps set `service.name` to `quickpizza-ios` / `quickpizza-android`,

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -45,8 +45,12 @@ It is intended for two audiences:
 | --- | --- | --- | --- | --- |
 | Flutter (Android + iOS) | `Mobiles/flutter/` | `faro` Dart SDK | `QuickPizza_Flutter` (app_id `69`) | Faro collector → Grafana Cloud Frontend Observability |
 | React Native (Android + iOS) | `Mobiles/react-native/` | `@grafana/faro-react-native` | `QuickPizza_ReactNative` (app_id `123`) | Faro collector → Grafana Cloud Frontend Observability |
-| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` | OTLP/HTTP → Grafana Cloud Tempo + Loki |
-| Android native (Compose) | `Mobiles/android/` | `opentelemetry-android` (RUM agent) | `quickpizza-android` | OTLP/HTTP → Grafana Cloud Tempo + Loki |
+| iOS native (SwiftUI) | `Mobiles/ios/` | `opentelemetry-swift` | `quickpizza-ios` → `QuickPizza_iOS` | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
+| Android native (Compose) | `Mobiles/android/` | `opentelemetry-android` (RUM agent) | `quickpizza-android` → `QuickPizza_Android` (app_id `182`) | OTLP/HTTP → Faro collector → Grafana Cloud Frontend Observability |
+
+The native apps set `service.name` to `quickpizza-ios` / `quickpizza-android`,
+but the Faro collector replaces it with the registered app name on ingest, so
+they surface as `QuickPizza_iOS` / `QuickPizza_Android`.
 
 All four apps talk to the same QuickPizza backend (`/api/pizza`,
 `/api/ratings`, `/api/users/token/login`, …) and implement the same core
@@ -81,22 +85,25 @@ Common feature set:
 | --- | --- |
 | Flutter | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
 | React Native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
-| iOS native | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) on your Grafana Cloud stack |
-| Android native | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) on your Grafana Cloud stack |
+| iOS native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
+| Android native | Frontend Observability plugin → `/a/grafana-kowalski-app/apps/<faro-app-id>` on your Grafana Cloud stack |
 
 Underlying datasources on whichever Grafana Cloud stack you target:
 
 - Faro signals → the stack's Loki datasource (`grafanacloud-<stack>-logs`).
   Faro stores all four signal kinds (`event`, `log`, `measurement`,
   `exception`) as Loki streams with `app_id` / `app_name` labels.
-- OTel signals → the stack's Tempo datasource
-  (`grafanacloud-<stack>-traces`) for spans and the stack's Loki datasource
-  for log records, both labeled with `service_name` / `service_namespace`.
+- Native OTel signals reach the same place. The collector translates OTLP to
+  Faro on ingest, so spans still land in the stack's Tempo datasource
+  (`grafanacloud-<stack>-traces`) and log records in Loki, but both carry the
+  registered app identity and the plugin can read them.
 
-The Frontend Observability plugin queries Loki for Faro-shaped data; the
-Mobile OTel RUM dashboard queries Tempo + Loki for OTel-shaped data.
-To import and configure the reusable dashboard, see
-[`MOBILE_OTEL_RUM_DASHBOARD.md`](./MOBILE_OTEL_RUM_DASHBOARD.md).
+The Frontend Observability plugin queries Loki for Faro-shaped data.
+
+Point the native apps at the Grafana Cloud OTLP gateway instead
+([Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway))
+and the data bypasses the collector, landing as raw OTel in Tempo + Loki. That
+is what the [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) reads.
 
 ---
 
@@ -252,14 +259,14 @@ events.
 
 | | Faro (Flutter, RN) | OpenTelemetry (iOS, Android) |
 | --- | --- | --- |
-| Wire format | Faro JSON → Faro collector | OTLP/HTTP → Grafana Alloy / Grafana Cloud |
+| Wire format | Faro JSON → Faro collector `/collect/<appKey>` | OTLP/HTTP → Faro collector `/otlp/<appKey>`, translated to Faro on ingest |
 | Signal model | Four kinds: `event`, `log`, `measurement`, `exception`. All flattened into Loki. | Two kinds we use today: spans (Tempo) + log records (Loki). |
 | Auto HTTP | Faro fetch/XHR instrumentation emits `event_name=faro.tracing.*` events that double as spans (with `traceID`/`spanID`) | Native HTTP client wrappers emit OTel spans |
 | Auto user actions | `event_name=faro.user.action` (Flutter + RN) | _None_ |
 | Auto perf metrics | `app_memory`, `app_cpu_usage`, `app_frames_rate`, `app_frozen_frame`, `app_startup` (both) | _None on iOS_; `app.jank` events on Android |
 | Crashes | Native crash → `kind=exception, type=crash` (FaroCrashKit) | iOS: MetricKit (delayed); Android: `device.crash` event (next launch) |
-| Where to query | Frontend Observability plugin (Loki under the hood) | Tempo + Loki via Explore + custom dashboards |
-| Where to view | Frontend Observability plugin (per-app drilldown UI) | [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) |
+| Where to query | Frontend Observability plugin (Loki under the hood) | Same, once translated. Raw Tempo + Loki when sent to the OTLP gateway instead |
+| Where to view | Frontend Observability plugin (per-app drilldown UI) | Same. [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) on the OTLP gateway path |
 | User context | `user_id` / `user_username` (Faro auto when set via SDK) | Not yet attached on every signal — `enduser.id` is the OTel attribute to use; tracked in [#48](https://github.com/grafana/mobile-o11y-demo/issues/48) / [`OTEL_MOBILE_MATURITY.md` § M-001](./OTEL_MOBILE_MATURITY.md#m-001--no-first-class-user-context-enduserid-on-mobile-sdks) |
 
 ---

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -93,17 +93,21 @@ Underlying datasources on whichever Grafana Cloud stack you target:
 - Faro signals → the stack's Loki datasource (`grafanacloud-<stack>-logs`).
   Faro stores all four signal kinds (`event`, `log`, `measurement`,
   `exception`) as Loki streams with `app_id` / `app_name` labels.
-- Native OTel signals reach the same place. The collector translates OTLP to
-  Faro on ingest, so spans still land in the stack's Tempo datasource
-  (`grafanacloud-<stack>-traces`) and log records in Loki, but both carry the
-  registered app identity and the plugin can read them.
+- Native OTel signals land in the same datasources. The collector translates
+  OTLP to Faro on ingest, so the Loki streams carry the same `app_id` /
+  `app_key` / `kind` labels as the Faro apps, under the registered app name
+  (`QuickPizza_Android`, not `quickpizza-android`). Spans still reach the
+  stack's Tempo datasource (`grafanacloud-<stack>-traces`).
 
-The Frontend Observability plugin queries Loki for Faro-shaped data.
+The Frontend Observability plugin queries Loki for Faro-shaped data, matched by
+those app labels.
 
-Point the native apps at the Grafana Cloud OTLP gateway instead
-([Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway))
-and the data bypasses the collector, landing as raw OTel in Tempo + Loki. That
-is what the [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) reads.
+The Grafana Cloud OTLP gateway is a legacy alternative for the native apps
+([Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md#alternative-the-otlp-gateway)).
+It bypasses the collector, so the data stays raw OTel: streams carry
+`service_name` / `service_namespace` only, keep the kebab-case `service.name`,
+and gain no app identity. The plugin cannot read them. The
+[Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) exists for that path.
 
 ---
 
@@ -265,8 +269,8 @@ events.
 | Auto user actions | `event_name=faro.user.action` (Flutter + RN) | _None_ |
 | Auto perf metrics | `app_memory`, `app_cpu_usage`, `app_frames_rate`, `app_frozen_frame`, `app_startup` (both) | _None on iOS_; `app.jank` events on Android |
 | Crashes | Native crash → `kind=exception, type=crash` (FaroCrashKit) | iOS: MetricKit (delayed); Android: `device.crash` event (next launch) |
-| Where to query | Frontend Observability plugin (Loki under the hood) | Same, once translated. Raw Tempo + Loki when sent to the OTLP gateway instead |
-| Where to view | Frontend Observability plugin (per-app drilldown UI) | Same. [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) on the OTLP gateway path |
+| Where to query | Frontend Observability plugin (Loki under the hood) | Same — the collector stamps the app labels the plugin needs |
+| Where to view | Frontend Observability plugin (per-app drilldown UI) | Same. On the legacy OTLP gateway path the plugin cannot read the data; use the [Mobile OTel RUM dashboard](./MOBILE_OTEL_RUM_DASHBOARD.md) |
 | User context | `user_id` / `user_username` (Faro auto when set via SDK) | Not yet attached on every signal — `enduser.id` is the OTel attribute to use; tracked in [#48](https://github.com/grafana/mobile-o11y-demo/issues/48) / [`OTEL_MOBILE_MATURITY.md` § M-001](./OTEL_MOBILE_MATURITY.md#m-001--no-first-class-user-context-enduserid-on-mobile-sdks) |
 
 ---

--- a/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
+++ b/Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md
@@ -92,7 +92,7 @@ Underlying datasources on whichever Grafana Cloud stack you target:
 
 - Faro signals → the stack's Loki datasource (`grafanacloud-<stack>-logs`).
   Faro stores all four signal kinds (`event`, `log`, `measurement`,
-  `exception`) as Loki streams with `app_id` / `app_name` labels.
+  `exception`) as Loki streams with `app_id` / `app_key` / `kind` labels.
 - Native OTel signals land in the same datasources. The collector translates
   OTLP to Faro on ingest, so the Loki streams carry the same `app_id` /
   `app_key` / `kind` labels as the Faro apps, under the registered app name
@@ -216,7 +216,7 @@ For deeper iOS detail see
 | Metrics | _none custom_ — but the RUM agent computes things like jank counts and exposes them as events rather than metrics. | — |
 
 Resource attributes are **the richest of any platform**: `service.*`,
-`deployment.environment`, `os.name`, `os.version`, `os.description`,
+`os.name`, `os.version`, `os.description`,
 `android.os.api_level`, `device.manufacturer`, `device.model.identifier`,
 `device.model.name`, `network.connection.type` (e.g. `wifi`),
 `app.installation.id`, `screen.name` (current Activity), `nav.destination`

--- a/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
+++ b/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
@@ -8,11 +8,15 @@ This dashboard reads the **OTLP gateway** path: apps send OTLP/HTTP straight to
 Grafana Cloud, which lands raw OTel in Loki and Tempo. The dashboard queries
 those two data sources.
 
-The Faro collector also accepts OTLP at `/otlp/<appKey>` and translates it to
-Faro, which puts native apps in the Frontend Observability plugin instead. That
-route is not enabled in production yet. Use this dashboard for the gateway path,
-and see [Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md) to choose between
-the two.
+The gateway path is the legacy option. It keeps the data as raw OTel, so the
+streams carry no app identity and the Frontend Observability plugin cannot read
+them — this dashboard is how you query them.
+
+The preferred path sends OTLP to the Faro collector at `/otlp/<appKey>`, which
+translates it to Faro and puts the native apps in the Frontend Observability
+plugin next to the Flutter and React Native apps. That route runs on development
+collectors only for now. See
+[Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md) for both paths.
 
 ## Dashboard Artifact
 

--- a/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
+++ b/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
@@ -4,10 +4,15 @@ This guide explains how to import and configure the reusable Mobile OTel RUM
 dashboard for native Android and iOS apps that send OpenTelemetry logs and
 traces to Grafana Cloud.
 
-The dashboard is a lightweight RUM-style view for mobile telemetry while
-Frontend Observability does not ingest native OTLP mobile data directly. It
-queries the stack's Loki and Tempo data sources, which are populated through
-Grafana Cloud OTLP ingest.
+This dashboard reads the **OTLP gateway** path: apps send OTLP/HTTP straight to
+Grafana Cloud, which lands raw OTel in Loki and Tempo. The dashboard queries
+those two data sources.
+
+The Faro collector also accepts OTLP at `/otlp/<appKey>` and translates it to
+Faro, which puts native apps in the Frontend Observability plugin instead. That
+route is not enabled in production yet. Use this dashboard for the gateway path,
+and see [Connect to Grafana Cloud](./CONNECT_GRAFANA_CLOUD.md) to choose between
+the two.
 
 ## Dashboard Artifact
 

--- a/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
+++ b/Mobiles/docs/MOBILE_OTEL_RUM_DASHBOARD.md
@@ -32,7 +32,7 @@ Grafana 13 or later.
 ## Requirements
 
 - Grafana 13 or later.
-- A Grafana Cloud stack with OTLP ingest enabled for logs and traces.
+- A Grafana Cloud stack with OTLP gateway ingest enabled for logs and traces.
 - Native Android or iOS telemetry collected with the [OpenTelemetry Android SDK](https://github.com/open-telemetry/opentelemetry-android) or [OpenTelemetry Swift](https://github.com/open-telemetry/opentelemetry-swift), shaped like the QuickPizza demo apps.
 - A Loki data source named `grafanacloud-logs`.
 - A Tempo data source named `grafanacloud-traces`.
@@ -88,6 +88,9 @@ service.namespace
 service.version
 deployment.environment
 ```
+
+The Android demo app does not set `deployment.environment` today, so panels that
+filter on it drop its data. The iOS demo app sets it to `production`.
 
 Session-aware views expect session attributes to be present. In Grafana Cloud
 Loki queries, `session.id` is available as `session_id`.

--- a/Mobiles/ios/Config.xcconfig.example
+++ b/Mobiles/ios/Config.xcconfig.example
@@ -20,11 +20,15 @@ PORT = 3333
 // OpenTelemetry OTLP endpoint (optional)
 // Leave empty to disable OTLP export (stdout only)
 //
-// Faro OTLP ingest — the app key in the path identifies the app, so leave
-// OTLP_INSTANCE_ID and OTLP_API_KEY empty:
+// Faro OTLP ingest (preferred) — the app key in the path identifies the app, so
+// leave OTLP_INSTANCE_ID and OTLP_API_KEY empty. The app then appears in
+// Frontend Observability. This route runs on development collectors only for
+// now; a production collector returns 404.
 //   https:/$()/faro-collector-<region>.grafana.net/otlp/<appKey>
 //
-// Grafana Cloud OTLP gateway — needs both credentials below:
+// Grafana Cloud OTLP gateway (legacy) — needs both credentials below. Keeps the
+// data as raw OTel, so the app does NOT appear in Frontend Observability; query
+// Tempo/Loki or the Mobile OTel RUM dashboard instead.
 //   https:/$()/otlp-gateway-<clusterSlug>.grafana.net/otlp
 //
 // Local collector: http:/$()/localhost:4318

--- a/Mobiles/ios/Config.xcconfig.example
+++ b/Mobiles/ios/Config.xcconfig.example
@@ -18,13 +18,20 @@ BASE_URL = http:/$()/localhost:3333
 PORT = 3333
 
 // OpenTelemetry OTLP endpoint (optional)
-// Example: http://localhost:4318
-// Example: https://otlp-gateway-prod-us-central-0.grafana.net/otlp
 // Leave empty to disable OTLP export (stdout only)
+//
+// Faro OTLP ingest — the app key in the path identifies the app, so leave
+// OTLP_INSTANCE_ID and OTLP_API_KEY empty:
+//   https:/$()/faro-collector-<region>.grafana.net/otlp/<appKey>
+//
+// Grafana Cloud OTLP gateway — needs both credentials below:
+//   https:/$()/otlp-gateway-<clusterSlug>.grafana.net/otlp
+//
+// Local collector: http:/$()/localhost:4318
 OTLP_ENDPOINT =
 
 // OTLP credentials for the Grafana Cloud OTLP Gateway (optional).
 // The app combines these into "Authorization: Basic base64(instanceId:apiKey)" at runtime.
-// Leave both empty if your OTLP receiver doesn't require auth.
+// Leave both empty for Faro OTLP ingest, or if your receiver doesn't require auth.
 OTLP_INSTANCE_ID =
 OTLP_API_KEY =

--- a/Mobiles/ios/README.md
+++ b/Mobiles/ios/README.md
@@ -164,14 +164,16 @@ bash Scripts/sim-run.sh
 ```
 
 The data appears under the `QuickPizza_iOS` app in **Frontend Observability**
-within seconds.
+within seconds. The `/otlp/<appKey>` route runs on development collectors only
+for now — a production collector returns `404`.
 
-To send to the Grafana Cloud OTLP gateway instead — which lands traces in Tempo
-and logs in Loki for the shared
-[Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md) — set
+A legacy option: send to the Grafana Cloud OTLP gateway instead. Set
 `OTLP_ENDPOINT` to `https:/$()/otlp-gateway-<clusterSlug>.grafana.net/otlp` and
-fill in `OTLP_INSTANCE_ID` and `OTLP_API_KEY`. The app then computes
-`Authorization: Basic base64(instanceId:apiKey)` at runtime.
+fill in `OTLP_INSTANCE_ID` and `OTLP_API_KEY`; the app then computes
+`Authorization: Basic base64(instanceId:apiKey)` at runtime. That path keeps the
+data as raw OTel, so the app does **not** appear in Frontend Observability —
+traces go to Tempo and logs to Loki for the shared
+[Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md).
 
 ---
 

--- a/Mobiles/ios/README.md
+++ b/Mobiles/ios/README.md
@@ -138,23 +138,23 @@ details.
 
 ## Sending Telemetry to Grafana Cloud
 
-To send traces and logs to a Grafana Cloud stack you need an OTLP endpoint,
-instance ID, and token. Finding those values is the same for both native apps —
-see [**Connect to Grafana Cloud**](../docs/CONNECT_GRAFANA_CLOUD.md#opentelemetry-apps-ios-native-android-native).
-Then fill them into `Config.xcconfig` as shown below.
+The app sends OTLP/HTTP to the Faro collector, which translates OTLP to Faro on
+ingest and registers the app in Frontend Observability. Finding the endpoint is
+the same for both native apps — see
+[**Connect to Grafana Cloud**](../docs/CONNECT_GRAFANA_CLOUD.md#opentelemetry-apps-ios-native-android-native).
+Then fill it into `Config.xcconfig` as shown below.
 
 ### Update Config.xcconfig
 
-The app computes `Authorization: Basic base64(instanceId:apiKey)` at runtime,
-so you only need to provide the raw values:
+The app key sits in the URL path, so no credentials are needed:
 
 ```
 BASE_URL = http:/$()/localhost:3333
 PORT = 3333
 
-OTLP_ENDPOINT = https://otlp-gateway-<clusterSlug>.grafana.net/otlp
-OTLP_INSTANCE_ID = 123456
-OTLP_API_KEY = glc_abc123...
+OTLP_ENDPOINT = https:/$()/faro-collector-<region>.grafana.net/otlp/<appKey>
+OTLP_INSTANCE_ID =
+OTLP_API_KEY =
 ```
 
 Then re-run the app:
@@ -163,9 +163,15 @@ Then re-run the app:
 bash Scripts/sim-run.sh
 ```
 
-Traces will appear in **Explore → Tempo** in your Grafana Cloud stack within seconds.
-To view native iOS telemetry in a RUM-style dashboard, import and configure the
-shared [Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md).
+The data appears under the `QuickPizza_iOS` app in **Frontend Observability**
+within seconds.
+
+To send to the Grafana Cloud OTLP gateway instead — which lands traces in Tempo
+and logs in Loki for the shared
+[Mobile OTel RUM dashboard](../docs/MOBILE_OTEL_RUM_DASHBOARD.md) — set
+`OTLP_ENDPOINT` to `https:/$()/otlp-gateway-<clusterSlug>.grafana.net/otlp` and
+fill in `OTLP_INSTANCE_ID` and `OTLP_API_KEY`. The app then computes
+`Authorization: Basic base64(instanceId:apiKey)` at runtime.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Native apps now target the Faro collector.** [Android](Mobiles/android/config.json.example) and [iOS](Mobiles/ios/Config.xcconfig.example) export OTLP/HTTP to `/otlp/<appKey>` instead of the Grafana Cloud OTLP gateway, so all four demo apps land in Frontend Observability, one app per key.
- **CI reads two new per-app Vault secrets.** [mobile_demo_telemetry.yaml](.github/workflows/mobile_demo_telemetry.yaml) swaps the shared gateway endpoint and credentials for `faro_otlp_url_android` and `faro_otlp_url_ios` — the same one-URL-per-app pattern the Flutter and React Native legs already use.
- **No app code changes.** The app key sits in the URL path, and both apps already skip the `Authorization` header when the instance ID or token is empty.
- **Docs lead with the Faro OTLP URL** and keep the OTLP gateway as the documented alternative for the Mobile OTel RUM dashboard: [CONNECT_GRAFANA_CLOUD.md](Mobiles/docs/CONNECT_GRAFANA_CLOUD.md), [MOBILE_OBSERVABILITY_OVERVIEW.md](Mobiles/docs/MOBILE_OBSERVABILITY_OVERVIEW.md), [ANDROID_NATIVE_SETUP.md](Mobiles/docs/ANDROID_NATIVE_SETUP.md), and the platform READMEs.
- **Docs note the production gap.** The `/otlp/<appKey>` route is enabled on development collectors only; a production collector returns `404` today. [CONNECT_GRAFANA_CLOUD.md](Mobiles/docs/CONNECT_GRAFANA_CLOUD.md) says so and keeps the OTLP gateway as the documented path until the route ships.

Both Vault secrets (`faro_otlp_url_android`, `faro_otlp_url_ios`) are in place. Verified by run [31602242313](https://github.com/grafana/mobile-o11y-demo/actions/runs/31602242313) on this head: both legs green, and telemetry landed under `QuickPizza_Android` and `QuickPizza_iOS` in Frontend Observability.

_PR description authored by Claude on Domas's behalf._
