### PR TITLE
Add security reporting guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,3 +184,4 @@ The application is specifically designed for k6 load testing:
 - Support for k6 browser testing
 - k6 extensions and disruptor examples
 - Prometheus output for k6 metrics correlation
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
